### PR TITLE
Implement unified file/zookeeper configuration loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@ can be automatically monitored. The agent will also include a set of dimensions
 for each metric sent that associate each datapoint with the managing orchestration
 system identifiers.
 
+## Dependencies
+
+Go dependencies are specified in `glide.yaml`. Of note the version of docker/libkv is currently a forked version from https://github.com/cohodata/libkv that has a ZooKeeper fix for watch events.
+
+Run `glide install` to pull down dependencies.
 
 ## Build Image From Source
 
 Run `make image`
-
 
 ## Run Agent Container
 

--- a/config/assets.go
+++ b/config/assets.go
@@ -1,0 +1,188 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+	"strings"
+	"time"
+
+	"os"
+
+	"github.com/docker/libkv"
+	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/zookeeper"
+	"github.com/signalfx/neo-agent/watchers"
+	"github.com/spf13/viper"
+)
+
+// Stores is a global metastore instance
+var Stores = newStores()
+
+const defaultScheme = "fs"
+
+type source interface {
+	Get(string) (*store.KVPair, error)
+	Watch(string, <-chan struct{}) (<-chan *store.KVPair, error)
+	WatchTree(string, <-chan struct{}) (<-chan []*store.KVPair, error)
+	Close()
+}
+
+type fs struct {
+	watcher *watchers.PollingWatcher
+}
+
+func newFs() *fs {
+	// TODO: configurable polling interval
+	return &fs{watchers.NewPollingWatcher(5 * time.Second)}
+}
+
+func (f *fs) Get(path string) (*store.KVPair, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return &store.KVPair{Key: path, Value: data, LastIndex: 0}, nil
+}
+
+func (f *fs) Watch(path string, stopCh <-chan struct{}) (<-chan *store.KVPair, error) {
+	return f.watcher.Watch(path, stopCh)
+}
+
+func (f *fs) WatchTree(path string, stopCh <-chan struct{}) (<-chan []*store.KVPair, error) {
+	return f.watcher.WatchTree(path, stopCh)
+}
+
+func (f *fs) Close() {
+	f.watcher.Close()
+}
+
+type metaStore struct {
+	stores map[string]source
+}
+
+// newStores creates a new metastore instance with a default filesystem source
+func newStores() *metaStore {
+	store := &metaStore{map[string]source{
+		"fs": newFs(),
+	}}
+
+	// Kind of a hack. Unfortunately UnmarshalKey used in the configuration
+	// doesn't support environment variable overrides. This can't be set in an
+	// merge file because merge files might contain a zk:// merge and this has
+	// to be configured before that.
+	if hosts := os.Getenv("SFX_STORES_ZK_HOSTS"); hosts != "" {
+		viper.Set("stores.zk.type", "zookeeper")
+		viper.Set("stores.zk.hosts", hosts)
+	}
+
+	return store
+}
+
+// Config configures metastore from a viper config
+func (s *metaStore) Config(config *viper.Viper) error {
+	// TODO: handle reload (have to shut down unused ones or reconfigure fs)
+	if config == nil {
+		return errors.New("stores configuration is nil")
+	}
+	var sources map[string]struct{}
+	if err := config.Unmarshal(&sources); err != nil {
+		return err
+	}
+
+	for source := range sources {
+		typ := config.GetString(source + ".type")
+		switch typ {
+		case "filesystem":
+			log.Print("configuring filesystem store")
+			var fs struct {
+				Interval float32
+			}
+			if err := config.UnmarshalKey(source, &fs); err != nil {
+				return err
+			}
+			// TODO: reconfigure if already present
+			if _, ok := s.stores[source]; !ok {
+				s.stores[source] = newFs()
+			}
+		case "zookeeper":
+			log.Print("configuring zookeeper store")
+			var zk struct {
+				// Hosts may be an array or a comma separated list of hosts.
+				Hosts interface{}
+			}
+			if err := config.UnmarshalKey(source, &zk); err != nil {
+				return err
+			}
+			if _, ok := s.stores[source]; !ok {
+				// TODO: reconfigure
+				log.Printf("added new store for %s %s", source, typ)
+				config := store.Config{}
+				zookeeper.Register()
+				var zkHosts []string
+
+				if zk.Hosts == nil {
+					return errors.New("zookeeper hosts cannot be empty")
+				}
+
+				switch hosts := zk.Hosts.(type) {
+				case string:
+					zkHosts = strings.Split(hosts, ",")
+				case []interface{}:
+					for _, s := range hosts {
+						if str, ok := s.(string); ok {
+							zkHosts = append(zkHosts, str)
+						}
+					}
+				default:
+					return errors.New("unknown hosts type")
+				}
+
+				store, err := libkv.NewStore(store.ZK, zkHosts, &config)
+				if err != nil {
+					return err
+				}
+				s.stores[source] = store
+			}
+
+		default:
+			return fmt.Errorf("unknown type '%s'", source)
+		}
+	}
+
+	return nil
+}
+
+// Get returns a source instance and the parsed out path if it's valid and
+// the source exists, otherwise err is set
+func (s *metaStore) Get(uri string) (source source, path string, err error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, "", err
+	}
+
+	scheme := u.Scheme
+
+	if scheme == "" {
+		scheme = defaultScheme
+	}
+
+	if s, ok := s.stores[scheme]; ok {
+		if u.Host != "" {
+			return s, u.Host + u.Path, nil
+		}
+
+		return s, u.Path, nil
+	}
+
+	return nil, "", fmt.Errorf("unknown source '%s'", scheme)
+}
+
+// Close closes all the underlying sources
+func (s *metaStore) Close() {
+	for _, source := range s.stores {
+		source.Close()
+	}
+}

--- a/etc/agent.yaml
+++ b/etc/agent.yaml
@@ -4,9 +4,6 @@
 # Default pipeline to run.
 # pipeline: docker
 
-# Number of seconds before polling configuration files for changes.
-# pollingInterval: 5
-
 # Whether to poll plugin configuration files for changes.
 # fileWatching: true
 
@@ -20,17 +17,16 @@
 # Metric ingest URL.
 # ingestURL: https://ingest.signalfx.com
 
+stores:
+    fs:
+        type: filesystem
+        # Number of seconds before polling configuration files for changes.
+        interval: 5
+
 plugins:
     file:
         plugin: observers/file
         path: /etc/signalfx/service_instances.json
-
-    local-docker:
-        plugin: observers/docker
-        url: unix:///var/run/docker.sock
-
-    mesosphere:
-        plugin: observers/mesosphere
 
     collectd:
         plugin: monitors/collectd
@@ -59,18 +55,6 @@ plugins:
         overrides: /etc/signalfx/overrides
 
 pipelines:
-    mesosphere:
-    - mesosphere
-    - integrations
-    - proxy
-    - collectd
-
-    docker:
-    - local-docker
-    - integrations
-    - proxy
-    - collectd
-
     file:
     - file
     - proxy

--- a/etc/docker-defaults.yml
+++ b/etc/docker-defaults.yml
@@ -1,0 +1,13 @@
+pipeline: docker
+
+plugins:
+    local-docker:
+        plugin: observers/docker
+        url: unix:///var/run/docker.sock
+
+pipelines:
+    docker:
+    - local-docker
+    - integrations
+    - proxy
+    - collectd

--- a/etc/mesosphere-defaults.yml
+++ b/etc/mesosphere-defaults.yml
@@ -1,0 +1,12 @@
+pipeline: mesosphere
+
+plugins:
+    mesosphere:
+        plugin: observers/mesosphere
+
+pipelines:
+    mesosphere:
+    - mesosphere
+    - integrations
+    - proxy
+    - collectd

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ca239a2daeef2d50c5d5980c00cc0931f8e2f9437c9342e5d963f98b58eceaba
-updated: 2017-04-12T16:53:39.251419125-04:00
+hash: dbd180b61bb1eab08905a4c10ace48654d8ef72a4f8f04dc90da37fc65acf06e
+updated: 2017-04-25T16:04:21.869528371-04:00
 imports:
 - name: github.com/blang/semver
   version: aea32c919a18e5ef4537bbd283ff29594b1b0165
@@ -52,6 +52,12 @@ imports:
   - tlsconfig
 - name: github.com/docker/go-units
   version: 0bbddae09c5a5419a8c6dcdd7ff90da3d450393b
+- name: github.com/docker/libkv
+  version: a9894d135ee6319a13e5388c5ef4acac56138175
+  repo: https://github.com/signalfx/libkv.git
+  subpackages:
+  - store
+  - store/zookeeper
 - name: github.com/emicklei/go-restful
   version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
@@ -178,6 +184,10 @@ imports:
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/rjeczalik/notify
   version: 41a86457b5eea072a7e6f40bbfaf94c8df41d3aa
+- name: github.com/samuel/go-zookeeper
+  version: 1d7be4effb13d2d908342d349d71a284a7542693
+  subpackages:
+  - zk
 - name: github.com/signalfx/cadvisor-integration
   version: 9ec4dcf2f98f9e35da31adb3b1bccaf368b02585
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,8 @@
 package: github.com/signalfx/neo-agent
 import:
+- package: github.com/docker/libkv
+  repo: https://github.com/signalfx/libkv.git
+  version: a9894d135ee6319a13e5388c5ef4acac56138175
 - package: github.com/docker/engine-api
   version: ~0.4.0
   subpackages:

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -6,10 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"time"
-
 	"github.com/signalfx/neo-agent/config"
-	"github.com/signalfx/neo-agent/watchers"
 	"github.com/spf13/viper"
 )
 
@@ -52,37 +49,37 @@ func (m *Manager) configureWatching(plugin IPlugin, pluginConfig *viper.Viper) {
 		return
 	}
 
-	duration := time.Duration(pollingInterval * float64(time.Second))
+	// duration := time.Duration(pollingInterval * float64(time.Second))
 
-	watchFiles := plugin.GetWatchFiles(pluginConfig)
-	watchDirs := plugin.GetWatchDirs(pluginConfig)
+	// watchFiles := plugin.GetWatchFiles(pluginConfig)
+	// watchDirs := plugin.GetWatchDirs(pluginConfig)
 
-	if watcher == nil && (len(watchFiles) > 0 || len(watchDirs) > 0) {
-		log.Printf("creating watcher for plugin %s", plugin.Name())
-		watcher = watchers.NewPollingWatcher(func(changed []string) error {
-			m.configLock.Lock()
-			defer m.configLock.Unlock()
+	// if watcher == nil && (len(watchFiles) > 0 || len(watchDirs) > 0) {
+	// 	log.Printf("creating watcher for plugin %s", plugin.Name())
+	// 	watcher = watchers.NewPollingWatcher(func(changed []string) error {
+	// 		m.configLock.Lock()
+	// 		defer m.configLock.Unlock()
 
-			log.Printf("%v changed for plugin %s", changed, plugin.Name())
-			if err := plugin.Reload(pluginConfig); err != nil {
-				log.Printf("error reloading plugin %s: %s", plugin.Name(), err)
-			}
-			return nil
-		}, duration)
-		plugin.SetWatcher(watcher)
-		watcher.Start()
+	// 		log.Printf("%v changed for plugin %s", changed, plugin.Name())
+	// 		if err := plugin.Reload(pluginConfig); err != nil {
+	// 			log.Printf("error reloading plugin %s: %s", plugin.Name(), err)
+	// 		}
+	// 		return nil
+	// 	}, duration)
+	// 	plugin.SetWatcher(watcher)
+	// 	watcher.Start()
 
-		// Need to reload plugin after starting watchers in case file changed
-		// between plugin creation and starting watcher. XXX: This might be
-		// better by having plugin constructors not initialize state but require
-		// that be done in Start().
-		if err := plugin.Reload(pluginConfig); err != nil {
-			log.Printf("failed to reload plugin %s post-watch: %s", plugin.Name(), err)
-		}
-	}
-	if watcher != nil {
-		watcher.Watch(watchDirs, watchFiles)
-	}
+	// 	// Need to reload plugin after starting watchers in case file changed
+	// 	// between plugin creation and starting watcher. XXX: This might be
+	// 	// better by having plugin constructors not initialize state but require
+	// 	// that be done in Start().
+	// 	if err := plugin.Reload(pluginConfig); err != nil {
+	// 		log.Printf("failed to reload plugin %s post-watch: %s", plugin.Name(), err)
+	// 	}
+	// }
+	// if watcher != nil {
+	// 	watcher.Watch(watchDirs, watchFiles)
+	// }
 }
 
 // Lock instance


### PR DESCRIPTION
This enables configuration to be loaded from any kind of "store". For now this
only includes the filesystem and zookeeper but any store libkv would be trivial
to add now. The store handles the loading of files as well as sending change
notifications.

There are still a number of TODOs to clean up but it seems to basically work.

Also there's more work to be done for plugins to be able to use the new store
infrastructure. This is just for config files.