### PR TITLE
Remove redundant names

### DIFF
--- a/pipelines/pipeline.go
+++ b/pipelines/pipeline.go
@@ -11,17 +11,17 @@ import (
 
 // Source is an interface that only produces service instances
 type Source interface {
-	Read() (services.ServiceInstances, error)
+	Read() (services.Instances, error)
 }
 
 // Sink is an interface that only consumes service instances
 type Sink interface {
-	Write(services.ServiceInstances) error
+	Write(services.Instances) error
 }
 
 // SourceSink is an interface that consumes and products service instances
 type SourceSink interface {
-	Map(services.ServiceInstances) (services.ServiceInstances, error)
+	Map(services.Instances) (services.Instances, error)
 }
 
 // Pipeline is a series of sink/source plugins to execute in a specific order
@@ -55,7 +55,7 @@ func NewPipeline(name string, pluginNames []string, plugins []plugins.IPlugin) (
 
 // Execute runs steps sequentially in the pipeline (returns after all stages have been run once)
 func (pipeline *Pipeline) Execute() error {
-	var services services.ServiceInstances
+	var services services.Instances
 	var err error
 
 	for i, s := range pipeline.plugins {

--- a/plugins/filters/debug/debug.go
+++ b/plugins/filters/debug/debug.go
@@ -25,7 +25,7 @@ func NewFilter(name string, config *viper.Viper) (*Filter, error) {
 }
 
 // Map prints the input
-func (d *Filter) Map(sis services.ServiceInstances) (services.ServiceInstances, error) {
+func (d *Filter) Map(sis services.Instances) (services.Instances, error) {
 	if bytes, err := json.MarshalIndent(sis, "", "  "); err == nil {
 		log.Printf("Debug:\n%s", string(bytes))
 	}

--- a/plugins/filters/services/services.go
+++ b/plugins/filters/services/services.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ServiceDiscoveryRuleset that names a set of service discovery rules
-type ServiceDiscoveryRuleset struct {
+// DiscoveryRuleset that names a set of service discovery rules
+type DiscoveryRuleset struct {
 	Name string
 	Type string
 	// Rules are criteria for service identification
@@ -25,22 +25,22 @@ type ServiceDiscoveryRuleset struct {
 	}
 }
 
-// ServiceDiscoverySignatures with name
-type ServiceDiscoverySignatures struct {
+// DiscoverySignatures with name
+type DiscoverySignatures struct {
 	Name       string
-	Signatures []ServiceDiscoveryRuleset
+	Signatures []DiscoveryRuleset
 }
 
 // RuleFilter filters instances based on rules
 type RuleFilter struct {
 	plugins.Plugin
-	serviceRules []*ServiceDiscoverySignatures
+	serviceRules []*DiscoverySignatures
 }
 
 // NewRuleFilter creates a new instance
 func NewRuleFilter(name string, config *viper.Viper) (*RuleFilter, error) {
 	var (
-		signatures    []*ServiceDiscoverySignatures
+		signatures    []*DiscoverySignatures
 		servicesFiles []string
 		err           error
 	)
@@ -67,8 +67,8 @@ func NewRuleFilter(name string, config *viper.Viper) (*RuleFilter, error) {
 }
 
 // loadServiceSignatures reads discovery rules from file
-func loadServiceSignatures(servicesFile string) (*ServiceDiscoverySignatures, error) {
-	var signatures ServiceDiscoverySignatures
+func loadServiceSignatures(servicesFile string) (*DiscoverySignatures, error) {
+	var signatures DiscoverySignatures
 	jsonContent, err := ioutil.ReadFile(servicesFile)
 	if err != nil {
 		return &signatures, err
@@ -81,7 +81,7 @@ func loadServiceSignatures(servicesFile string) (*ServiceDiscoverySignatures, er
 }
 
 // Matches if service instance satisfies rules
-func matches(si *services.ServiceInstance, ruleset ServiceDiscoveryRuleset) (bool, error) {
+func matches(si *services.Instance, ruleset DiscoveryRuleset) (bool, error) {
 	jsonRules, err := json.Marshal(ruleset.Rules)
 	if err != nil {
 		return false, err
@@ -117,8 +117,8 @@ func matches(si *services.ServiceInstance, ruleset ServiceDiscoveryRuleset) (boo
 }
 
 // Map matches discovered service instances to a plugin type.
-func (filter *RuleFilter) Map(sis services.ServiceInstances) (services.ServiceInstances, error) {
-	applicableServices := make(services.ServiceInstances, 0, len(sis))
+func (filter *RuleFilter) Map(sis services.Instances) (services.Instances, error) {
+	applicableServices := make(services.Instances, 0, len(sis))
 
 	// Find the first rule that matches each service instance.
 OUTER:

--- a/plugins/filters/services/services_test.go
+++ b/plugins/filters/services/services_test.go
@@ -9,17 +9,17 @@ import (
 )
 
 // May want to share these fixtures in the future with new tests.
-var discoveredApache = services.ServiceInstance{
+var discoveredApache = services.Instance{
 	ID: "test-instance",
 	Service: &services.Service{
 		Name: "default",
 	},
-	Container: &services.ServiceContainer{
+	Container: &services.Container{
 		Names:  []string{"apache"},
 		Image:  "apache",
 		Labels: map[string]string{},
 	},
-	Port: &services.ServicePort{
+	Port: &services.Port{
 		IP:          "localhost",
 		Type:        services.TCP,
 		PrivatePort: 80,
@@ -27,17 +27,17 @@ var discoveredApache = services.ServiceInstance{
 	},
 }
 
-var discoveredRedis = services.ServiceInstance{
+var discoveredRedis = services.Instance{
 	ID: "test-instance",
 	Service: &services.Service{
 		Name: "default",
 	},
-	Container: &services.ServiceContainer{
+	Container: &services.Container{
 		Names:  []string{"redis"},
 		Image:  "unknown",
 		Labels: map[string]string{"signalfx-integration": "redis"},
 	},
-	Port: &services.ServicePort{
+	Port: &services.Port{
 		IP:          "localhost",
 		Type:        services.TCP,
 		PrivatePort: 3689,
@@ -102,7 +102,7 @@ func TestNewRuleFilter(t *testing.T) {
 
 func TestRuleFilter_Map(t *testing.T) {
 	// Has to be an empty slice and not just nil for the DeepEqual comparison to work.
-	sis := make(services.ServiceInstances, 0)
+	sis := make(services.Instances, 0)
 
 	makeFilter := func(files ...string) *RuleFilter {
 		v := viper.New()
@@ -120,20 +120,20 @@ func TestRuleFilter_Map(t *testing.T) {
 	defaultRules := makeFilter("testdata/defaults.json")
 
 	type args struct {
-		sis services.ServiceInstances
+		sis services.Instances
 	}
 	tests := []struct {
 		name    string
 		filter  *RuleFilter
 		args    args
-		want    services.ServiceInstances
+		want    services.Instances
 		wantErr bool
 	}{
 		{"empty rules", emptyRules, args{sis}, sis, false},
-		{"custom rule wins", customRules, args{services.ServiceInstances{discoveredApache}},
-			services.ServiceInstances{apacheCustom}, false},
-		{"default rules match", defaultRules, args{services.ServiceInstances{discoveredApache, discoveredRedis}},
-			services.ServiceInstances{apacheImageMapped, redisLabelMapped}, false},
+		{"custom rule wins", customRules, args{services.Instances{discoveredApache}},
+			services.Instances{apacheCustom}, false},
+		{"default rules match", defaultRules, args{services.Instances{discoveredApache, discoveredRedis}},
+			services.Instances{apacheImageMapped, redisLabelMapped}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/plugins/monitors/collectd/collectd.go
+++ b/plugins/monitors/collectd/collectd.go
@@ -40,7 +40,7 @@ const (
 type Collectd struct {
 	plugins.Plugin
 	state        string
-	services     services.ServiceInstances
+	services     services.Instances
 	templatesDir string
 	confFile     string
 	pluginsDir   string
@@ -115,7 +115,7 @@ func loadTemplatesMap(path string, templatesMap map[string][]string) error {
 }
 
 // Monitor services from collectd monitor
-func (collectd *Collectd) Write(services services.ServiceInstances) error {
+func (collectd *Collectd) Write(services services.Instances) error {
 	changed := false
 	if len(collectd.services) != len(services) {
 		changed = true
@@ -215,7 +215,7 @@ func (collectd *Collectd) getStaticPlugins() ([]*config.Plugin, error) {
 	return plugins, nil
 }
 
-func (collectd *Collectd) createPluginsFromServices(sis services.ServiceInstances) ([]*config.Plugin, error) {
+func (collectd *Collectd) createPluginsFromServices(sis services.Instances) ([]*config.Plugin, error) {
 	log.Printf("Configuring collectd plugins for %+v", sis)
 	var plugins []*config.Plugin
 

--- a/plugins/observers/kubernetes/kubernetes.go
+++ b/plugins/observers/kubernetes/kubernetes.go
@@ -83,7 +83,7 @@ func NewKubernetes(name string, config *viper.Viper) (*Kubernetes, error) {
 }
 
 // Map adds additional data from the kubelet into instances
-func (k *Kubernetes) Map(sis services.ServiceInstances) (services.ServiceInstances, error) {
+func (k *Kubernetes) Map(sis services.Instances) (services.Instances, error) {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: k.Config.GetBool("ignoretlsverify"),
@@ -128,8 +128,8 @@ func (k *Kubernetes) Map(sis services.ServiceInstances) (services.ServiceInstanc
 
 // doMap takes a list of service instance and applies information discovered
 // from Kubernetes for matching containers
-func (k *Kubernetes) doMap(sis services.ServiceInstances, pods *pods) (services.ServiceInstances, error) {
-	var instances services.ServiceInstances
+func (k *Kubernetes) doMap(sis services.Instances, pods *pods) (services.Instances, error) {
+	var instances services.Instances
 
 	for _, pod := range pods.Items {
 		podIP := pod.Status.PodIP
@@ -150,7 +150,7 @@ func (k *Kubernetes) doMap(sis services.ServiceInstances, pods *pods) (services.
 				"kubernetes_pod_namespace": pod.Metadata.Namespace,
 				"kubernetes_node":          pod.Spec.NodeName,
 			}
-			orchestration := services.NewServiceOrchestration("kubernetes", services.KUBERNETES, dims, services.PRIVATE)
+			orchestration := services.NewOrchestration("kubernetes", services.KUBERNETES, dims, services.PRIVATE)
 
 			for _, port := range container.Ports {
 				for _, status := range pod.Status.ContainerStatuses {
@@ -168,11 +168,11 @@ func (k *Kubernetes) doMap(sis services.ServiceInstances, pods *pods) (services.
 
 					id := fmt.Sprintf("%s-%s-%d", k.String(), pod.Metadata.Name, port.ContainerPort)
 					service := services.NewService(id, services.UnknownService)
-					servicePort := services.NewServicePort(podIP, port.Protocol, port.ContainerPort, 0)
-					container := services.NewServiceContainer(status.ContainerID,
+					servicePort := services.NewPort(podIP, port.Protocol, port.ContainerPort, 0)
+					container := services.NewContainer(status.ContainerID,
 						[]string{status.Name}, container.Image, pod.Metadata.Name, "",
 						containerState, pod.Metadata.Labels)
-					instances = append(instances, *services.NewServiceInstance(id, service, container,
+					instances = append(instances, *services.NewInstance(id, service, container,
 						orchestration, servicePort, now()))
 				}
 			}

--- a/plugins/observers/kubernetes/kubernetes_test.go
+++ b/plugins/observers/kubernetes/kubernetes_test.go
@@ -53,7 +53,7 @@ func Test_load(t *testing.T) {
 
 func TestKubernetes_doMap(t *testing.T) {
 	var running, nonRunningContainer *pods
-	var expected services.ServiceInstances
+	var expected services.Instances
 	neotest.LoadJSON(t, "testdata/pods.json", &running)
 	neotest.LoadJSON(t, "testdata/pods.json", &nonRunningContainer)
 	neotest.LoadJSON(t, "testdata/2-discovered.json", &expected)
@@ -80,14 +80,14 @@ func TestKubernetes_doMap(t *testing.T) {
 		hostURL string
 	}
 	type args struct {
-		sis  services.ServiceInstances
+		sis  services.Instances
 		pods *pods
 	}
 	tests := []struct {
 		name     string
 		instance *Kubernetes
 		args     args
-		want     services.ServiceInstances
+		want     services.Instances
 		wantErr  bool
 	}{
 		{"zero instances", k, args{nil, &pods{}}, nil, false},

--- a/plugins/observers/observer.go
+++ b/plugins/observers/observer.go
@@ -11,6 +11,6 @@ const (
 
 // Observer type
 type Observer interface {
-	Discover() (services.ServiceInstances, error)
+	Discover() (services.Instances, error)
 	String() string
 }

--- a/services/service.go
+++ b/services/service.go
@@ -79,8 +79,8 @@ type Service struct {
 	Type ServiceType
 }
 
-// ServicePort network information
-type ServicePort struct {
+// Port network information
+type Port struct {
 	IP          string
 	Type        PortType
 	PrivatePort uint16
@@ -88,16 +88,16 @@ type ServicePort struct {
 	Labels      map[string]string
 }
 
-// ServiceOrchestration information
-type ServiceOrchestration struct {
+// Orchestration information
+type Orchestration struct {
 	ID       string
 	Type     OrchestrationType
 	Dims     map[string]string
 	PortPref PortPreference
 }
 
-// ServiceContainer information
-type ServiceContainer struct {
+// Container information
+type Container struct {
 	ID      string
 	Names   []string
 	Image   string
@@ -107,13 +107,13 @@ type ServiceContainer struct {
 	Labels  map[string]string
 }
 
-// ServiceInstance information for single instance of a discovered service
-type ServiceInstance struct {
+// Instance information for single instance of a discovered service
+type Instance struct {
 	ID            string
 	Service       *Service
-	Container     *ServiceContainer
-	Orchestration *ServiceOrchestration
-	Port          *ServicePort
+	Container     *Container
+	Orchestration *Orchestration
+	Port          *Port
 	Discovered    time.Time
 }
 
@@ -122,40 +122,40 @@ func NewService(name string, serviceType ServiceType) *Service {
 	return &Service{name, serviceType}
 }
 
-// NewServicePort constructor
-func NewServicePort(ip string, portType PortType, privatePort uint16, publicPort uint16) *ServicePort {
-	return &ServicePort{ip, portType, privatePort, publicPort, make(map[string]string)}
+// NewPort constructor
+func NewPort(ip string, portType PortType, privatePort uint16, publicPort uint16) *Port {
+	return &Port{ip, portType, privatePort, publicPort, make(map[string]string)}
 }
 
-// NewServiceOrchestration constructor
-func NewServiceOrchestration(id string, orchType OrchestrationType, dims map[string]string, portPref PortPreference) *ServiceOrchestration {
-	return &ServiceOrchestration{id, orchType, dims, portPref}
+// NewOrchestration constructor
+func NewOrchestration(id string, orchType OrchestrationType, dims map[string]string, portPref PortPreference) *Orchestration {
+	return &Orchestration{id, orchType, dims, portPref}
 }
 
-// NewServiceContainer constructor
-func NewServiceContainer(id string, names []string, image string, pod string, command string, state string, labels map[string]string) *ServiceContainer {
-	return &ServiceContainer{id, names, image, pod, command, state, labels}
+// NewContainer constructor
+func NewContainer(id string, names []string, image string, pod string, command string, state string, labels map[string]string) *Container {
+	return &Container{id, names, image, pod, command, state, labels}
 }
 
-// NewServiceInstance constructor
-func NewServiceInstance(id string, service *Service, container *ServiceContainer, orchestration *ServiceOrchestration, port *ServicePort, discovered time.Time) *ServiceInstance {
-	return &ServiceInstance{id, service, container, orchestration, port, discovered}
+// NewInstance constructor
+func NewInstance(id string, service *Service, container *Container, orchestration *Orchestration, port *Port, discovered time.Time) *Instance {
+	return &Instance{id, service, container, orchestration, port, discovered}
 }
 
-// ServiceInstances type containing sorted set of services
-type ServiceInstances []ServiceInstance
+// Instances type containing sorted set of services
+type Instances []Instance
 
 // Len for serviceinstances sort
-func (svcs ServiceInstances) Len() int {
+func (svcs Instances) Len() int {
 	return len(svcs)
 }
 
 // Swap for serviceinstances sort
-func (svcs ServiceInstances) Swap(i, j int) {
+func (svcs Instances) Swap(i, j int) {
 	svcs[i], svcs[j] = svcs[j], svcs[i]
 }
 
 // Less for serviceinstances sort
-func (svcs ServiceInstances) Less(i, j int) bool {
+func (svcs Instances) Less(i, j int) bool {
 	return svcs[i].ID < svcs[j].ID
 }


### PR DESCRIPTION
Since exported variables from packages are always referenced with the package
(e.g. for Baz in package foo you always say foo.Baz) go suggests not repeating
the package name in the variable.

This removes the redundancy in Service and ServiceDiscovery. This makes things
a little easier to read.