### PR TITLE
Move service rule filtering to observers

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -6,13 +6,18 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
+	"github.com/signalfx/neo-agent/pipelines"
+	"github.com/signalfx/neo-agent/plugins"
+	"github.com/signalfx/neo-agent/plugins/filters"
+	"github.com/signalfx/neo-agent/plugins/filters/services"
 	"github.com/signalfx/neo-agent/plugins/monitors"
 	"github.com/signalfx/neo-agent/plugins/monitors/collectd"
 	"github.com/signalfx/neo-agent/plugins/observers"
 	"github.com/signalfx/neo-agent/plugins/observers/docker"
-	"github.com/signalfx/neo-agent/services"
+	"github.com/signalfx/neo-agent/utils"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
 )
@@ -33,20 +38,64 @@ const DefaultInterval = 10
 type Agent struct {
 	// Interval to observer service activity
 	Interval int
-	// Observers used to discover services
-	Observers []observers.Observer
-	// Monitors that collect metrics
-	Monitors []monitors.Monitor
+	plugins  []plugins.IPlugin
+	pipeline *pipelines.Pipeline
 }
 
 // NewAgent with defaults
 func NewAgent() *Agent {
-	return &Agent{DefaultInterval, make([]observers.Observer, 0), make([]monitors.Monitor, 0)}
+	return &Agent{DefaultInterval, nil, nil}
+}
+
+// pluginConfig is just a holder for a plugin name and type when loading
+type pluginConfig struct {
+	Name string
+	Type string
+}
+
+// Loads subconfigs from configuration file. The given name should be a map
+// whose keys are the name of a plugin. That map should itself have a key `type`
+// that is the plugin type.
+func loadSubConfigs(name string) (map[pluginConfig]*viper.Viper, error) {
+	sub := viper.Sub(name)
+	if sub == nil {
+		return nil, fmt.Errorf("no %ss have been configured", name)
+	}
+
+	var keys []string
+
+	for _, key := range sub.AllKeys() {
+		idx := strings.Index(key, ".")
+		if idx < 1 {
+			return nil, fmt.Errorf("key %s is missing '.'", key)
+		}
+		keys = append(keys, key[0:idx])
+	}
+
+	keys = utils.UniqueStrings(keys)
+	ret := map[pluginConfig]*viper.Viper{}
+
+	for _, key := range keys {
+		viperKey := fmt.Sprintf("%s.%s", name, key)
+		s := viper.Sub(viperKey)
+		if s == nil {
+			return nil, fmt.Errorf("missing key %s", viperKey)
+		}
+
+		typ := s.GetString("type")
+		if typ == "" {
+			return nil, fmt.Errorf("%s is missing type", viperKey)
+		}
+
+		config := s.Sub("configuration")
+		ret[pluginConfig{key, typ}] = config
+	}
+
+	return ret, nil
 }
 
 // Configure an agent using configuration file
 func (agent *Agent) Configure(configfile string) error {
-
 	viper.SetDefault("interval", DefaultInterval)
 
 	viper.SetConfigFile(configfile)
@@ -56,46 +105,62 @@ func (agent *Agent) Configure(configfile string) error {
 
 	agent.Interval = viper.GetInt("interval")
 
-	observer := viper.GetString("observer.name")
-	observerConfig := viper.Sub("observer.configuration")
-	switch observer {
-	case observers.Docker:
-		if dockerObserver, err := docker.NewDocker(observerConfig); err == nil {
-			agent.Observers = append(agent.Observers, dockerObserver)
-		} else {
-			return err
+	loaded, err := loadSubConfigs("observers")
+	if err != nil {
+		return err
+	}
+
+	for plugin, configuration := range loaded {
+		switch plugin.Type {
+		case observers.Docker:
+			if observer, err := docker.NewDocker(plugin.Name, configuration); err == nil {
+				agent.plugins = append(agent.plugins, observer)
+			} else {
+				return err
+			}
 		}
 	}
 
-	monitor := viper.GetString("monitor.name")
-	monitorConfig := viper.Sub("monitor.configuration")
-	switch monitor {
-	case monitors.Collectd:
-		if collectdMonitor, err := collectd.NewCollectd(monitorConfig); err == nil {
-			agent.Monitors = append(agent.Monitors, collectdMonitor)
-		} else {
-			return err
+	loaded, err = loadSubConfigs("monitors")
+	if err != nil {
+		return err
+	}
+
+	for plugin, configuration := range loaded {
+		switch plugin.Type {
+		case monitors.Collectd:
+			if monitor, err := collectd.NewCollectd(plugin.Name, configuration); err == nil {
+				agent.plugins = append(agent.plugins, monitor)
+			} else {
+				return err
+			}
 		}
+	}
+
+	loaded, err = loadSubConfigs("filters")
+	if err != nil {
+		return err
+	}
+
+	for plugin, configuration := range loaded {
+		switch plugin.Type {
+		case filters.Services:
+			if filter, err := services.NewRuleFilter(plugin.Name, configuration); err == nil {
+				agent.plugins = append(agent.plugins, filter)
+			} else {
+				return err
+			}
+		}
+	}
+
+	if agent.pipeline, err = pipelines.NewPipeline("default", viper.GetStringSlice("pipeline.default"), agent.plugins); err != nil {
+		return err
 	}
 
 	return nil
 }
 
-// Discover running services by the configured observers
-func (agent *Agent) Discover() (map[observers.Observer]services.ServiceInstances, error) {
-	result := make(map[observers.Observer]services.ServiceInstances)
-	for _, observers := range agent.Observers {
-		serviceInstances, err := observers.Discover()
-		if err != nil {
-			return nil, err
-		}
-		result[observers] = serviceInstances
-	}
-	return result, nil
-}
-
 func main() {
-
 	var agentConfig = flag.String("config", "/etc/signalfx/agent.yaml", "agent config file")
 	var version = flag.Bool("version", false, "print agent version")
 
@@ -110,50 +175,40 @@ func main() {
 
 	agent := NewAgent()
 	if err := agent.Configure(*agentConfig); err != nil {
-		fmt.Printf("failed to configure agent - %s", err)
+		log.Printf("failed to configure agent: %s", err)
 		os.Exit(1)
 	}
 
 	exitCh := make(chan struct{})
 	go func(ctx context.Context) {
+		log.Print("agent started")
 
-		fmt.Printf("agent started\n")
-
-		for _, mon := range agent.Monitors {
-			log.Printf("starting monitor %s", mon.String())
-			if err := mon.Start(); err != nil {
-				log.Printf("failed to start monitor %s: %s", mon.String(), err)
+		for _, plugin := range agent.plugins {
+			log.Printf("starting plugin %s", plugin.String())
+			if err := plugin.Start(); err != nil {
+				log.Printf("failed to start plugin %s: %s", plugin.String(), err)
 			}
 		}
 
 		for {
-			time.Sleep(time.Duration(agent.Interval) * time.Second)
+			log.Print("executing pipeline")
 
-			result, err := agent.Discover()
-			if err != nil {
-				log.Printf("failed to discover services- %s", err)
-				continue
-			}
-
-			for _, v := range result {
-				for _, mon := range agent.Monitors {
-					// TODO - send cloned observer results to each monitor
-					if err := mon.Monitor(v); err != nil {
-						log.Printf("failed to monitor observed services - %s", err)
-					}
-				}
+			if err := agent.pipeline.Execute(); err != nil {
+				log.Printf("pipeline execute failed: %s", err)
 			}
 
 			select {
 			case <-ctx.Done():
-				for _, mon := range agent.Monitors {
-					log.Printf("stopping monitor %s", mon.String())
-					mon.Stop()
+				for _, plugin := range agent.plugins {
+					log.Printf("stopping plugin %s", plugin.String())
+					plugin.Stop()
 				}
 				exitCh <- struct{}{}
 				return
 			default:
 			}
+
+			time.Sleep(time.Duration(agent.Interval) * time.Second)
 		}
 	}(cwc)
 
@@ -162,7 +217,7 @@ func main() {
 	go func() {
 		select {
 		case <-signalCh:
-			fmt.Println(" stopping agent ..")
+			log.Print("stopping agent ...")
 			cancel()
 			return
 		}

--- a/etc/agent.yaml
+++ b/etc/agent.yaml
@@ -1,12 +1,26 @@
 interval: 10
-observer: 
-        name: docker
-        configuration:
-                hostUrl: "unix:///var/run/docker.sock"
-monitor: 
-        name: collectd
-        configuration:
-                confFile: "/etc/collectd/collectd.conf"
-                servicesFile: "/etc/signalfx/collectd/services.yaml"
-                templatesDir: "/etc/signalfx/collectd/templates" 
 
+observers:
+    local-docker:
+        type: docker
+        configuration:
+            hostUrl: unix:///var/run/docker.sock
+
+monitors:
+    collectd:
+        type: collectd
+        configuration:
+            confFile: /etc/collectd/collectd.conf
+            templatesDir: /etc/signalfx/collectd/templates
+
+filters:
+    service-mapping:
+        type: services
+        configuration:
+            servicesFile: /etc/signalfx/collectd/services.json
+
+pipeline:
+    default:
+    - local-docker
+    - service-mapping
+    - collectd

--- a/etc/collectd/services.json
+++ b/etc/collectd/services.json
@@ -16,6 +16,21 @@
             "value": ""
         }
         ]
+    }, {
+        "name": "redis-default",
+        "type": "redis",
+        "rules": [
+        {
+            "comparator": "eq",
+            "path": "ContainerImage",
+            "value": "redis"
+        },
+        {
+            "comparator": "nexists",
+            "path": "ContainerLabel-monitor",
+            "value": ""
+        }
+        ]
     }
     ]
 }

--- a/pipelines/pipeline.go
+++ b/pipelines/pipeline.go
@@ -1,0 +1,96 @@
+package pipelines
+
+import (
+	"errors"
+
+	"fmt"
+
+	"log"
+
+	"github.com/signalfx/neo-agent/plugins"
+	"github.com/signalfx/neo-agent/services"
+)
+
+// Source is an interface that only produces service instances
+type Source interface {
+	Read() (services.ServiceInstances, error)
+}
+
+// Sink is an interface that only consumes service instances
+type Sink interface {
+	Write(services.ServiceInstances) error
+}
+
+// SourceSink is an interface that consumes and products service instances
+type SourceSink interface {
+	Map(services.ServiceInstances) (services.ServiceInstances, error)
+}
+
+// Pipeline is a series of sink/source plugins to execute in a specific order
+type Pipeline struct {
+	name    string
+	plugins []plugins.IPlugin
+}
+
+// NewPipeline creates a Pipeline instance
+func NewPipeline(name string, pluginNames []string, plugins []plugins.IPlugin) (*Pipeline, error) {
+	pipeline := &Pipeline{name, nil}
+
+	// TODO: Should probably have a map of name -> plugin instance.
+	for _, pluginName := range pluginNames {
+		found := false
+		for _, pluginInstance := range plugins {
+			if pluginName == pluginInstance.Name() {
+				pipeline.plugins = append(pipeline.plugins, pluginInstance)
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("unable to find plugin instance for %s", pluginName)
+		}
+	}
+
+	return pipeline, nil
+}
+
+// Execute runs steps sequentially in the pipeline (returns after all stages have been run once)
+func (pipeline *Pipeline) Execute() error {
+	var services services.ServiceInstances
+	var err error
+
+	for i, s := range pipeline.plugins {
+		// Verify that the first entry in the pipeline is a source.
+		if i == 0 {
+			switch s.(type) {
+			case Source:
+			default:
+				return errors.New("first entry in pipeline must be a source")
+			}
+		}
+
+		// TODO - send cloned observer results to each sink/source?
+		switch t := s.(type) {
+		case Source:
+			log.Printf("reading source %s", t)
+			if services, err = t.Read(); err != nil {
+				return err
+			}
+		case Sink:
+			log.Printf("writing source %s", t)
+			if err := t.Write(services); err != nil {
+				return err
+			}
+		case SourceSink:
+			log.Printf("reading/writing source %s", t)
+			if services, err = t.Map(services); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("%s does not support source/sink interface", s)
+		}
+	}
+
+	return nil
+}

--- a/plugins/filters/filter.go
+++ b/plugins/filters/filter.go
@@ -1,0 +1,6 @@
+package filters
+
+const (
+	// Services filter
+	Services = "services"
+)

--- a/plugins/filters/services/services.go
+++ b/plugins/filters/services/services.go
@@ -1,0 +1,155 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"log"
+	"strconv"
+
+	ruler "github.com/hopkinsth/go-ruler"
+	"github.com/signalfx/neo-agent/plugins"
+	"github.com/signalfx/neo-agent/services"
+	"github.com/spf13/viper"
+)
+
+// ServiceDiscoveryRule to use as criteria for service identification
+type ServiceDiscoveryRule struct {
+	Comparator string
+	Path       string
+	Value      interface{}
+}
+
+// NewServiceDiscoveryRule constructor
+func NewServiceDiscoveryRule(comparator string, path string, value interface{}) *ServiceDiscoveryRule {
+	return &ServiceDiscoveryRule{comparator, path, value}
+}
+
+// ServiceDiscoveryRuleset that names a set of service discovery rules
+type ServiceDiscoveryRuleset struct {
+	Name  string
+	Type  string
+	Rules []ServiceDiscoveryRule
+}
+
+// NewServiceDiscoveryRuleset constructor
+func NewServiceDiscoveryRuleset(name string, t string) *ServiceDiscoveryRuleset {
+	return &ServiceDiscoveryRuleset{name, t, make([]ServiceDiscoveryRule, 0)}
+}
+
+// ServiceDiscoverySignatures with name
+type ServiceDiscoverySignatures struct {
+	Name       string
+	Signatures []ServiceDiscoveryRuleset
+}
+
+// NewServiceDiscoverySignatures constructor
+func NewServiceDiscoverySignatures(name string, signatures []ServiceDiscoveryRuleset) *ServiceDiscoverySignatures {
+	return &ServiceDiscoverySignatures{name, signatures}
+}
+
+// loadServiceSignatures reads discovery rules from file
+func loadServiceSignatures(servicesFile string) (*ServiceDiscoverySignatures, error) {
+	var signatures ServiceDiscoverySignatures
+	jsonContent, err := ioutil.ReadFile(servicesFile)
+	if err != nil {
+		return &signatures, err
+	}
+
+	if err := json.Unmarshal(jsonContent, &signatures); err != nil {
+		return &signatures, err
+	}
+	return &signatures, nil
+}
+
+// RuleFilter filters instances based on rules
+type RuleFilter struct {
+	plugins.Plugin
+	serviceRules *ServiceDiscoverySignatures
+}
+
+// NewRuleFilter creates a new instance
+func NewRuleFilter(name string, config *viper.Viper) (*RuleFilter, error) {
+	var (
+		signatures   *ServiceDiscoverySignatures
+		servicesFile string
+		err          error
+	)
+
+	plugin, err := plugins.NewPlugin(name, config)
+	if err != nil {
+		return nil, err
+	}
+
+	if servicesFile = plugin.Config.GetString("servicesfile"); servicesFile == "" {
+		return nil, errors.New("servicesFile configuration value missing")
+	}
+
+	log.Printf("loading service discovery signatures from %s", servicesFile)
+	if signatures, err = loadServiceSignatures(servicesFile); err != nil {
+		return nil, err
+	}
+
+	return &RuleFilter{plugin, signatures}, nil
+}
+
+// Matches if service instance satisfies rules
+func matches(si *services.ServiceInstance, ruleset ServiceDiscoveryRuleset) (bool, error) {
+	jsonRules, err := json.Marshal(ruleset.Rules)
+	if err != nil {
+		return false, err
+	}
+
+	engine, err := ruler.NewRulerWithJson(jsonRules)
+	if err != nil {
+		return false, err
+	}
+
+	sm := map[string]interface{}{
+		"ContainerID":        si.Container.ID,
+		"ContainerName":      si.Container.Names[0],
+		"ContainerImage":     si.Container.Image,
+		"ContainerPod":       si.Container.Pod,
+		"ContainerCommand":   si.Container.Command,
+		"ContainerState":     si.Container.State,
+		"NetworkIP":          si.Port.IP,
+		"NetworkType":        si.Port.Type,
+		"NetworkPublicPort":  strconv.FormatUint(uint64(si.Port.PublicPort), 10),
+		"NetworkPrivatePort": strconv.FormatUint(uint64(si.Port.PrivatePort), 10),
+	}
+
+	for key, val := range si.Container.Labels {
+		sm["ContainerLabel-"+key] = val
+	}
+
+	for key, val := range si.Port.Labels {
+		sm["NetworkLabel-"+key] = val
+	}
+
+	return engine.Test(sm), nil
+}
+
+// Map matches discovered service instances to a plugin type.
+func (filter *RuleFilter) Map(sis services.ServiceInstances) (services.ServiceInstances, error) {
+	servicesDRS := filter.serviceRules.Signatures
+
+	applicableServices := make(services.ServiceInstances, 0, len(sis))
+	for i := range sis {
+		for _, ruleset := range servicesDRS {
+			matches, err := matches(&sis[i], ruleset)
+			if err != nil {
+				return nil, err
+			}
+
+			if matches {
+				// set service name to ruleset name and add as service to monitor
+				sis[i].Service.Name = ruleset.Name
+				sis[i].Service.Type = ruleset.Type
+				applicableServices = append(applicableServices, sis[i])
+				break
+			}
+		}
+	}
+
+	return applicableServices, nil
+}

--- a/plugins/monitors/monitor.go
+++ b/plugins/monitors/monitor.go
@@ -1,19 +1,6 @@
 package monitors
 
-import (
-	"github.com/signalfx/neo-agent/services"
-)
-
 const (
 	// Collectd Monitor plugin name
 	Collectd = "collectd"
 )
-
-// Monitor type
-type Monitor interface {
-	Monitor(services services.ServiceInstances) error
-	Start() error
-	Stop() error
-	Status() string
-	String() string
-}

--- a/plugins/observers/docker/docker.go
+++ b/plugins/observers/docker/docker.go
@@ -8,7 +8,6 @@ import (
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/signalfx/neo-agent/plugins"
-	"github.com/signalfx/neo-agent/plugins/observers"
 	"github.com/signalfx/neo-agent/services"
 	"github.com/spf13/viper"
 	"golang.org/x/net/context"
@@ -26,8 +25,8 @@ type Docker struct {
 }
 
 // NewDocker constructor
-func NewDocker(config *viper.Viper) (*Docker, error) {
-	plugin, err := plugins.NewPlugin(observers.Docker, config)
+func NewDocker(name string, config *viper.Viper) (*Docker, error) {
+	plugin, err := plugins.NewPlugin(name, config)
 	if err != nil {
 		return nil, err
 	}
@@ -35,8 +34,7 @@ func NewDocker(config *viper.Viper) (*Docker, error) {
 }
 
 // Discover services from querying docker api
-func (docker *Docker) Discover() (services.ServiceInstances, error) {
-
+func (docker *Docker) Read() (services.ServiceInstances, error) {
 	defaultHeaders := map[string]string{"User-Agent": userAgent}
 	hostURL := defaultHostURL
 	if configVal := docker.Config.GetString("hosturl"); configVal != "" {

--- a/plugins/observers/observer.go
+++ b/plugins/observers/observer.go
@@ -1,8 +1,6 @@
 package observers
 
-import (
-	"github.com/signalfx/neo-agent/services"
-)
+import "github.com/signalfx/neo-agent/services"
 
 const (
 	// Docker Observer plugin name

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -12,6 +12,14 @@ type Plugin struct {
 	Config *viper.Viper
 }
 
+// IPlugin plugin interface
+type IPlugin interface {
+	Name() string
+	Start() error
+	Stop()
+	String() string
+}
+
 // NewPlugin constructor
 func NewPlugin(name string, config *viper.Viper) (Plugin, error) {
 	if config == nil {
@@ -20,7 +28,21 @@ func NewPlugin(name string, config *viper.Viper) (Plugin, error) {
 	return Plugin{name, config}, nil
 }
 
+// Name is name of plugin
+func (plugin *Plugin) Name() string {
+	return plugin.name
+}
+
 // String name of plugin
 func (plugin *Plugin) String() string {
 	return plugin.name
+}
+
+// Start default start (no-op)
+func (plugin *Plugin) Start() error {
+	return nil
+}
+
+// Stop default stop (no-op)
+func (plugin *Plugin) Stop() {
 }

--- a/utils/set.go
+++ b/utils/set.go
@@ -1,0 +1,16 @@
+package utils
+
+// UniqueStrings returns a slice with the unique set of strings from the input
+func UniqueStrings(strings []string) []string {
+	unique := map[string]struct{}{}
+	for _, v := range strings {
+		unique[v] = struct{}{}
+	}
+
+	keys := make([]string, 0)
+	for k := range unique {
+		keys = append(keys, k)
+	}
+
+	return keys
+}


### PR DESCRIPTION
This centralizes service rule filtering into observers instead of having each
monitor have to load and process it. Now a monitor is told exactly which
ServicesInstances to monitor and what their type is.

---

We discussed this the other day but I wanted you to look at the code to see if
we could come to a consensus. Let's discuss if you're still unsure.