### PR TITLE
Add Kubernetes dimensions to docker container metrics

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -74,11 +74,13 @@ func (agent *Agent) Configure(configfile string) error {
 	}
 
 	if merge := os.Getenv(envMergeConfig); len(merge) > 1 {
-		if file, err := os.Open(merge); err == nil {
-			defer file.Close()
-			log.Printf("merging config %s", merge)
-			if err := viper.MergeConfig(file); err != nil {
-				return err
+		for _, mergeFile := range strings.Split(merge, ":") {
+			if file, err := os.Open(mergeFile); err == nil {
+				defer file.Close()
+				log.Printf("merging config %s", mergeFile)
+				if err := viper.MergeConfig(file); err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/deploy/kubernetes/signalfx-agent.yml
+++ b/deploy/kubernetes/signalfx-agent.yml
@@ -58,12 +58,10 @@ spec:
                     secretKeyRef:
                         name: signalfx
                         key: apiToken
-              - name: SFX_PIPELINE
-                value: kubernetes
               - name: SFX_HOSTNAME
                 value: $(KUBERNETES_NODE_NAME)
               - name: SFX_MERGE_CONFIG
-                value: /mnt/config/merge.yml
+                value: /etc/signalfx/kubernetes-defaults.yaml:/mnt/config/merge.yml
             volumes:
               - name: config
                 configMap:

--- a/etc/collectd/templates/docker.conf.tmpl
+++ b/etc/collectd/templates/docker.conf.tmpl
@@ -9,6 +9,9 @@ LoadPlugin python
     BaseURL "{{.Config.url}}"
     Timeout 3
     Verbose false
+    {{range $key, $value := .Config.extradimensions -}}
+    Dimension "{{$key}}" "{{$value}}"
+    {{end -}}
   </Module>
 </Plugin>
 

--- a/etc/collectd/templates/write-http.conf.tmpl
+++ b/etc/collectd/templates/write-http.conf.tmpl
@@ -3,7 +3,7 @@
 </LoadPlugin>
 <Plugin "write_http">
   <Node "SignalFx">
-    URL "{{.Config.url}}/v1/collectd{{if .Config.dimensions}}?{{end}}{{.Config.dimensions}}"
+    URL "{{.Config.url}}/v1/collectd{{if .Config.dimensions}}?{{.Config.dimensions}}{{end}}"
     User "auth"
     Password "{{Secret "SFX_API_TOKEN"}}"
     Format "JSON"

--- a/etc/kubernetes-defaults.yaml
+++ b/etc/kubernetes-defaults.yaml
@@ -1,0 +1,11 @@
+pipeline: kubernetes
+
+plugins:
+  collectd:
+    staticPlugins:
+      docker-default:
+        extraDimensions:
+          container_image: inspect:Config.Image
+          container_name: inspect:Config.Labels['io.kubernetes.container.name']
+          kubernetes_pod_name: inspect:Config.Labels['io.kubernetes.pod.name']
+          kubernetes_pod_namespace: inspect:Config.Labels['io.kubernetes.pod.namespace']


### PR DESCRIPTION
This adds kubernetes container name, pod name, and pod namespace as dimensions
to the default docker plugin.

Also fix the issue with <no value> being used for cluster name in write_http plugin.