### PR TITLE
Implement agent configuration reloading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,21 @@
 RUN_CONTAINER := neo-agent-tmp
 
+go_pkgs := $(shell glide novendor)
+
+.PHONY: check
+check: lint vet test
+
 .PHONY: test
 test:
-	go test `glide novendor`
+	go test $(go_pkgs)
+
+.PHONY: vet
+vet:
+	go vet $(go_pkgs)
 
 .PHONY: lint
 lint:
-	golint -set_exit_status `glide novendor`
+	golint -set_exit_status $(go_pkgs)
 
 .PHONY: collectd
 collectd:

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,122 @@
+package config
+
+import (
+	"log"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
+)
+
+const (
+	// DefaultInterval is used if not configured
+	DefaultInterval = 10
+	// DefaultPipeline is used if not configured
+	DefaultPipeline = "docker"
+	// EnvPrefix is the environment variable prefix
+	EnvPrefix = "SFX"
+
+	envMergeConfig = "SFX_MERGE_CONFIG"
+)
+
+var (
+	// EnvReplacer replaces . and - with _
+	EnvReplacer = strings.NewReplacer(".", "_", "-", "_")
+)
+
+// getMergeConfigs returns list of config files to merge from the environment
+// variable
+func getMergeConfigs() []string {
+	var configs []string
+
+	if merge := os.Getenv(envMergeConfig); len(merge) > 1 {
+		for _, mergeFile := range strings.Split(merge, ":") {
+			configs = append(configs, mergeFile)
+		}
+	}
+
+	return configs
+}
+
+// WatchForChanges watches for changes to configuration files
+func WatchForChanges(watcher *fsnotify.Watcher, configfile string, reload func() error) error {
+	// Watch base config and merged config for changes. If either changes reload
+	// viper config.
+	configFileSet := map[string]bool{}
+	configFiles := append(getMergeConfigs(), configfile)
+
+	for _, configFile := range configFiles {
+		configDir, configName := path.Split(configFile)
+		// Remove trailing slash so ReadLink works.
+		configDir = path.Clean(configDir)
+
+		// Have to dereference symlink so that entry in configFileSet will match
+		// the path from fsnotify.
+		if linkDir, err := os.Readlink(configDir); err == nil {
+			configDir = linkDir
+		}
+
+		configFileSet[path.Join(configDir, configName)] = true
+		log.Printf("watching for changes to %s in %s", configFile, configDir)
+		// Have to monitor directory in case file doesn't exist.
+		if err := watcher.Add(configDir); err != nil {
+			return err
+		}
+	}
+
+	go func() {
+		for {
+			select {
+			case err := <-watcher.Errors:
+				if err == nil {
+					return
+				}
+				log.Printf("file watch error: %s", err)
+			case event := <-watcher.Events:
+				if event.Op == 0 {
+					return
+				}
+				// We're monitoring the whole directory so make sure the change
+				// maps to a file we're interested in.
+				if event.Op&(fsnotify.Create|fsnotify.Remove|fsnotify.Write) != 0 && configFileSet[event.Name] {
+					log.Printf("config file %s changed", event.Name)
+					if err := reload(); err != nil {
+						log.Printf("error reloading configuration: %s", err)
+					}
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// Load loads the config from configfile as well as any merge files from
+// environment variable
+func Load(configfile string) error {
+	viper.SetDefault("interval", DefaultInterval)
+	viper.SetDefault("pipeline", DefaultPipeline)
+
+	viper.AutomaticEnv()
+	viper.SetEnvKeyReplacer(EnvReplacer)
+	viper.SetEnvPrefix(EnvPrefix)
+	viper.SetConfigFile(configfile)
+
+	if err := viper.ReadInConfig(); err != nil {
+		return err
+	}
+
+	for _, mergeFile := range getMergeConfigs() {
+		if file, err := os.Open(mergeFile); err == nil {
+			defer file.Close()
+			log.Printf("merging config %s", mergeFile)
+			if err := viper.MergeConfig(file); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0ab1fea884a7bc90b0407e817c15832af3f7d30d9e21b4ed7c3a4e4ac1e6cf38
-updated: 2017-02-17T20:11:51.345934183-05:00
+hash: fbd55cf0c05968bbc57350d85b11e6cadeb7fee196904daa40ab43a03f466558
+updated: 2017-03-13T11:33:04.136215205-04:00
 imports:
 - name: github.com/docker/distribution
   version: fb0bebc4b64e3881cc52a2478d749845ed76d2a8
@@ -32,7 +32,7 @@ imports:
 - name: github.com/docker/go-units
   version: 0dadbb0345b35ec7ef35e228dabb8de89a65bf52
 - name: github.com/fsnotify/fsnotify
-  version: a904159b9206978bb6d53fcc7a769e5cd726c737
+  version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/hashicorp/hcl
   version: db4f0768927a665a06c32855186e1bc762bcc8f5
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,5 +10,7 @@ import:
 - package: golang.org/x/net
   subpackages:
   - context
+- package: github.com/fsnotify/fsnotify
+  version: ~1.4.2
 testImport:
 - package: github.com/kr/pretty

--- a/plugins/filters/debug/debug.go
+++ b/plugins/filters/debug/debug.go
@@ -9,18 +9,22 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	pluginType = "filters/debug"
+)
+
 // Filter prints the input and passes
 type Filter struct {
 	plugins.Plugin
 }
 
 func init() {
-	plugins.Register("filters/debug", NewFilter)
+	plugins.Register(pluginType, NewFilter)
 }
 
 // NewFilter creates a new instance
 func NewFilter(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, config)
+	plugin, err := plugins.NewPlugin(name, pluginType, config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/filters/services/services.go
+++ b/plugins/filters/services/services.go
@@ -13,6 +13,10 @@ import (
 	"github.com/spf13/viper"
 )
 
+const (
+	pluginType = "filters/service-rules"
+)
+
 // DiscoveryRuleset that names a set of service discovery rules
 type DiscoveryRuleset struct {
 	Name string
@@ -38,7 +42,7 @@ type RuleFilter struct {
 }
 
 func init() {
-	plugins.Register("filters/service-rules", NewRuleFilter)
+	plugins.Register(pluginType, NewRuleFilter)
 }
 
 // NewRuleFilter creates a new instance
@@ -49,7 +53,7 @@ func NewRuleFilter(name string, config *viper.Viper) (plugins.IPlugin, error) {
 		err           error
 	)
 
-	plugin, err := plugins.NewPlugin(name, config)
+	plugin, err := plugins.NewPlugin(name, pluginType, config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -1,0 +1,115 @@
+package plugins
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/signalfx/neo-agent/config"
+	"github.com/spf13/viper"
+)
+
+func configurePlugin(pluginName string, c *viper.Viper) {
+	// This allows a configuration variable foo.bar to be overridable by
+	// SFX_FOO_BAR=value.
+	c.AutomaticEnv()
+	c.SetEnvKeyReplacer(config.EnvReplacer)
+	c.SetEnvPrefix(strings.ToUpper(
+		fmt.Sprintf("%s_plugins_%s", config.EnvPrefix, pluginName)))
+}
+
+// Load an agent using configuration file
+func Load(currentPlugins []IPlugin) ([]IPlugin, error) {
+	// Load plugins.
+	pluginsConfig := viper.GetStringMap("plugins")
+
+	currentPluginSet := map[string]IPlugin{}
+	for _, plugin := range currentPlugins {
+		currentPluginSet[plugin.Name()] = plugin
+	}
+
+	var newPlugins []IPlugin
+	var removedPlugins []IPlugin
+	var reloadPlugins []IPlugin
+
+	for pluginName := range pluginsConfig {
+		pluginType := viper.GetString(fmt.Sprintf("plugins.%s.plugin", pluginName))
+
+		if len(pluginType) < 1 {
+			return nil, fmt.Errorf("plugin %s missing plugin key", pluginName)
+		}
+
+		if plugin := currentPluginSet[pluginName]; plugin != nil {
+			// Already exists, just reload.
+			reloadPlugins = append(reloadPlugins, plugin)
+		} else {
+			// New plugin
+			if create, ok := Plugins[pluginType]; ok {
+				log.Printf("configuring plugin %s (%s)", pluginType, pluginName)
+
+				pluginConfig := viper.Sub("plugins." + pluginName)
+				configurePlugin(pluginName, pluginConfig)
+				pluginInst, err := create(pluginName, pluginConfig)
+				if err != nil {
+					return nil, err
+				}
+
+				newPlugins = append(newPlugins, pluginInst)
+			} else {
+				return nil, fmt.Errorf("unknown plugin %s", pluginType)
+			}
+		}
+	}
+
+	// NOTE: By this point we can't return errors with an unmodified plugin list
+	// as some new plugins may have been started. If there's an old plugin 'foo'
+	// and we start a new 'foo' but return an old plugin set there might be two
+	// foos running.
+
+	// Find removed plugins (in loaded plugins but not the new config).
+	for _, plugin := range currentPlugins {
+		if pluginsConfig[plugin.Name()] == nil {
+			removedPlugins = append(removedPlugins, plugin)
+		}
+	}
+
+	// Stop removed plugins.
+	for _, plugin := range removedPlugins {
+		log.Printf("stopping plugin %s", plugin.Name())
+		plugin.Stop()
+	}
+
+	// Reload existing plugins.
+	for _, plugin := range reloadPlugins {
+		log.Printf("reloading plugin %s", plugin.Name())
+		pluginConfig := viper.Sub("plugins." + plugin.Name())
+
+		if pluginConfig == nil {
+			log.Printf("%s plugin unexpectedly missing config", plugin.Name())
+			continue
+		}
+
+		pluginType := pluginConfig.GetString("plugin")
+
+		if pluginType != plugin.Type() {
+			log.Printf("%s plugin is currently type %s but changed to %s, skipping",
+				plugin.Name(), plugin.Type(), pluginType)
+			continue
+		}
+
+		configurePlugin(plugin.Name(), pluginConfig)
+		if err := plugin.Reload(pluginConfig); err != nil {
+			log.Printf("reloading %s plugin failed: %s", plugin.Name(), err)
+		}
+	}
+
+	// Start new plugins.
+	for _, plugin := range newPlugins {
+		log.Printf("starting plugin %s", plugin.String())
+		if err := plugin.Start(); err != nil {
+			log.Printf("failed to start plugin %s: %s", plugin.String(), err)
+		}
+	}
+
+	return append(reloadPlugins, newPlugins...), nil
+}

--- a/plugins/observers/docker/docker.go
+++ b/plugins/observers/docker/docker.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	pluginType     = "observers/docker"
 	defaultHostURL = "unix:///var/run/docker.sock"
 	userAgent      = "signalfx-agent"
 	version        = "v1.22"
@@ -25,12 +26,12 @@ type Docker struct {
 }
 
 func init() {
-	plugins.Register("observers/docker", NewDocker)
+	plugins.Register(pluginType, NewDocker)
 }
 
 // NewDocker constructor
 func NewDocker(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, config)
+	plugin, err := plugins.NewPlugin(name, pluginType, config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/observers/kubernetes/kubernetes.go
+++ b/plugins/observers/kubernetes/kubernetes.go
@@ -26,6 +26,7 @@ var now = time.Now
 type phase string
 
 const (
+	pluginType = "observers/kubernetes"
 	// RunningPhase Kubernetes running phase
 	runningPhase phase = "Running"
 )
@@ -69,12 +70,12 @@ type pods struct {
 }
 
 func init() {
-	plugins.Register("observers/kubernetes", NewKubernetes)
+	plugins.Register(pluginType, NewKubernetes)
 }
 
 // NewKubernetes constructor
 func NewKubernetes(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, config)
+	plugin, err := plugins.NewPlugin(name, pluginType, config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/observers/mesosphere/mesosphere.go
+++ b/plugins/observers/mesosphere/mesosphere.go
@@ -16,6 +16,8 @@ import (
 )
 
 const (
+	pluginType = "observers/mesosphere"
+
 	// DefaultPort of the task state api
 	DefaultPort = 5051
 	// RunningState string for a currently running task
@@ -80,12 +82,12 @@ type tasks struct {
 }
 
 func init() {
-	plugins.Register("observers/mesosphere", NewMesosphere)
+	plugins.Register(pluginType, NewMesosphere)
 }
 
 // NewMesosphere observer
 func NewMesosphere(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, config)
+	plugin, err := plugins.NewPlugin(name, pluginType, config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -14,8 +14,9 @@ var Plugins = map[string]CreatePlugin{}
 
 // Plugin type
 type Plugin struct {
-	name   string
-	Config *viper.Viper
+	name       string
+	pluginType string
+	Config     *viper.Viper
 }
 
 // IPlugin plugin interface
@@ -23,15 +24,17 @@ type IPlugin interface {
 	Name() string
 	Start() error
 	Stop()
+	Reload(config *viper.Viper) error
 	String() string
+	Type() string
 }
 
 // NewPlugin constructor
-func NewPlugin(name string, config *viper.Viper) (Plugin, error) {
+func NewPlugin(name, pluginType string, config *viper.Viper) (Plugin, error) {
 	if config == nil {
 		return Plugin{}, errors.New("config cannot be nil")
 	}
-	return Plugin{name, config}, nil
+	return Plugin{name, pluginType, config}, nil
 }
 
 // Name is name of plugin
@@ -51,6 +54,23 @@ func (plugin *Plugin) Start() error {
 
 // Stop default stop (no-op)
 func (plugin *Plugin) Stop() {
+}
+
+// Type returns the plugin type
+func (plugin *Plugin) Type() string {
+	return plugin.pluginType
+}
+
+// Reload replaces the config with the newly loaded conifg. Plugins that need to
+// do anything special should implement their own reload.
+func (plugin *Plugin) Reload(config *viper.Viper) error {
+	// Need to be careful about when this Reload function gets called so as to
+	// avoid any data race issues with plugins. Right now reload is called
+	// before an execution is run so most plugins won't have any code running in
+	// other goroutines. If they do they should take care to synchronize the
+	// config replacement.
+	plugin.Config = config
+	return nil
 }
 
 // Register registers a plugin

--- a/scripts/circle.sh
+++ b/scripts/circle.sh
@@ -8,6 +8,6 @@ if [ "$1" = "test" ]; then
     mkdir -p $CIRCLE_TEST_REPORTS/reports
 
     cd ../.go_workspace/src/github.com/signalfx/neo-agent
-    make lint
+    make lint vet
     go test -v `glide novendor` | go2xunit > $CIRCLE_TEST_REPORTS/reports/unit.xml
 fi


### PR DESCRIPTION
This implement agent reloading such that if the main configuration file or any
merge configuration files change the agent and its plugins are reloaded.
Plugins can be added, removed, or have their configuration changed without
restarting.

Not all properties in the collectd monitor plugin are currently being reloaded.
That will be fixed in an upcoming change.