### PR TITLE
A few memory optimizations based on profiling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
           mkdir ~/testresults
           docker run --rm \
             signalfx-agent-dev \
-            bash -eo pipefail -c "make templates >/dev/null && go test -v ./... | go2xunit" > ~/testresults/unit.xml
+            bash -eo pipefail -c "make templates >/dev/null && go test -v ./... | tee /dev/stderr | go2xunit" > ~/testresults/unit.xml
 
       - store_test_results:
           path: ~/testresults

--- a/internal/core/diagnostics.go
+++ b/internal/core/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	// Import for side-effect of registering http handler
@@ -121,6 +122,14 @@ func (a *Agent) InternalMetrics() []*datapoint.Datapoint {
 
 func (a *Agent) ensureProfileServerRunning() {
 	if !a.profileServerRunning {
+		// We don't use that much memory so the default mem sampling rate is
+		// too small to be very useful. Setting to 1 profiles ALL allocations
+		runtime.MemProfileRate = 1
+		// Crank up CPU profile rate too since our CPU usage tends to be pretty
+		// bursty around read cycles.
+		runtime.SetCPUProfileRate(-1)
+		runtime.SetCPUProfileRate(2000)
+
 		go func() {
 			a.profileServerRunning = true
 			// This is very difficult to access from the host on mac without

--- a/internal/monitors/cadvisor/converter/converter.go
+++ b/internal/monitors/cadvisor/converter/converter.go
@@ -2,8 +2,8 @@ package converter
 
 import (
 	"math"
-	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -717,8 +717,8 @@ func (c *CadvisorCollector) sendDatapoint(dp *datapoint.Datapoint) {
 
 	// filter POD level metrics
 	if dims["container_name"] == "POD" {
-		matched, _ := regexp.MatchString("^pod_network_.*", dp.Metric)
-		if !matched {
+		isNetworkMetric := strings.HasPrefix(dp.Metric, "pod_network_")
+		if !isNetworkMetric {
 			return
 		}
 		delete(dims, "container_name")

--- a/internal/monitors/kubernetes/cluster/clusterstate.go
+++ b/internal/monitors/kubernetes/cluster/clusterstate.go
@@ -16,9 +16,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// State makes extensive use of the K8s client's "informer" framework,
-// which is fairly poorly documented but seems to work pretty well and is well
-// suited to our use case.
+// State makes use of the K8s client's "reflector" helper to watch the API
+// server for changes and keep the datapoint cache up to date,
 type State struct {
 	clientset  *k8s.Clientset
 	reflectors map[string]*cache.Reflector

--- a/internal/monitors/kubernetes/cluster/metrics/util.go
+++ b/internal/monitors/kubernetes/cluster/metrics/util.go
@@ -1,15 +1,17 @@
 package metrics
 
-import "regexp"
+import "strings"
 
-var propNameSanitizer = regexp.MustCompile(`[./]`)
+var propNameSanitizer = strings.NewReplacer(
+	".", "_",
+	"/", "_")
 
 func propsAndTagsFromLabels(labels map[string]string) (map[string]string, map[string]bool) {
 	props := make(map[string]string)
 	tags := make(map[string]bool)
 
 	for label, value := range labels {
-		key := propNameSanitizer.ReplaceAllLiteralString(label, "_")
+		key := propNameSanitizer.Replace(label)
 		// K8s labels without values are treated as tags
 		if value == "" {
 			tags[key] = true

--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -33,7 +33,7 @@ func RemoveEmptyMapValues(m map[string]string) map[string]string {
 
 // StringMapToInterfaceMap converts a map[string]string to a map[string]interface{}.
 func StringMapToInterfaceMap(m map[string]string) map[string]interface{} {
-	out := map[string]interface{}{}
+	out := make(map[string]interface{}, len(m))
 	for k, v := range m {
 		out[k] = v
 	}
@@ -59,7 +59,7 @@ func MergeInterfaceMaps(maps ...map[string]interface{}) map[string]interface{} {
 
 // CloneStringMap makes a shallow copy of a map[string]string
 func CloneStringMap(m map[string]string) map[string]string {
-	m2 := make(map[string]string)
+	m2 := make(map[string]string, len(m))
 	for k, v := range m {
 		m2[k] = v
 	}
@@ -70,7 +70,7 @@ func CloneStringMap(m map[string]string) map[string]string {
 // map[string]string.  Keys and values will be converted with fmt.Sprintf so
 // the original key/values don't have to be strings.
 func InterfaceMapToStringMap(m map[interface{}]interface{}) map[string]string {
-	out := make(map[string]string)
+	out := make(map[string]string, len(m))
 	for k, v := range m {
 		out[fmt.Sprintf("%v", k)] = fmt.Sprintf("%v", v)
 	}
@@ -80,7 +80,11 @@ func InterfaceMapToStringMap(m map[interface{}]interface{}) map[string]string {
 // SortMapKeys returns a slice of all of the keys of a map sorted
 // alphabetically ascending.
 func SortMapKeys(m map[string]interface{}) []string {
-	var keys []string
+	if len(m) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
@@ -91,7 +95,7 @@ func SortMapKeys(m map[string]interface{}) []string {
 // StringInterfaceMapToAllInterfaceMap converts a map[string]interface{} to a
 // map[interface{}]interface{}
 func StringInterfaceMapToAllInterfaceMap(in map[string]interface{}) map[interface{}]interface{} {
-	out := make(map[interface{}]interface{})
+	out := make(map[interface{}]interface{}, len(in))
 	for k, v := range in {
 		out[k] = v
 	}


### PR DESCRIPTION
A lot of it is just getting rid of unnecessary uses of Regexp.

Also increasing profile sample rates for both CPU and heap since the agent tends to be pretty bursty and the defaults weren't very helpful.