### PR TITLE
Fix static plugin configuration

### DIFF
--- a/deploy/kubernetes/signalfx-agent-configmap.yml
+++ b/deploy/kubernetes/signalfx-agent-configmap.yml
@@ -5,7 +5,6 @@ data:
     #   kubernetes:
     #     # Set to true to ignore certificate verification checks connecting to kubelet.
     #     ignoreTLSVerify: false
-    # plugins:
     #   collectd:
     #     staticPlugins:
     #       writehttp-default:


### PR DESCRIPTION
Configuration keys of static plugins weren't getting passed through (like
dimensions). Kind of hacky but couldn't get inline working, not sure if it does
in viper.

Also fix configmap template as plugins: was being set twice and settings lost
during merge. (Already changed in deployed version)