### PR TITLE
Mysql fix

### DIFF
--- a/etc/integrations/mysql.yml
+++ b/etc/integrations/mysql.yml
@@ -9,9 +9,14 @@ integrations:
       Databases:
       # - exampledatabase123 # specify the name of a database to monitor
       # - exampledatabase321 # specify the name of a database to monitor
+
+      # This option indicates whether to report the hostname (pod ip) of the mysql container as host, 
+      # or to not report it and use the hostname discovered by collectd
+      ReportHost: false
     template: |
       {{range $database := .Vars.Databases}}
       <Database "{{$.Name}}[{{$.Dims}}]">
+        ReportHost "{{$.Vars.ReportHost}}"
         Host "{{$.Host}}"
         Port {{$.Port}}
         User "{{$.Vars.Username}}"

--- a/scripts/agent-image/Dockerfile
+++ b/scripts/agent-image/Dockerfile
@@ -94,7 +94,7 @@ RUN mkdir -p /usr/share/collectd/mongodb-collectd-plugin \
     && pip install pymongo==${PYMONGO_V}
 
 # collectd-rabbitmq
-ENV RABBITMQ_COLLECTD_PLUGIN_V=1.0.0
+ENV RABBITMQ_COLLECTD_PLUGIN_V=1.0.1
 RUN mkdir -p /usr/share/collectd/rabbitmq-collectd-plugin \
     && curl -L "https://github.com/signalfx/collectd-rabbitmq/archive/v${RABBITMQ_COLLECTD_PLUGIN_V}.tar.gz" --output /usr/share/collectd/rabbitmq-collectd-plugin/v${RABBITMQ_COLLECTD_PLUGIN_V}.tar.gz \
     && tar -zxvf /usr/share/collectd/rabbitmq-collectd-plugin/v${RABBITMQ_COLLECTD_PLUGIN_V}.tar.gz -C /usr/share/collectd/rabbitmq-collectd-plugin/ \
@@ -130,6 +130,7 @@ COPY etc /etc/signalfx/
 COPY agent /usr/sbin/signalfx-agent
 COPY libcollectd.so /usr/local/lib/collectd/libcollectd.so
 COPY java.so /usr/lib/collectd/java.so
+COPY mysql.so /usr/lib/collectd/mysql.so
 COPY nginx.so /usr/lib/collectd/nginx.so
 COPY python.so /usr/lib/collectd/python.so
 COPY aggregation.so /usr/lib/collectd/aggregation.so

--- a/scripts/build-collectd.sh
+++ b/scripts/build-collectd.sh
@@ -58,6 +58,7 @@ cd ${COLLECTD_LIB_DIR}
 
 $SUDO gcc -shared -o libcollectd.so collectd-collectd.o collectd-meta_data.o collectd-utils_cache.o collectd-utils_llist.o collectd-utils_threshold.o collectd-configfile.o collectd-plugin.o collectd-utils_complain.o collectd-utils_random.o collectd-utils_time.o utils_avltree.o collectd-filter_chain.o collectd-types_list.o collectd-utils_ignorelist.o collectd-utils_subst.o common.o utils_heap.o oconfig.o parser.o scanner.o -ldl -lltdl -lpthread -lm
 $SUDO cp ${BASE_DIR}/collectd-collectd-${COLLECTD_VERSION}/src/.libs/java.so ${COLLECTD_LIB_DIR}
+$SUDO cp ${BASE_DIR}/collectd-collectd-${COLLECTD_VERSION}/src/.libs/mysql.so ${COLLECTD_LIB_DIR}
 $SUDO cp ${BASE_DIR}/collectd-collectd-${COLLECTD_VERSION}/src/.libs/nginx.so ${COLLECTD_LIB_DIR}
 $SUDO cp ${BASE_DIR}/collectd-collectd-${COLLECTD_VERSION}/src/.libs/python.so ${COLLECTD_LIB_DIR}
 $SUDO cp ${BASE_DIR}/collectd-collectd-${COLLECTD_VERSION}/src/.libs/aggregation.so ${COLLECTD_LIB_DIR}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -55,7 +55,7 @@ cp -r ${GO_PACKAGES[@]} ${BUILDER_IMAGE_ROOT}/src
 mkdir -p ${AGENT_IMAGE_ROOT}
 # Copy collectd and Go agent binaries into the agent-image staging directory.
 docker run --rm -v ${SRC_ROOT}/${AGENT_IMAGE_ROOT}:/opt/build ${BUILDER_IMAGE_NAME}:${TAG} \
-    bash -c "cp /usr/local/lib/collectd/{libcollectd,java,nginx,python,aggregation}.so /usr/local/lib/collectd/generic-jmx.jar /opt/go/bin/agent /opt/build"
+    bash -c "cp /usr/local/lib/collectd/{libcollectd,java,mysql,nginx,python,aggregation}.so /usr/local/lib/collectd/generic-jmx.jar /opt/go/bin/agent /opt/build"
 
 cp ${PROJECT_DIR}/scripts/agent-image/* ${AGENT_IMAGE_ROOT}
 cp -r etc ${AGENT_IMAGE_ROOT}


### PR DESCRIPTION
* modify mysql plugin to accept configuration "ReportHost"
  * To view the actual changes to the mysql plugin please view the last commit.
  * the default value in the plugin is `true` (the existing behavior)
  * the default configuration is `false` because in neo-agent we want the hostname identified by collectd to be reported.  Not the the pod ip of the mysql container.

* Upgrade the rabbitmq plugin to the latest version