### PR TITLE
Tweaking Plugin Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /vendor
 test-build
 build/
+local-etc/
+/agent

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -54,7 +54,7 @@ func (agent *Agent) Configure() error {
 		return err
 	}
 
-	pluginList, err := agent.plugins.Load()
+	plugins, err := agent.plugins.Load()
 	if err == nil {
 		// Reset pipeline which has a reference to the current plugin set.
 		log.Println("resetting pipeline")
@@ -77,7 +77,7 @@ func (agent *Agent) Configure() error {
 		return fmt.Errorf("%s pipeline is missing or empty", pipelineName)
 	}
 
-	agent.pipeline, err = pipelines.NewPipeline(pipelineName, pipelineConfig, pluginList)
+	agent.pipeline, err = pipelines.NewPipeline(pipelineName, pipelineConfig, plugins)
 	if err != nil {
 		return fmt.Errorf("failed creating pipeline: %s", err)
 	}
@@ -168,7 +168,7 @@ func main() {
 					log.Printf("error reconfiguring agent: %s", err)
 				}
 			case <-ctx.Done():
-				agent.plugins.Stop()
+				agent.plugins.Shutdown()
 				exitCh <- struct{}{}
 				return
 			case <-ticker.C:

--- a/plugins/filters/debug/debug.go
+++ b/plugins/filters/debug/debug.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/signalfx/neo-agent/plugins"
 	"github.com/signalfx/neo-agent/services"
-	"github.com/spf13/viper"
 )
 
 const (
@@ -14,22 +13,10 @@ const (
 )
 
 // Filter prints the input and passes
-type Filter struct {
-	plugins.Plugin
-}
+type Filter struct {}
 
 func init() {
-	plugins.Register(pluginType, NewFilter)
-}
-
-// NewFilter creates a new instance
-func NewFilter(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, pluginType, config)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Filter{plugin}, nil
+	plugins.Register(pluginType, func() interface{} { return &Filter{} })
 }
 
 // Map prints the input

--- a/plugins/monitors/kubernetes/plugin.go
+++ b/plugins/monitors/kubernetes/plugin.go
@@ -46,7 +46,6 @@ import (
 // Plugin makes a distinction between the plugin and the monitor
 // itself for less coupling to neo-agent in case we split it out at some point
 type Plugin struct {
-	plugins.Plugin
 	monitor *Kubernetes
 	lock    sync.Mutex
 }
@@ -56,28 +55,7 @@ const (
 )
 
 func init() {
-	plugins.Register(pluginType, NewPlugin)
-}
-
-// NewPlugin makes a new instance of the plugin
-func NewPlugin(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, pluginType, config)
-	if err != nil {
-		return nil, err
-	}
-
-	kmp := &Plugin{
-		Plugin:  plugin,
-		monitor: nil, // This gets set in Configure
-	}
-
-	err = kmp.Configure(config)
-	if err != nil {
-		log.Printf("k8sMonitor: %v", err)
-		return nil, err
-	}
-	log.Println("FLAG: k8sMonitor: NewPlugin() complete")
-	return kmp, nil
+	plugins.Register(pluginType, func() interface{} { return &Plugin{} })
 }
 
 // This can take configuration if needed for other types of auth
@@ -137,12 +115,11 @@ func (kmp *Plugin) Configure(config *viper.Viper) error {
 	defer kmp.lock.Unlock()
 	if kmp.monitor != nil {
 		// lock on configure
-		kmp.Stop()
+		kmp.Shutdown()
 	}
 
-	kmp.Config = config
-	kmp.Config.SetDefault("alwaysClusterReporter", false)
-	kmp.Config.SetDefault("intervalSeconds", 10)
+	config.SetDefault("alwaysClusterReporter", false)
+	config.SetDefault("intervalSeconds", 10)
 
 	k8sClient, err := makeK8sClient(config)
 	if err != nil {
@@ -201,14 +178,9 @@ func (kmp *Plugin) Configure(config *viper.Viper) error {
 	return nil
 }
 
-// Stop halts everything that is syncing
-func (kmp *Plugin) Stop() {
+// Shutdown halts everything that is syncing
+func (kmp *Plugin) Shutdown() {
 	if kmp.monitor != nil {
 		kmp.monitor.Stop()
 	}
-}
-
-// Start begins the data collection
-func (kmp *Plugin) Start() error {
-	return nil
 }

--- a/plugins/observers/file/file.go
+++ b/plugins/observers/file/file.go
@@ -18,22 +18,19 @@ const (
 
 // File observer plugin
 type File struct {
-	plugins.Plugin
 	path string
 }
 
 func init() {
-	plugins.Register(pluginType, NewFile)
+	plugins.Register(pluginType, func() interface{} { return &File{} })
 }
 
-// NewFile constructor
-func NewFile(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, pluginType, config)
-	if err != nil {
-		return nil, err
-	}
-	config.SetDefault("path", "/etc/signalfx/service_instances.json");
-	return &File{plugin, config.GetString("path")}, nil
+// Configure callback
+func (file *File) Configure(config *viper.Viper) error {
+	config.SetDefault("path", "/etc/signalfx/service_instances.json")
+	file.path = config.GetString("path")
+
+	return nil
 }
 
 // Discover services from a file

--- a/plugins/observers/kubernetes/kubernetes_test.go
+++ b/plugins/observers/kubernetes/kubernetes_test.go
@@ -1,8 +1,10 @@
 package kubernetes
 
 import (
+	"fmt"
 	"io/ioutil"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,11 +72,11 @@ func TestKubernetes_doMap(t *testing.T) {
 
 	config := viper.New()
 	config.Set("hosturl", "unused")
-	k, err := NewKubernetes("kubernetes", config)
-	if err != nil {
-		t.Fatal(err)
+	kub := plugins.MakePlugin(pluginType).(*Kubernetes)
+
+	for i := range expected {
+		expected[i].ID = strings.Replace(expected[i].ID, "POINTER", fmt.Sprintf("%p", kub), 1)
 	}
-	kub := k.(*Kubernetes)
 
 	type fields struct {
 		Plugin  plugins.Plugin

--- a/plugins/observers/kubernetes/testdata/2-discovered.json
+++ b/plugins/observers/kubernetes/testdata/2-discovered.json
@@ -1,6 +1,6 @@
 [
   {
-    "ID": "kubernetes-kubernetes-dashboard-v1.5.1-5zg3f-9090",
+    "ID": "POINTER-kubernetes-dashboard-v1.5.1-5zg3f-9090",
     "Service": {
       "Name": "kubernetes-dashboard-v1.5.1-5zg3f",
       "Type": ""
@@ -43,7 +43,7 @@
     "Discovered": "2016-01-05T15:04:05-06:00"
   },
   {
-    "ID": "kubernetes-redis-3165242388-n1vc7-6379",
+    "ID": "POINTER-redis-3165242388-n1vc7-6379",
     "Service": {
       "Name": "redis-3165242388-n1vc7",
       "Type": ""

--- a/plugins/observers/mesosphere/mesosphere.go
+++ b/plugins/observers/mesosphere/mesosphere.go
@@ -27,7 +27,7 @@ const (
 
 // Mesosphere observer plugin
 type Mesosphere struct {
-	plugins.Plugin
+	config  *viper.Viper
 	hostURL string
 	client  http.Client
 }
@@ -84,31 +84,21 @@ type tasks struct {
 }
 
 func init() {
-	plugins.Register(pluginType, NewMesosphere)
-}
-
-// NewMesosphere observer
-func NewMesosphere(name string, config *viper.Viper) (plugins.IPlugin, error) {
-	plugin, err := plugins.NewPlugin(name, pluginType, config)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Mesosphere{plugin, "", http.Client{}}, nil
+	plugins.Register(pluginType, func() interface{} { return &Mesosphere{} })
 }
 
 // Configure the mesosphere observer/client
 func (mesos *Mesosphere) Configure(config *viper.Viper) error {
-	mesos.Config = config
+	mesos.config = config
 	return mesos.load()
 }
 
 func (mesos *Mesosphere) load() error {
 	if hostname, err := os.Hostname(); err == nil {
-		mesos.Config.SetDefault("hosturl", fmt.Sprintf("http://%s:%d", hostname, DefaultPort))
+		mesos.config.SetDefault("hosturl", fmt.Sprintf("http://%s:%d", hostname, DefaultPort))
 	}
 
-	hostURL := mesos.Config.GetString("hosturl")
+	hostURL := mesos.config.GetString("hosturl")
 	if len(hostURL) == 0 {
 		return errors.New("hostURL config value missing")
 	}


### PR DESCRIPTION
Wrapping plugin instance instead of using embedded types.  This gives more
flexibility in how we create plugins and reduces plugin coupling to the agent.

Removing the `Start` method on plugin interface.  This was unnecessary and
mostly unused.  Any startup work should be done in either the factory function
or Configure.

Simplifying the plugin factory function to be a simple no-arg builder that
returns `interface{}`.  Passing the config into the factory was unnecessary
and confusing since there is a Configure method made for that.