### PR TITLE
Copying k8s dps since they aren't thread safe

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/cache.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cache.go
@@ -138,7 +138,12 @@ func (dc *DatapointCache) AllDatapoints() []*datapoint.Datapoint {
 
 	for k := range dc.dpCache {
 		if dc.dpCache[k] != nil {
-			dps = append(dps, dc.dpCache[k]...)
+			for i := range dc.dpCache[k] {
+				// Copy the datapoint since nothing in datapoints is thread
+				// safe.
+				dp := *dc.dpCache[k][i]
+				dps = append(dps, &dp)
+			}
 		}
 	}
 


### PR DESCRIPTION
This only becomes an issue if intervals start overlapping due to CPU limits.

@jchengsfx this should fix the panic you ran into with the tests.