### PR TITLE
Make validation errors more user friendly

### DIFF
--- a/internal/monitors/monitor.go
+++ b/internal/monitors/monitor.go
@@ -1,9 +1,9 @@
 package monitors
 
 import (
+	"fmt"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"github.com/signalfx/signalfx-agent/internal/core/config"
 	"github.com/signalfx/signalfx-agent/internal/core/services"
 	"github.com/signalfx/signalfx-agent/internal/monitors/types"
@@ -102,7 +102,7 @@ type Shutdownable interface {
 func getCustomConfigForMonitor(conf *config.MonitorConfig) (config.MonitorCustomConfig, error) {
 	confTemplate, ok := ConfigTemplates[conf.Type]
 	if !ok {
-		return nil, errors.Errorf("Unknown monitor type %s", conf.Type)
+		return nil, fmt.Errorf("Unknown monitor type %s", conf.Type)
 	}
 	monConfig := utils.CloneInterface(confTemplate).(config.MonitorCustomConfig)
 

--- a/internal/monitors/validation.go
+++ b/internal/monitors/validation.go
@@ -4,11 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	validator "gopkg.in/go-playground/validator.v9"
 
 	"github.com/signalfx/signalfx-agent/internal/core/config"
 	"github.com/signalfx/signalfx-agent/internal/core/services"
+	"github.com/signalfx/signalfx-agent/internal/utils"
 )
 
 // Used to validate configuration that is common to all monitors up front
@@ -35,6 +37,14 @@ func validateConfig(monConfig config.MonitorCustomConfig) error {
 	validate := validator.New()
 	err := validate.Struct(monConfig)
 	if err != nil {
+		if ves, ok := err.(validator.ValidationErrors); ok {
+			var msgs []string
+			for _, e := range ves {
+				fieldName := utils.YAMLNameOfFieldInStruct(e.Field(), monConfig)
+				msgs = append(msgs, fmt.Sprintf("Validation error in field '%s': %s", fieldName, e.Tag()))
+			}
+			return errors.New(strings.Join(msgs, "; "))
+		}
 		return err
 	}
 

--- a/internal/utils/yaml.go
+++ b/internal/utils/yaml.go
@@ -40,6 +40,20 @@ func YAMLNameOfField(field reflect.StructField) string {
 	return parts[0]
 }
 
+// YAMLNameOfFieldInStruct returns the YAML key that is used for the given
+// struct field, looking up fieldName in the given st struct.  If the field has
+// no key (e.g. if the `yaml:"-"` tag is set, this will return an empty string.
+// It uses YAMLNameOfField under the covers.  If st is not a struct, this will
+// panic.
+func YAMLNameOfFieldInStruct(fieldName string, st interface{}) string {
+	stType := reflect.Indirect(reflect.ValueOf(st)).Type()
+	field, ok := stType.FieldByName(fieldName)
+	if !ok {
+		return ""
+	}
+	return YAMLNameOfField(field)
+}
+
 // ParseLineNumberFromYAMLError takes an error message nested in yaml.TypeError
 // and returns a line number if indicated in the error message.  This is pretty
 // hacky but is the only way to actually get at the line number in the standard

--- a/tests/monitors/rabbitmq_test.py
+++ b/tests/monitors/rabbitmq_test.py
@@ -1,0 +1,26 @@
+from functools import partial as p
+import os
+import string
+
+from tests.helpers import fake_backend
+from tests.helpers.util import wait_for, run_agent, run_container
+from tests.helpers.assertions import *
+
+rabbitmq_config = string.Template("""
+monitors:
+  - type: collectd/rabbitmq
+    host: $host
+    port: 15672
+    username: guest
+    password: guest
+    collectNodes: true
+    collectChannels: true
+""")
+
+def test_rabbitmq():
+    with run_container("rabbitmq:3.6-management") as rabbitmq_cont:
+        config = rabbitmq_config.substitute(host=rabbitmq_cont.attrs["NetworkSettings"]["IPAddress"])
+
+        with run_agent(config) as [backend, _, _]:
+            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "rabbitmq")), "Didn't get rabbitmq datapoints"
+

--- a/tests/monitors/validation_test.py
+++ b/tests/monitors/validation_test.py
@@ -1,0 +1,17 @@
+from functools import partial as p
+import os
+import string
+
+from tests.helpers import fake_backend
+from tests.helpers.util import wait_for, run_agent, run_container
+from tests.helpers.assertions import *
+
+config = """
+monitors:
+  - type: collectd/rabbitmq
+    host: 127.0.0.1
+"""
+
+def test_validation_required_log_output():
+    with run_agent(config) as [backend, get_output, _]:
+        assert wait_for(lambda: has_log_message(get_output(), "error", "Validation error in field 'port': required")), "Didn't get validation error message"


### PR DESCRIPTION
Don't log stacktraces on unknown monitor type

Use YAML name of struct field in validation errors

Add tests around all of this