### PR TITLE
Use pod name as the service name

### DIFF
--- a/plugins/filters/services/services.go
+++ b/plugins/filters/services/services.go
@@ -131,8 +131,7 @@ OUTER:
 				}
 
 				if matches {
-					// set service name to ruleset name and add as service to monitor
-					sis[i].Service.Name = ruleset.Name
+					// add as service to monitor
 					// FIXME: what if it's not a known service type?
 					sis[i].Service.Type = services.ServiceType(ruleset.Type)
 					applicableServices = append(applicableServices, sis[i])

--- a/plugins/filters/services/services_test.go
+++ b/plugins/filters/services/services_test.go
@@ -12,7 +12,7 @@ import (
 var discoveredApache = services.Instance{
 	ID: "test-instance",
 	Service: &services.Service{
-		Name: "default",
+		Name: "apache-6789",
 	},
 	Container: &services.Container{
 		Names:  []string{"apache"},
@@ -30,7 +30,7 @@ var discoveredApache = services.Instance{
 var discoveredRedis = services.Instance{
 	ID: "test-instance",
 	Service: &services.Service{
-		Name: "default",
+		Name: "redis-1234",
 	},
 	Container: &services.Container{
 		Names:  []string{"redis"},
@@ -57,16 +57,16 @@ var redisLabelMapped = discoveredRedis
 func init() {
 	// Customize cloned service instances.
 	apacheImageMapped.Service = &services.Service{
-		Name: "apache-image-default",
+		Name: "apache-6789",
 		Type: services.ApacheService,
 	}
 	apacheCustom.Service = &services.Service{
-		Name: "apache-custom",
+		Name: "apache-6789",
 		Type: services.ApacheService,
 	}
 
 	redisLabelMapped.Service = &services.Service{
-		Name: "redis-labeled-default",
+		Name: "redis-1234",
 		Type: services.RedisService,
 	}
 }

--- a/plugins/observers/kubernetes/kubernetes.go
+++ b/plugins/observers/kubernetes/kubernetes.go
@@ -167,7 +167,7 @@ func (k *Kubernetes) doMap(sis services.Instances, pods *pods) (services.Instanc
 					}
 
 					id := fmt.Sprintf("%s-%s-%d", k.String(), pod.Metadata.Name, port.ContainerPort)
-					service := services.NewService(id, services.UnknownService)
+					service := services.NewService(pod.Metadata.Name, services.UnknownService)
 					servicePort := services.NewPort(podIP, port.Protocol, port.ContainerPort, 0)
 					container := services.NewContainer(status.ContainerID,
 						[]string{status.Name}, container.Image, pod.Metadata.Name, "",

--- a/plugins/observers/kubernetes/testdata/2-discovered.json
+++ b/plugins/observers/kubernetes/testdata/2-discovered.json
@@ -2,7 +2,7 @@
   {
     "ID": "kubernetes-kubernetes-dashboard-v1.5.1-5zg3f-9090",
     "Service": {
-      "Name": "kubernetes-kubernetes-dashboard-v1.5.1-5zg3f-9090",
+      "Name": "kubernetes-dashboard-v1.5.1-5zg3f",
       "Type": ""
     },
     "Container": {
@@ -44,7 +44,7 @@
   {
     "ID": "kubernetes-redis-3165242388-n1vc7-6379",
     "Service": {
-      "Name": "kubernetes-redis-3165242388-n1vc7-6379",
+      "Name": "redis-3165242388-n1vc7",
       "Type": ""
     },
     "Container": {

--- a/services/service.go
+++ b/services/service.go
@@ -118,6 +118,7 @@ type Instance struct {
 }
 
 // NewService constructor
+// name should be unique enough for using as an id (host, instance, etc.)
 func NewService(name string, serviceType ServiceType) *Service {
 	return &Service{name, serviceType}
 }


### PR DESCRIPTION
Before the service name was set to the rule name. Templates use the service
name to identify the service (e.g. the redis instance was being given the name
redis-image-default for all monitored instances).

Instead set the service name to something that makes sense for the observer
(pod name in the case of Kubernetes) and leave it untouched.