### PR TITLE
Add back owner references to pod properties

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/pods.go
+++ b/internal/monitors/kubernetes/cluster/metrics/pods.go
@@ -66,6 +66,10 @@ func datapointsForPod(pod *v1.Pod) []*datapoint.Datapoint {
 func dimPropsForPod(pod *v1.Pod) *atypes.DimProperties {
 	props, tags := propsAndTagsFromLabels(pod.Labels)
 
+	for _, or := range pod.OwnerReferences {
+		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
+	}
+
 	if len(props) == 0 && len(tags) == 0 {
 		return nil
 	}

--- a/internal/monitors/kubernetes/cluster/monitor_test.go
+++ b/internal/monitors/kubernetes/cluster/monitor_test.go
@@ -112,6 +112,12 @@ var _ = Describe("Kubernetes plugin", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test1",
 					UID:  "abcd",
+					OwnerReferences: []metav1.OwnerReference{
+						metav1.OwnerReference{
+							Kind: "DaemonSet",
+							Name: "MySet",
+						},
+					},
 				},
 				Status: v1.PodStatus{
 					Phase: v1.PodRunning,
@@ -136,6 +142,12 @@ var _ = Describe("Kubernetes plugin", func() {
 		Expect(intValue(dps[1].Value)).To(Equal(int64(5)))
 		Expect(dps[2].Metric).To(Equal("kubernetes.container_ready"))
 		Expect(intValue(dps[2].Value)).To(Equal(int64(1)))
+
+		dimProps := output.WaitForDimensionProps(1, 3)
+		Expect(len(dimProps)).Should(Equal(1))
+		Expect(dimProps[0].Name).Should(Equal("kubernetes_pod_uid"))
+		Expect(dimProps[0].Value).Should(Equal("abcd"))
+		Expect(dimProps[0].Properties["daemonSet"]).Should(Equal("MySet"))
 
 		dims := dps[0].Dimensions
 		Expect(dims["metric_source"]).To(Equal("kubernetes"))


### PR DESCRIPTION
Somehow this got lost in a refactoring

Add a test to ensure it stays in the future