### PR TITLE
Looking up FQDN at startup and propagating to plugins

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 
 	"sync"
 
+	"github.com/ShowMax/go-fqdn"
 	"github.com/docker/libkv/store"
 	"github.com/signalfx/neo-agent/config/userconfig"
 	"github.com/spf13/viper"
@@ -255,6 +256,14 @@ func Init(configfile string, reload chan<- struct{}, mutex *sync.Mutex) error {
 	viper.SetDefault("pipeline", DefaultPipeline)
 	viper.SetDefault("pollingInterval", DefaultPollingInterval)
 	viper.SetDefault("ingesturl", "https://ingest.signalfx.com")
+
+	fqdn := fqdn.Get()
+	if fqdn == "unknown" {
+		log.Printf("Error getting hostname")
+	} else {
+		log.Printf("Using hostname '%s'", fqdn)
+		viper.SetDefault("hostname", fqdn)
+	}
 
 	viper.AutomaticEnv()
 	viper.SetEnvKeyReplacer(EnvReplacer)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3b042115ce4c7ca8b7dfac86b010696cdd8961f1bf180d73abd6b45eea334884
-updated: 2017-07-11T13:49:24.580027927-04:00
+hash: d35b58d1ffe072bb414f027db97af4611713acd4e33972b19f0d61d8e728229c
+updated: 2017-07-19T09:00:08.514615446-04:00
 imports:
 - name: github.com/blang/semver
   version: aea32c919a18e5ef4537bbd283ff29594b1b0165
@@ -205,6 +205,8 @@ imports:
   version: 1d7be4effb13d2d908342d349d71a284a7542693
   subpackages:
   - zk
+- name: github.com/ShowMax/go-fqdn
+  version: 2501cdd51ef4c60dd727c58b2199e1a09466b10f
 - name: github.com/signalfx/com_signalfx_metrics_protobuf
   version: 1477d7f5730360be99fcaf7e7d7c56e03be2eabc
 - name: github.com/signalfx/gohistogram

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,6 +35,7 @@ import:
   version: v2.0.0
 - package: github.com/onsi/ginkgo
   version: ~1.3.1
+- package: github.com/ShowMax/go-fqdn
 testImport:
 - package: github.com/kr/pretty
 - package: github.com/smartystreets/goconvey

--- a/plugins/monitors/cadvisor/cadvisor.go
+++ b/plugins/monitors/cadvisor/cadvisor.go
@@ -131,6 +131,7 @@ func (c *Cadvisor) Configure(config *viper.Viper) error {
 		return err
 	}
 
+	hostname := viper.GetString("hostname")
 	ingestURL := viper.GetString("ingesturl")
 	if ingestURL == "" {
 		return errors.New("ingestURL cannot be empty")
@@ -146,8 +147,10 @@ func (c *Cadvisor) Configure(config *viper.Viper) error {
 		return errors.New("cadvisorURL cannot be empty")
 	}
 
-	dimensions := viper.GetStringMapString("dimensions")
+	dimensions := utils.CloneStringMap(viper.GetStringMapString("dimensions"))
 	clusterName := dimensions["kubernetes_cluster"]
+	dimensions["host"] = hostname
+
 	forwarder := poller.NewSfxClient(ingestURL, apiToken)
 	cfg := &poller.Config{
 		IngestURL:              ingestURL,


### PR DESCRIPTION
This should fix an issue where some plugins are using a short hostname and
others (e.g. collectd) are using the FQDN.