### PR TITLE
Fix collectd change detection

### DIFF
--- a/etc/kubernetes-defaults.yaml
+++ b/etc/kubernetes-defaults.yaml
@@ -13,6 +13,11 @@ plugins:
           kubernetes_pod_name: inspect:Config.Labels['io.kubernetes.pod.name']
           kubernetes_pod_namespace: inspect:Config.Labels['io.kubernetes.pod.namespace']
 
+  service-mapping:
+    servicesFiles:
+    - /mnt/services/custom-services.json
+    - /etc/signalfx/collectd/services.json
+
   cadvisor:
     plugin: monitors/cadvisor
     dataSendRate: 30

--- a/plugins/monitors/collectd/collectd.go
+++ b/plugins/monitors/collectd/collectd.go
@@ -132,7 +132,11 @@ func (collectd *Collectd) Write(services services.Instances) error {
 		changed = true
 	} else {
 		for i := range services {
-			if services[i].ID != collectd.services[i].ID {
+			// Checks if the services are either completely different (i.e. a
+			// service has been added or removed) or if the service's
+			// configuration has changed such as mapping to a different
+			// template.
+			if !services[i].Equivalent(&collectd.services[i]) {
 				changed = true
 				break
 			}

--- a/services/service.go
+++ b/services/service.go
@@ -1,6 +1,7 @@
 package services
 
 import "time"
+import "reflect"
 
 // OrchestrationType of service
 type OrchestrationType int
@@ -147,6 +148,21 @@ func NewContainer(id string, names []string, image string, pod string, command s
 // NewInstance constructor
 func NewInstance(id string, service *Service, container *Container, orchestration *Orchestration, port *Port, discovered time.Time) *Instance {
 	return &Instance{id, service, container, orchestration, port, discovered, ""}
+}
+
+// Equivalent determine if rhs and lhs and roughly equal (ignores Discovered time)
+func (lhs *Instance) Equivalent(rhs *Instance) bool {
+	// Quick check before doing DeepEqual.
+	if lhs.ID != rhs.ID {
+		return false
+	}
+
+	rhsCopy := *rhs
+	// Ignore discovered time.
+	rhsCopy.Discovered = lhs.Discovered
+	// Have to take address of rhsCopy so that it's comparing pointers to
+	// pointers.
+	return reflect.DeepEqual(lhs, &rhsCopy)
 }
 
 // Instances type containing sorted set of services


### PR DESCRIPTION
collectd wasn't being reloaded when a service instance's template changed such
as when a new service rule was added.

Also configure service mapping to load custom services from a configmap in
kubernetes. Supporting deployment changes will be made in integrations repo.