### PR TITLE
Add environmental configuration

### DIFF
--- a/etc/agent.yaml
+++ b/etc/agent.yaml
@@ -1,4 +1,5 @@
-interval: 10
+# interval: 10
+# pipeline: docker
 
 observers:
     local-docker:
@@ -23,12 +24,8 @@ monitors:
             staticPlugins:
                 - name: writehttp-default
                   type: writehttp
-                  config:
-                      apiToken: <API TOKEN>
                 - name: signalfx-default
                   type: signalfx
-                  config:
-                      apiToken: <API TOKEN>
                 - name: docker-default
                   type: docker
                   config:
@@ -41,8 +38,13 @@ filters:
             - /etc/signalfx/collectd/custom-services.json
             - /etc/signalfx/collectd/services.json
 
-pipeline:
-    default:
+pipelines:
+    kubernetes:
+    - kubernetes
+    - service-mapping
+    - collectd
+
+    docker:
     - local-docker
     - service-mapping
     - collectd


### PR DESCRIPTION
This allows configuration settings to be overriden by environmental variables
in preparation for Kubernetes daemonset.

Pipeline to run is now configurable with `pipeline` setting (which would be
SFX_PIPELINE as an env var.)

Removed apiToken entry in agent.yaml because that already comes from env var.