### PR TITLE
Adding metric for absolute container CPU percent

### DIFF
--- a/docs/monitors/cadvisor.md
+++ b/docs/monitors/cadvisor.md
@@ -44,6 +44,7 @@ cause only a subset of metrics to be emitted.
 | `container_cpu_cfs_periods` | counter | Total number of elapsed CFS enforcement intervals |
 | `container_cpu_cfs_throttled_periods` | counter | Total number of times tasks in the cgroup have been throttled |
 | `container_cpu_cfs_throttled_time` | counter | Total time duration, in nanoseconds, for which tasks in the cgroup have been throttled |
+| `container_cpu_percent` | counter | Cumulative cpu utilization as a percentage of the host total CPU available |
 | `container_cpu_system_seconds_total` | counter | Cumulative system cpu time consumed in nanoseconds |
 | `container_cpu_usage_seconds_total` | counter | Cumulative cpu time consumed per cpu in nanoseconds |
 | `container_cpu_user_seconds_total` | counter | Cumulative user cpu time consumed in nanoseconds |

--- a/docs/monitors/kubelet-stats.md
+++ b/docs/monitors/kubelet-stats.md
@@ -46,6 +46,7 @@ cause only a subset of metrics to be emitted.
 | `container_cpu_cfs_periods` | counter | Total number of elapsed CFS enforcement intervals |
 | `container_cpu_cfs_throttled_periods` | counter | Total number of times tasks in the cgroup have been throttled |
 | `container_cpu_cfs_throttled_time` | counter | Total time duration, in nanoseconds, for which tasks in the cgroup have been throttled |
+| `container_cpu_percent` | counter | Cumulative cpu utilization as a percentage of the host total CPU available |
 | `container_cpu_system_seconds_total` | counter | Cumulative system cpu time consumed in nanoseconds |
 | `container_cpu_usage_seconds_total` | counter | Cumulative cpu time consumed per cpu in nanoseconds |
 | `container_cpu_user_seconds_total` | counter | Cumulative user cpu time consumed in nanoseconds |

--- a/internal/monitors/cadvisor/converter/converter.go
+++ b/internal/monitors/cadvisor/converter/converter.go
@@ -10,6 +10,7 @@ import (
 
 	info "github.com/google/cadvisor/info/v1"
 	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/signalfx-agent/internal/utils"
 )
 
 // InfoProvider provides a swappable interface to actually get the cAdvisor
@@ -91,6 +92,7 @@ func networkValues(net []info.InterfaceStats, valueFn func(*info.InterfaceStats)
 // COUNTER(container_cpu_usage_seconds_total): Cumulative cpu time consumed per cpu in nanoseconds
 // COUNTER(container_cpu_user_seconds_total): Cumulative user cpu time consumed in nanoseconds
 // COUNTER(container_cpu_utilization): Cumulative cpu utilization in percentages
+// COUNTER(container_cpu_percent): Cumulative cpu utilization as a percentage of the host total CPU available
 // COUNTER(container_cpu_cfs_periods): Total number of elapsed CFS enforcement intervals
 // COUNTER(container_cpu_cfs_throttled_periods): Total number of times tasks in the cgroup have been throttled
 // COUNTER(container_cpu_cfs_throttled_time): Total time duration, in nanoseconds, for which tasks in the cgroup have been throttled
@@ -162,6 +164,15 @@ func getContainerMetrics() []containerMetric {
 			valueType: datapoint.Counter,
 			getValues: func(s *info.ContainerStats) metricValues {
 				return metricValues{{value: datapoint.NewIntValue(int64(s.Cpu.Usage.Total / 10000000))}}
+			},
+		},
+		{
+			name:      "container_cpu_percent",
+			help:      "Cumulative cpu utilization as a percentage of the host total CPU available",
+			valueType: datapoint.Counter,
+			getValues: func(s *info.ContainerStats) metricValues {
+				cpuCount := utils.MaxInt(len(s.Cpu.Usage.PerCpu), 1)
+				return metricValues{{value: datapoint.NewIntValue(int64(int(s.Cpu.Usage.Total) / (10000000 * cpuCount)))}}
 			},
 		},
 		{


### PR DESCRIPTION
This takes into account the number of cores to normalize the metric as
an absolute percentage of the host total CPU