### PR TITLE
Outputting version line in usage output

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -91,13 +91,24 @@ func main() {
 	var version = flag.Bool("version", false, "print agent version")
 	var noWatch = flag.Bool("no-watch", false, "disable watch for changes")
 
+	versionLine := fmt.Sprintf("agent-version: %s, collectd-version: %s, built-time: %s\n",
+	                           Version, CollectdVersion, BuiltTime)
+
+	// Override Usage to support the signalfx-metadata plugin, which expects a
+	// line with the collectd version from the -h flag.
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(os.Stderr, versionLine)
+	}
+
 	flag.Parse()
 
 	watch := !*noWatch
 	viper.SetDefault("filewatching", watch)
 
 	if *version {
-		fmt.Printf("agent-version: %s, collectd-version: %s, built-time: %s\n", Version, CollectdVersion, BuiltTime)
+		fmt.Printf(versionLine)
 		os.Exit(0)
 	}
 

--- a/scripts/agent-image/Dockerfile
+++ b/scripts/agent-image/Dockerfile
@@ -7,23 +7,25 @@ ENV LD_LIBRARY_PATH /usr/lib:/usr/lib/collectd:/usr/lib/jvm/java-8-openjdk-amd64
 
 RUN sed -i -e '/^deb-src/d' /etc/apt/sources.list \
     && apt-get update \
-    && apt-get install -y software-properties-common \
-    && apt-get install -y python-software-properties \
-    && apt-get install -y dpkg \
-    && apt-get install -y curl \
-    && apt-get install -y libcurl4-gnutls-dev \
+    && apt-get install -y \
+      software-properties-common \
+      python-software-properties \
+      curl \
+      libcurl4-gnutls-dev \
+      wget \
+      net-tools \
+      libpython2.7 \
+      libmysqlclient-dev \
+      python-pip \
     && apt-get install -y libcurl4-openssl-dev \
-    && apt-get install -y wget \
-    && apt-get install -y net-tools \
-    && apt-get install -y libpython2.7 \
-    && apt-get install -y libmysqlclient-dev \
-    && apt-get install -y python-pip \
     && add-apt-repository -y ppa:signalfx/collectd-release \
     && add-apt-repository -y ppa:signalfx/collectd-plugin-release \
     && apt-get update \
     && apt-get install -y --no-install-recommends collectd \
-    && apt-get install -y signalfx-collectd-plugin \
-    && apt-get install -y openjdk-8-jre-headless
+    && apt-get install -y \
+        signalfx-collectd-plugin \
+        openjdk-8-jre-headless \
+        vim  # Get a text editor on there for easier debug
 
 LABEL agent.version="$signalfx_agent_version" \
       app="signalfx-agent"


### PR DESCRIPTION
This is to ensure compatibility with the changes to the metadata plugin (see
https://github.com/signalfx/signalfx-collectd-plugin/pull/53).

Also consolidating apt installs and installing vim for easier debugging inside
container