### PR TITLE
Removing duplicated key in collectd/etcd

### DIFF
--- a/docs/monitors/collectd-etcd.md
+++ b/docs/monitors/collectd-etcd.md
@@ -23,14 +23,12 @@ Monitor Type: `collectd/etcd`
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
 | `name` | no | `string` |  |
-| `clusterName` | no | `string` |  |
+| `clusterName` | **yes** | `string` | An arbitrary name of the etcd cluster to make it easier to group together and identify instances. |
 | `sslKeyFile` | no | `string` |  |
 | `sslCertificate` | no | `string` |  |
 | `sslCACerts` | no | `string` |  |
-| `sslCertValidation` | no | `bool` |  (**default:** `true`) |
+| `skipSSLValidation` | no | `bool` |  (**default:** `false`) |
 | `enhancedMetrics` | no | `bool` |  (**default:** `false`) |
-| `metricsToInclude` | no | `list of string` |  |
-| `metricsToExclude` | no | `list of string` |  |
 
 
 

--- a/internal/monitors/collectd/etcd/etcd.go
+++ b/internal/monitors/collectd/etcd/etcd.go
@@ -3,7 +3,6 @@ package etcd
 //go:generate collectd-template-to-go etcd.tmpl
 
 import (
-	"github.com/pkg/errors"
 	"github.com/signalfx/signalfx-agent/internal/core/config"
 	"github.com/signalfx/signalfx-agent/internal/monitors"
 	"github.com/signalfx/signalfx-agent/internal/monitors/collectd"
@@ -28,25 +27,17 @@ func init() {
 type Config struct {
 	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
 
-	Host              string   `yaml:"host" validate:"required"`
-	Port              uint16   `yaml:"port" validate:"required"`
-	Name              string   `yaml:"name"`
-	ClusterName       string   `yaml:"clusterName" required:"true"`
-	SSLKeyFile        string   `yaml:"sslKeyFile"`
-	SSLCertificate    string   `yaml:"sslCertificate"`
-	SSLCACerts        string   `yaml:"sslCACerts"`
-	SSLCertValidation bool     `yaml:"sslCertValidation" default:"true"`
-	EnhancedMetrics   bool     `yaml:"enhancedMetrics"`
-	MetricsToInclude  []string `yaml:"metricsToInclude"`
-	MetricsToExclude  []string `yaml:"metricsToExclude"`
-}
-
-// Validate will check the config before the monitor is instantiated
-func (c *Config) Validate() error {
-	if c.ClusterName == "" {
-		return errors.New("Etcd monitor config requires a clusterName")
-	}
-	return nil
+	Host string `yaml:"host" validate:"required"`
+	Port uint16 `yaml:"port" validate:"required"`
+	Name string `yaml:"name"`
+	// An arbitrary name of the etcd cluster to make it easier to group
+	// together and identify instances.
+	ClusterName       string `yaml:"clusterName" validate:"required"`
+	SSLKeyFile        string `yaml:"sslKeyFile"`
+	SSLCertificate    string `yaml:"sslCertificate"`
+	SSLCACerts        string `yaml:"sslCACerts"`
+	SkipSSLValidation bool   `yaml:"skipSSLValidation"`
+	EnhancedMetrics   bool   `yaml:"enhancedMetrics"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/internal/monitors/collectd/etcd/etcd.tmpl
+++ b/internal/monitors/collectd/etcd/etcd.tmpl
@@ -19,13 +19,7 @@ LoadPlugin python
     {{with .SSLCACerts -}}
     ssl_ca_certs "{{.}}"
     {{- end}}
-    ssl_cert_validation {{if .SSLCertValidation}}"True"{{else}}"False"{{end}}
+    ssl_cert_validation {{if .SkipSSLValidation}}"False"{{else}}"True"{{end}}
     EnhancedMetrics {{if .EnhancedMetrics}}"True"{{else}}"False"{{end}}
-    {{range .MetricsToInclude}}
-    IncludeMetric "{{.}}"
-    {{end}}
-    {{range .MetricsToExclude}}
-    ExcludeMetric "{{.}}"
-    {{end}}
   </Module>
 </Plugin>

--- a/tests/monitors/etcd_test.py
+++ b/tests/monitors/etcd_test.py
@@ -1,0 +1,26 @@
+from functools import partial as p
+import os
+import string
+
+from tests.helpers import fake_backend
+from tests.helpers.util import wait_for, run_agent, run_container
+from tests.helpers.assertions import *
+
+
+ETCD_COMMAND="-listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -advertise-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001"
+
+etcd_config = string.Template("""
+monitors:
+  - type: collectd/etcd
+    host: $host
+    port: 2379
+    clusterName: test-cluster
+""")
+
+def test_etcd_monitor():
+    with run_container("quay.io/coreos/etcd:v2.3.8", command=ETCD_COMMAND) as etcd_cont:
+        config = etcd_config.substitute(host=etcd_cont.attrs["NetworkSettings"]["IPAddress"])
+
+        with run_agent(config) as [backend, _, _]:
+            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "etcd")), "Didn't get etcd datapoints"
+


### PR DESCRIPTION
 - This was conflicting with the monitor metricsToExclude key.
 - Also reversing logic of ssl verification skip so default works.
 - Adding test case in integration tests