### PR TITLE
Adding processes monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ monitors/collectd/collectd.conf.go
 scripts/.Dockerfile*
 .glide/
 *.pyc
+/collectd

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,19 +74,18 @@ RUN sed -i -e '/^deb-src/d' /etc/apt/sources.list &&\
 
 RUN apt install -y libcurl4-gnutls-dev
 
-COPY VERSIONS .
+COPY VERSIONS /tmp
 # TODO: once neoagent-changes branch in collectd gets merged, change "collectd_file_base"
 # below to "$(./VERSIONS collectd_version)" and remove the former build arg.
-ARG collectd_file_base=neoagent-changes
 RUN cd /tmp &&\
-    wget https://github.com/signalfx/collectd/archive/${collectd_file_base}.tar.gz &&\
-	tar -xvf ${collectd_file_base}.tar.gz &&\
+    wget https://github.com/signalfx/collectd/archive/`./VERSIONS collectd_commit`.tar.gz &&\
+	tar -xvf `./VERSIONS collectd_commit`.tar.gz &&\
 	mkdir -p /usr/src/ &&\
-	mv collectd-${collectd_file_base}* /usr/src/collectd
+	mv collectd-`./VERSIONS collectd_commit`* /usr/src/collectd
 
 # Hack to get our custom version compiled into collectd
 RUN echo "#!/bin/bash" > /usr/src/collectd/version-gen.sh &&\
-    echo "collectd_version=$(./VERSIONS collectd_version)" >> /usr/src/collectd/version-gen.sh &&\
+    echo "collectd_version=$(/tmp/VERSIONS collectd_version)" >> /usr/src/collectd/version-gen.sh &&\
     echo "printf \${collectd_version//-/.}" >> /usr/src/collectd/version-gen.sh
 
 WORKDIR /usr/src/collectd

--- a/VERSIONS
+++ b/VERSIONS
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+collectd_commit="245be19b7026358921e3995e48d9306b9674ccc7"
 collectd_version="5.7.2-sfx0"
 agent_version="2.1.0"
 

--- a/core/modules.go
+++ b/core/modules.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/signalfx/neo-agent/monitors/collectd/mongodb"
 	_ "github.com/signalfx/neo-agent/monitors/collectd/mysql"
 	_ "github.com/signalfx/neo-agent/monitors/collectd/nginx"
+	_ "github.com/signalfx/neo-agent/monitors/collectd/processes"
 	_ "github.com/signalfx/neo-agent/monitors/collectd/rabbitmq"
 	_ "github.com/signalfx/neo-agent/monitors/collectd/redis"
 	_ "github.com/signalfx/neo-agent/monitors/collectd/spark"

--- a/monitors/collectd/processes/processes.go
+++ b/monitors/collectd/processes/processes.go
@@ -1,0 +1,49 @@
+package processes
+
+//go:generate collectd-template-to-go processes.tmpl
+
+import (
+	"github.com/signalfx/neo-agent/core/config"
+	"github.com/signalfx/neo-agent/monitors"
+	"github.com/signalfx/neo-agent/monitors/collectd"
+)
+
+const monitorType = "collectd/processes"
+
+func init() {
+	monitors.Register(monitorType, func() interface{} {
+		return &Monitor{
+			*collectd.NewStaticMonitorCore(CollectdTemplate),
+		}
+	}, &Config{})
+}
+
+// Config is the monitor-specific config with the generic config embedded
+type Config struct {
+	config.MonitorConfig
+	Processes            []string          `yaml:"processes"`
+	ProcessMatch         map[string]string `yaml:"processMatch"`
+	CollectContextSwitch bool              `yaml:"collectContextSwitch" default:"false"`
+	ProcFSPath           string            `yaml:"procFSPath"`
+}
+
+// Validate will check the config for correctness.
+func (c *Config) Validate() error {
+	return nil
+}
+
+// Monitor is the main type that represents the monitor
+type Monitor struct {
+	collectd.StaticMonitorCore
+}
+
+// Configure configures and runs the plugin in collectd
+func (am *Monitor) Configure(conf *Config) bool {
+	// ProcFSPath is a global config setting that gets propagated to each
+	// monitor config, but allow overriding it if desired.
+	if conf.ProcFSPath == "" {
+		conf.ProcFSPath = conf.MonitorConfig.ProcFSPath
+	}
+
+	return am.SetConfigurationAndRun(conf)
+}

--- a/monitors/collectd/processes/processes.tmpl
+++ b/monitors/collectd/processes/processes.tmpl
@@ -1,0 +1,13 @@
+<LoadPlugin "processes">
+  Interval {{.C.IntervalSeconds}}
+</LoadPlugin>
+<Plugin processes>
+  {{range .C.Processes -}}
+  Process "{{.}}"
+  {{end}}
+  {{range $name, $regex := .C.ProcessMatch -}}
+  ProcessMatch "{{$name}}" "{{$regex}}"
+  {{end}}
+  CollectContextSwitch {{.C.CollectContextSwitch}}
+  ProcFSPath "{{.C.ProcFSPath}}"
+</Plugin>

--- a/scripts/make-dev-image
+++ b/scripts/make-dev-image
@@ -35,7 +35,14 @@ RUN cp /tmp/usr-godeps/bin/jq /tmp/usr-godeps/bin/glide /usr/bin/
 
 RUN pip install ipython==5 ipdb
 
-RUN apt install -y libzmq5-dev
+RUN apt update &&\
+    apt install -y \
+      libzmq5-dev \
+      autoconf \
+      automake \
+      autotools-dev \
+      bison \
+      build-essential
 
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin GOPATH=/go
 


### PR DESCRIPTION
This is dependent on the corresponding change in collectd to enable custom procfs paths

Also making build use collectd commit hash instead of branch to bust docker image
cache more easily.

https://github.com/signalfx/collectd/pull/17