### PR TITLE
Remove 'name' option from monitors that don't use it

### DIFF
--- a/docs/monitors/collectd-consul.md
+++ b/docs/monitors/collectd-consul.md
@@ -31,7 +31,6 @@ Monitor Type: `collectd/consul`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `aclToken` | no | `string` |  |
 | `useHTTPS` | no | `bool` |  (**default:** `false`) |
 | `enhancedMetrics` | no | `bool` |  (**default:** `false`) |

--- a/docs/monitors/collectd-elasticsearch.md
+++ b/docs/monitors/collectd-elasticsearch.md
@@ -22,7 +22,6 @@ Monitor Type: `collectd/elasticsearch`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `additionalMetrics` | no | `list of string` | AdditionalMetrics to report on |
 | `detailedMetrics` | no | `bool` | DetailedMetrics turns on additional metric time series (**default:** `true`) |
 | `enableClusterHealth` | no | `bool` | EnableClusterHealth enables reporting on the cluster health (**default:** `true`) |

--- a/docs/monitors/collectd-etcd.md
+++ b/docs/monitors/collectd-etcd.md
@@ -22,7 +22,6 @@ Monitor Type: `collectd/etcd`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `clusterName` | **yes** | `string` | An arbitrary name of the etcd cluster to make it easier to group together and identify instances. |
 | `sslKeyFile` | no | `string` |  |
 | `sslCertificate` | no | `string` |  |

--- a/docs/monitors/collectd-haproxy.md
+++ b/docs/monitors/collectd-haproxy.md
@@ -21,7 +21,6 @@ Monitor Type: `collectd/haproxy`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `proxiesToMonitor` | no | `list of string` |  |
 | `excludedMetrics` | no | `list of string` |  |
 | `enhancedMetrics` | no | `bool` |  (**default:** `false`) |

--- a/docs/monitors/collectd-marathon.md
+++ b/docs/monitors/collectd-marathon.md
@@ -24,7 +24,6 @@ Monitor Type: `collectd/marathon`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `username` | no | `string` |  |
 | `password` | no | `string` |  |
 

--- a/docs/monitors/collectd-mongodb.md
+++ b/docs/monitors/collectd-mongodb.md
@@ -22,7 +22,6 @@ Monitor Type: `collectd/mongodb`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `databases` | no | `list of string` |  |
 | `username` | no | `string` |  |
 | `password` | no | `string` |  |

--- a/docs/monitors/collectd-rabbitmq.md
+++ b/docs/monitors/collectd-rabbitmq.md
@@ -25,7 +25,6 @@ Monitor Type: `collectd/rabbitmq`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `collectChannels` | no | `bool` |  (**default:** `false`) |
 | `collectConnections` | no | `bool` |  (**default:** `false`) |
 | `collectExchanges` | no | `bool` |  (**default:** `false`) |

--- a/docs/monitors/collectd-spark.md
+++ b/docs/monitors/collectd-spark.md
@@ -28,7 +28,6 @@ Monitor Type: `collectd/spark`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
-| `name` | no | `string` |  |
 | `isMaster` | no | `bool` | Set to `true` when monitoring a master Spark node (**default:** `false`) |
 | `clusterType` | no | `string` | Should be one of `Standalone` or `Mesos` |
 | `collectApplicationMetrics` | no | `bool` |  (**default:** `false`) |

--- a/docs/monitors/prometheus-exporter.md
+++ b/docs/monitors/prometheus-exporter.md
@@ -33,7 +33,6 @@ Monitor Type: `prometheus-exporter`
 | --- | --- | --- | --- |
 | `host` | **yes** | `string` | Host of the exporter |
 | `port` | **yes** | `integer` | Port of the exporter |
-| `name` | no | `string` |  |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default).` (**default:** `/metrics`) |
 
 

--- a/internal/core/config/dynamic.go
+++ b/internal/core/config/dynamic.go
@@ -16,14 +16,14 @@ import (
 // DecodeExtraConfigStrict will pull out any config values from 'in' and put them
 // on the 'out' struct, returning an error if anything in 'in' isn't in 'out'.
 func DecodeExtraConfigStrict(in CustomConfigurable, out interface{}) error {
-	return decodeExtraConfig(in, out, true)
+	return DecodeExtraConfig(in, out, true)
 }
 
 // DecodeExtraConfig will pull out the OtherConfig values from both
 // ObserverConfig and MonitorConfig and decode them to a struct that is
 // provided in the `out` arg.  Whether all fields have to be in 'out' is
 // determined by the 'strict' flag.  Any errors decoding will cause `out` to be nil.
-func decodeExtraConfig(in CustomConfigurable, out interface{}, strict bool) error {
+func DecodeExtraConfig(in CustomConfigurable, out interface{}, strict bool) error {
 	pkgPaths := strings.Split(reflect.Indirect(reflect.ValueOf(out)).Type().PkgPath(), "/")
 
 	otherYaml, err := yaml.Marshal(in.ExtraConfig())

--- a/internal/monitors/activemonitor.go
+++ b/internal/monitors/activemonitor.go
@@ -38,7 +38,7 @@ func (am *ActiveMonitor) configureMonitor(monConfig config.MonitorCustomConfig) 
 	}
 
 	if am.endpoint != nil {
-		err := config.DecodeExtraConfigStrict(am.endpoint, monConfig)
+		err := config.DecodeExtraConfig(am.endpoint, monConfig, false)
 		if err != nil {
 			return errors.Wrap(err, "Could not inject endpoint config into monitor config")
 		}

--- a/internal/monitors/collectd/consul/consul.go
+++ b/internal/monitors/collectd/consul/consul.go
@@ -38,7 +38,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 
 	ACLToken            string `yaml:"aclToken"`
 	UseHTTPS            bool   `yaml:"useHTTPS"`

--- a/internal/monitors/collectd/elasticsearch/elasticsearch.go
+++ b/internal/monitors/collectd/elasticsearch/elasticsearch.go
@@ -29,7 +29,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 	// AdditionalMetrics to report on
 	AdditionalMetrics []string `yaml:"additionalMetrics"`
 	// DetailedMetrics turns on additional metric time series

--- a/internal/monitors/collectd/etcd/etcd.go
+++ b/internal/monitors/collectd/etcd/etcd.go
@@ -29,7 +29,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 	// An arbitrary name of the etcd cluster to make it easier to group
 	// together and identify instances.
 	ClusterName       string `yaml:"clusterName" validate:"required"`

--- a/internal/monitors/collectd/haproxy/haproxy.go
+++ b/internal/monitors/collectd/haproxy/haproxy.go
@@ -28,7 +28,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 
 	ProxiesToMonitor []string `yaml:"proxiesToMonitor"`
 	ExcludedMetrics  []string `yaml:"excludedMetrics"`

--- a/internal/monitors/collectd/marathon/marathon.go
+++ b/internal/monitors/collectd/marathon/marathon.go
@@ -32,7 +32,6 @@ type Config struct {
 
 	Host     string `yaml:"host" validate:"required"`
 	Port     uint16 `yaml:"port" validate:"required"`
-	Name     string `yaml:"name"`
 	Username string `yaml:"username"`
 	Password string `yaml:"password" neverLog:"true"`
 }

--- a/internal/monitors/collectd/mongodb/mongodb.go
+++ b/internal/monitors/collectd/mongodb/mongodb.go
@@ -31,7 +31,6 @@ type Config struct {
 
 	Host                   string   `yaml:"host" validate:"required"`
 	Port                   uint16   `yaml:"port" validate:"required"`
-	Name                   string   `yaml:"name"`
 	Databases              []string `yaml:"databases"`
 	Username               string   `yaml:"username"`
 	Password               string   `yaml:"password" neverLog:"true"`

--- a/internal/monitors/collectd/rabbitmq/rabbitmq.go
+++ b/internal/monitors/collectd/rabbitmq/rabbitmq.go
@@ -32,7 +32,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 
 	CollectChannels    bool   `yaml:"collectChannels"`
 	CollectConnections bool   `yaml:"collectConnections"`

--- a/internal/monitors/collectd/spark/spark.go
+++ b/internal/monitors/collectd/spark/spark.go
@@ -44,7 +44,6 @@ type Config struct {
 
 	Host string `yaml:"host" validate:"required"`
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 	// Set to `true` when monitoring a master Spark node
 	IsMaster bool `yaml:"isMaster" default:"false"`
 	// Should be one of `Standalone` or `Mesos`

--- a/internal/monitors/prometheus/prometheus.go
+++ b/internal/monitors/prometheus/prometheus.go
@@ -50,7 +50,6 @@ type Config struct {
 	Host string `yaml:"host" validate:"required"`
 	// Port of the exporter
 	Port uint16 `yaml:"port" validate:"required"`
-	Name string `yaml:"name"`
 
 	// Path to the metrics endpoint on the exporter server, usually `/metrics`
 	// (the default).`


### PR DESCRIPTION
This also involved making the monitor configuration logic not require it