### PR TITLE
Implement asset loading for plugins from stores

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -184,7 +184,7 @@ func load(path string, reload chan<- struct{}, cb func(pair *store.KVPair) error
 	return fmt.Errorf("failed ensuring %s exists", path)
 
 Success:
-	ch, err := reconnectWatch(source, path, nil)
+	ch, err := ReconnectWatch(source, path, nil)
 
 	if err != nil {
 		return err

--- a/etc/mesosphere-agent-defaults.yml
+++ b/etc/mesosphere-agent-defaults.yml
@@ -9,6 +9,9 @@ plugins:
             mesos:
                 plugin: mesos-agent
 
+    integrations:
+        overrides: zk://signalfx/agent/integrations
+
 pipelines:
     mesosphere:
     - mesosphere

--- a/plugins/monitors/collectd/collectd.go
+++ b/plugins/monitors/collectd/collectd.go
@@ -62,16 +62,11 @@ func NewCollectd(name string, config *viper.Viper) (plugins.IPlugin, error) {
 	if err != nil {
 		return nil, err
 	}
-	c := &Collectd{
+	return &Collectd{
 		Plugin:     plugin,
 		state:      Stopped,
 		reloadChan: make(chan int),
-		stopChan:   make(chan int)}
-	if err := c.load(plugin.Config); err != nil {
-		return nil, err
-	}
-
-	return c, nil
+		stopChan:   make(chan int)}, nil
 }
 
 // load collectd plugin config from the provided config
@@ -325,8 +320,8 @@ func (collectd *Collectd) Stop() {
 	}
 }
 
-// Reload collectd config
-func (collectd *Collectd) Reload(config *viper.Viper) error {
+// Configure collectd config
+func (collectd *Collectd) Configure(config *viper.Viper) error {
 	collectd.configMutex.Lock()
 	defer collectd.configMutex.Unlock()
 

--- a/plugins/observers/docker/docker.go
+++ b/plugins/observers/docker/docker.go
@@ -37,16 +37,11 @@ func NewDocker(name string, config *viper.Viper) (plugins.IPlugin, error) {
 		return nil, err
 	}
 
-	docker := &Docker{plugin, nil}
-	if err := docker.load(); err != nil {
-		return nil, err
-	}
-
-	return docker, nil
+	return &Docker{plugin, nil}, nil
 }
 
-// Reload the docker client
-func (docker *Docker) Reload(config *viper.Viper) error {
+// Configure the docker client
+func (docker *Docker) Configure(config *viper.Viper) error {
 	docker.Config = config
 	return docker.load()
 }

--- a/plugins/observers/kubernetes/kubernetes.go
+++ b/plugins/observers/kubernetes/kubernetes.go
@@ -38,7 +38,7 @@ const (
 type Kubernetes struct {
 	plugins.Plugin
 	hostURL string
-	client http.Client
+	client  http.Client
 }
 
 // pod structure from kubelet
@@ -84,16 +84,11 @@ func NewKubernetes(name string, config *viper.Viper) (plugins.IPlugin, error) {
 		return nil, err
 	}
 
-	k := &Kubernetes{plugin, "", http.Client{}}
-	if err := k.load(); err != nil {
-		return nil, err
-	}
-
-	return k, nil
+	return &Kubernetes{plugin, "", http.Client{}}, nil
 }
 
-// Reload the kubernetes observer/client
-func (k *Kubernetes) Reload(config *viper.Viper) error {
+// Configure the kubernetes observer/client
+func (k *Kubernetes) Configure(config *viper.Viper) error {
 	k.Config = config
 	return k.load()
 }

--- a/plugins/observers/mesosphere/mesosphere.go
+++ b/plugins/observers/mesosphere/mesosphere.go
@@ -94,16 +94,11 @@ func NewMesosphere(name string, config *viper.Viper) (plugins.IPlugin, error) {
 		return nil, err
 	}
 
-	m := &Mesosphere{plugin, "", http.Client{}}
-	if err := m.load(); err != nil {
-		return nil, err
-	}
-
-	return m, nil
+	return &Mesosphere{plugin, "", http.Client{}}, nil
 }
 
-// Reload the mesosphere observer/client
-func (mesos *Mesosphere) Reload(config *viper.Viper) error {
+// Configure the mesosphere observer/client
+func (mesos *Mesosphere) Configure(config *viper.Viper) error {
 	mesos.Config = config
 	return mesos.load()
 }

--- a/plugins/plugin.go
+++ b/plugins/plugin.go
@@ -3,7 +3,6 @@ package plugins
 import (
 	"errors"
 
-	"github.com/signalfx/neo-agent/watchers"
 	"github.com/spf13/viper"
 )
 
@@ -17,7 +16,6 @@ var Plugins = map[string]CreatePlugin{}
 type Plugin struct {
 	name       string
 	pluginType string
-	watcher    *watchers.PollingWatcher
 	Config     *viper.Viper
 }
 
@@ -26,13 +24,9 @@ type IPlugin interface {
 	Name() string
 	Start() error
 	Stop()
-	Reload(config *viper.Viper) error
+	Configure(config *viper.Viper) error
 	String() string
 	Type() string
-	Watcher() *watchers.PollingWatcher
-	SetWatcher(*watchers.PollingWatcher)
-	GetWatchFiles(config *viper.Viper) []string
-	GetWatchDirs(config *viper.Viper) []string
 }
 
 // NewPlugin constructor
@@ -67,40 +61,9 @@ func (plugin *Plugin) Type() string {
 	return plugin.pluginType
 }
 
-// Reload replaces the config with the newly loaded conifg. Plugins that need to
-// do anything special should implement their own reload.
-func (plugin *Plugin) Reload(config *viper.Viper) error {
-	// Need to be careful about when this Reload function gets called so as to
-	// avoid any data race issues with plugins. Right now reload is called
-	// before an execution is run so most plugins won't have any code running in
-	// other goroutines. If they do they should take care to synchronize the
-	// config replacement.
-	plugin.Config = config
+// Configure configures the plugin on start and reload
+func (plugin *Plugin) Configure(c *viper.Viper) error {
 	return nil
-}
-
-// GetWatchFiles returns list of files that when changed will trigger reload.
-// This will be called *before* a plugin is reloaded with the new configuration
-// values that may contain a different set of files to watch.
-func (plugin *Plugin) GetWatchFiles(config *viper.Viper) []string {
-	return nil
-}
-
-// GetWatchDirs returns list of directories that when changed will trigger
-// reload. This will be called *before* a plugin is reloaded with the new
-// configuration values that may contain a different set of files to watch.
-func (plugin *Plugin) GetWatchDirs(config *viper.Viper) []string {
-	return nil
-}
-
-// Watcher returns the watcher instance
-func (plugin *Plugin) Watcher() *watchers.PollingWatcher {
-	return plugin.watcher
-}
-
-// SetWatcher sets watcher instance
-func (plugin *Plugin) SetWatcher(watcher *watchers.PollingWatcher) {
-	plugin.watcher = watcher
 }
 
 // Register registers a plugin


### PR DESCRIPTION
Adds directory-based asset loading for plugins. Instead of having it managed by
the manager each plugin that needs assets will have to create its own
AssetSyncer. The AssetSyncer is there to keep track of multiple sources and
merges it into one view so the plugin doesn't have to worry about tracking
multiple watches itself.

Also restructures plugin interface a bit. Reload() is gone and replaced with
Configure(). Configure() is called on what used to be reload as well as after
start. This is so there doesn't have to be two different load paths.