### PR TITLE
Add IHostPort for common host/port configuration

### DIFF
--- a/plugins/monitors/collectd/config/yaml.go
+++ b/plugins/monitors/collectd/config/yaml.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/signalfx/neo-agent/services"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -47,7 +48,7 @@ func LoadYamlConfig(configFile string) (*AppConfig, error) {
 			return nil, errors.New("plugin name not of type string")
 		}
 
-		pluginStruct, err := NewPlugin(pluginType, pluginName)
+		pluginStruct, err := NewPlugin(services.ServiceType(pluginType), pluginName)
 		if err != nil {
 			return nil, err
 		}

--- a/services/service.go
+++ b/services/service.go
@@ -14,8 +14,10 @@ type ServiceType string
 const (
 	// REDIS Redis server
 	REDIS ServiceType = "redis"
-	// APACHE
+	// APACHE Apache web server
 	APACHE ServiceType = "apache"
+	// SIGNALFX SignalFx plugins
+	SIGNALFX ServiceType = "signalfx"
 )
 
 const (


### PR DESCRIPTION
This adds an interface and struct that collectd plugins can mixin if they need
a host and port number. Plugins can have additional properties that may need to
be configured but they'll still get host and port configured for free if they
just add it to the struct.