### PR TITLE
Use viper for plugin config

### DIFF
--- a/plugins/monitors/collectd/collectd.go
+++ b/plugins/monitors/collectd/collectd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/signalfx/neo-agent/plugins"
 	"github.com/signalfx/neo-agent/plugins/monitors"
 	"github.com/signalfx/neo-agent/services"
+	"github.com/spf13/viper"
 )
 
 const (
@@ -34,8 +35,12 @@ type Collectd struct {
 }
 
 // NewCollectd constructor
-func NewCollectd(configuration map[string]string) *Collectd {
-	return &Collectd{plugins.NewPlugin(monitors.Collectd, configuration), Stopped, nil, nil}
+func NewCollectd(config *viper.Viper) (*Collectd, error) {
+	plugin, err := plugins.NewPlugin(monitors.Collectd, config)
+	if err != nil {
+		return nil, err
+	}
+	return &Collectd{plugin, Stopped, nil, nil}, nil
 }
 
 // Monitor services from collectd monitor
@@ -121,7 +126,7 @@ func (collectd *Collectd) Start() (err error) {
 
 	collectd.services = make(services.ServiceInstances, 0)
 
-	if servicesFile, ok := collectd.GetConfig("servicesfile"); ok == true {
+	if servicesFile := collectd.Config.GetString("servicesfile"); servicesFile != "" {
 		log.Printf("loading service discovery signatures from %s", servicesFile)
 		lsignatures, err := services.LoadServiceSignatures(servicesFile)
 		if err != nil {

--- a/plugins/monitors/monitor.go
+++ b/plugins/monitors/monitor.go
@@ -11,7 +11,6 @@ const (
 
 // Monitor type
 type Monitor interface {
-	GetConfig(key string) (string, bool)
 	Monitor(services services.ServiceInstances) error
 	Start() error
 	Stop() error

--- a/plugins/observers/docker/docker.go
+++ b/plugins/observers/docker/docker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/signalfx/neo-agent/plugins"
 	"github.com/signalfx/neo-agent/plugins/observers"
 	"github.com/signalfx/neo-agent/services"
+	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
 
@@ -25,8 +26,12 @@ type Docker struct {
 }
 
 // NewDocker constructor
-func NewDocker(configuration map[string]string) *Docker {
-	return &Docker{plugins.NewPlugin(observers.Docker, configuration)}
+func NewDocker(config *viper.Viper) (*Docker, error) {
+	plugin, err := plugins.NewPlugin(observers.Docker, config)
+	if err != nil {
+		return nil, err
+	}
+	return &Docker{plugin}, nil
 }
 
 // Discover services from querying docker api
@@ -34,7 +39,7 @@ func (docker *Docker) Discover() (services.ServiceInstances, error) {
 
 	defaultHeaders := map[string]string{"User-Agent": userAgent}
 	hostURL := defaultHostURL
-	if configVal, ok := docker.GetConfig("hosturl"); ok {
+	if configVal := docker.Config.GetString("hosturl"); configVal != "" {
 		hostURL = configVal
 	}
 

--- a/plugins/observers/observer.go
+++ b/plugins/observers/observer.go
@@ -12,6 +12,5 @@ const (
 // Observer type
 type Observer interface {
 	Discover() (services.ServiceInstances, error)
-	GetConfig(key string) (string, bool)
 	String() string
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -1,23 +1,26 @@
 package plugins
 
+import (
+	"errors"
+
+	"github.com/spf13/viper"
+)
+
 // Plugin type
 type Plugin struct {
-	name          string
-	configuration map[string]string
+	name   string
+	Config *viper.Viper
 }
 
 // NewPlugin constructor
-func NewPlugin(name string, configuration map[string]string) Plugin {
-	return Plugin{name, configuration}
+func NewPlugin(name string, config *viper.Viper) (Plugin, error) {
+	if config == nil {
+		return Plugin{}, errors.New("config cannot be nil")
+	}
+	return Plugin{name, config}, nil
 }
 
 // String name of plugin
 func (plugin *Plugin) String() string {
 	return plugin.name
-}
-
-// GetConfig value from plugin configuration
-func (plugin *Plugin) GetConfig(key string) (string, bool) {
-	val, ok := plugin.configuration[key]
-	return val, ok
 }


### PR DESCRIPTION
I needed to get a map out of the `configuration` inside Plugin but it was
specific to getting string values. Instead of implementing our own interface we
can just use sub-instances of viper.