### PR TITLE
Not working: Configure collectd hostname

### DIFF
--- a/deploy/kubernetes/signalfx-agent.yml
+++ b/deploy/kubernetes/signalfx-agent.yml
@@ -40,3 +40,5 @@ spec:
                 value: "1"
               - name: SFX_PIPELINE
                 value: kubernetes
+              - name: SFX_MONITORS_COLLECTD_CONFIG_HOSTNAME
+                value: $(KUBERNETES_NODE_NAME)

--- a/etc/agent.yaml
+++ b/etc/agent.yaml
@@ -9,7 +9,7 @@ observers:
     kubernetes:
         type: kubernetes
         config:
-            hostUrl: http://localhost:10250
+            hostUrl: https://localhost:10250
             # Whether to ignore SSL certification validation errors.
             # ignoreTLSVerify: false
 
@@ -17,6 +17,8 @@ monitors:
     collectd:
         type: collectd
         config:
+            # If hostname is unset collectd determines the hostname at runtime.
+            # hostname:
             confFile: /etc/collectd/collectd.conf
             templatesDir: /etc/signalfx/collectd/templates
             templatesMap: /etc/signalfx/collectd/templates.json
@@ -31,6 +33,9 @@ monitors:
                   config:
                       hostUrl: unix:///var/run/docker.sock
 filters:
+    debug:
+        type: debug
+        config: {}
     service-mapping:
         type: service-rules
         config:

--- a/etc/collectd/templates/collectd.conf.tmpl
+++ b/etc/collectd/templates/collectd.conf.tmpl
@@ -1,17 +1,19 @@
 TypesDB "{{Globals.PluginRoot}}/types.db"
 
-#   If you use the Hostname parameter, you
-#   must quote ("...") the second argument
-### Hostname "<YOUR_HOSTNAME_HERE>"
-# %%%HOSTNAME%%%
-
+{{- with .AgentConfig -}}
+{{if .Hostname}}
+Hostname "{{.Hostname}}"
+FQDNLookup false
+{{else}}
 FQDNLookup true
-Interval {{ .AgentConfig.Interval }}
-Timeout {{ .AgentConfig.Timeout }}
-ReadThreads {{ .AgentConfig.ReadThreads }}
-WriteQueueLimitHigh {{ .AgentConfig.WriteQueueLimitHigh }}
-WriteQueueLimitLow  {{ .AgentConfig.WriteQueueLimitLow }}
-CollectInternalStats {{ .AgentConfig.CollectInternalStats }}
+{{end}}
+Interval {{ .Interval }}
+Timeout {{ .Timeout }}
+ReadThreads {{ .ReadThreads }}
+WriteQueueLimitHigh {{ .WriteQueueLimitHigh }}
+WriteQueueLimitLow  {{ .WriteQueueLimitLow }}
+CollectInternalStats {{ .CollectInternalStats }}
+{{end}}
 
 LoadPlugin logfile
 

--- a/plugins/monitors/collectd/collectd.go
+++ b/plugins/monitors/collectd/collectd.go
@@ -166,8 +166,12 @@ func (collectd *Collectd) reload() {
 // writePlugins takes a list of plugin instances and generates a collectd.conf
 // formatted configuration.
 func (collectd *Collectd) writePlugins(plugins []*config.Plugin) error {
+	collectdConfig := config.NewCollectdConfig()
+	// If this is empty then collectd determines hostname.
+	collectdConfig.Hostname = collectd.Config.GetString("hostname")
+
 	config, err := config.RenderCollectdConf(collectd.pluginsDir, collectd.templatesDir, &config.AppConfig{
-		AgentConfig: config.NewCollectdConfig(),
+		AgentConfig: collectdConfig,
 		Plugins:     plugins,
 	})
 

--- a/plugins/monitors/collectd/config/config-example.yml
+++ b/plugins/monitors/collectd/config/config-example.yml
@@ -6,6 +6,7 @@
 # writeQueueLimitHigh:  500000
 # writeQueueLimitLow:   400000
 # collectInternalStats: true
+# hostname: <dynamic>
 
 plugins:
 - plugin: signalfx

--- a/plugins/monitors/collectd/config/types.go
+++ b/plugins/monitors/collectd/config/types.go
@@ -94,6 +94,7 @@ type CollectdConfig struct {
 	WriteQueueLimitHigh  uint `yaml:"writeQueueLimitHigh"`
 	WriteQueueLimitLow   uint `yaml:"writeQueueLimitLow"`
 	CollectInternalStats bool
+	Hostname             string
 	Plugins              []map[string]interface{}
 }
 


### PR DESCRIPTION
This makes collectd hostname configurable. When run from kubernetes set the
hostname to be the node's hostname (instead of the pod hostname which is the
pod name).

Also:

* s/http/https for Kubernetes host url so it's a good default for local testing
* add debug filter (but don't include it in the pipeline) for both reference and also to make it easier to turn on for debugging