### PR TITLE
Using a fake store for k8s cluster resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,8 @@ jobs:
       - run: |
           mkdir ~/testresults
           docker run --rm \
-            -v ~/testresults:/output \
             signalfx-agent-dev \
-            bash -eo pipefail -c "make templates && go test -v ./... | go2xunit > /output/unit.xml"
+            bash -eo pipefail -c "make templates >/dev/null && go test -v ./... | go2xunit" > ~/testresults/unit.xml
 
       - store_test_results:
           path: ~/testresults

--- a/internal/monitors/kubernetes/cluster/monitor.go
+++ b/internal/monitors/kubernetes/cluster/monitor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	k8s "k8s.io/client-go/kubernetes"
 
 	"github.com/signalfx/signalfx-agent/internal/core/common/dpmeta"
@@ -129,10 +128,7 @@ func (m *Monitor) Start() error {
 
 	shouldReport := m.config.AlwaysClusterReporter
 
-	clusterState := newState(m.k8sClient)
-	clusterState.ChangeFunc = func(oldObj, newObj runtime.Object) {
-		m.datapointCache.HandleChange(oldObj, newObj)
-	}
+	clusterState := newState(m.k8sClient, m.datapointCache)
 
 	var leaderCh <-chan bool
 	var unregister func()

--- a/internal/utils/k8sutil/fakestore.go
+++ b/internal/utils/k8sutil/fakestore.go
@@ -1,0 +1,17 @@
+package k8sutil
+
+import "k8s.io/client-go/tools/cache"
+
+// FixedFakeCustomStore is necessary until we use a client-go version that
+// includes https://github.com/kubernetes/kubernetes/pull/62406.
+type FixedFakeCustomStore struct {
+	cache.FakeCustomStore
+}
+
+// Update calls the custom Update function if defined
+func (f *FixedFakeCustomStore) Update(obj interface{}) error {
+	if f.UpdateFunc != nil {
+		return f.UpdateFunc(obj)
+	}
+	return nil
+}

--- a/tests/monitors/docker_container_stats_test.py
+++ b/tests/monitors/docker_container_stats_test.py
@@ -61,7 +61,7 @@ def test_docker_stops_watching_old_containers():
         """) as [backend, get_output, _]:
             assert wait_for(p(has_datapoint_with_dim, backend, "container_id", nginx_container.id)), "Didn't get nginx datapoints"
             nginx_container.stop(timeout=10)
-            time.sleep(1)
+            time.sleep(3)
             backend.datapoints.clear()
             assert ensure_always(lambda: not has_datapoint_with_dim(backend, "container_id", nginx_container.id))
             assert not has_log_message(get_output(), "error")


### PR DESCRIPTION
We don't really need to keep the resource data itself, only the key used
to cache it so that it can be easily deleted from the cache when it gets
deleted from k8s.