### PR TITLE
Tweak collectd monitor shutdown logic

### DIFF
--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -1,17 +1,15 @@
 from contextlib import contextmanager
-import docker
-import inspect
 import io
 import os
-import queue
 import select
-import shutil
 import subprocess
-import string
 import tempfile
 import threading
 import time
+
+import docker
 import yaml
+
 from . import fake_backend
 
 AGENT_BIN = os.environ.get("AGENT_BIN", "/bundle/bin/signalfx-agent")

--- a/tests/monitors/custom_collectd_test.py
+++ b/tests/monitors/custom_collectd_test.py
@@ -1,10 +1,9 @@
 from functools import partial as p
-import os
-import string
+from textwrap import dedent
+import time
 
-from tests.helpers import fake_backend
-from tests.helpers.util import wait_for, run_agent
-from tests.helpers.assertions import *
+from tests.helpers.util import ensure_always, wait_for, run_agent
+from tests.helpers.assertions import has_datapoint_with_dim
 
 def test_custom_collectd():
     with run_agent("""
@@ -39,4 +38,43 @@ collectd:
 """) as [backend, _, _]:
         assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "df")), "Didn't get df datapoints"
         assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "cpu")), "Didn't get cpufreq datapoints"
+        assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "ping")), "Didn't get ping datapoints"
+
+
+def test_custom_collectd_shutdown():
+    with run_agent(dedent("""
+        monitors:
+          - type: collectd/df
+          - type: collectd/custom
+            template: |
+              LoadPlugin "ping"
+              <Plugin ping>
+                Host "google.com"
+              </Plugin>
+    """)) as [backend, _, configure]:
+        assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "ping")), "Didn't get ping datapoints"
+        assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "df")), "Didn't get df datapoints"
+
+        configure(dedent("""
+            monitors:
+              - type: collectd/df
+        """))
+
+        time.sleep(3)
+        backend.datapoints.clear()
+
+        assert ensure_always(lambda: not has_datapoint_with_dim(backend, "plugin", "ping")), \
+            "Got ping datapoint when we shouldn't have"
+
+        configure(dedent("""
+            monitors:
+              - type: collectd/df
+              - type: collectd/custom
+                template: |
+                  LoadPlugin "ping"
+                  <Plugin ping>
+                    Host "google.com"
+                  </Plugin>
+        """))
+
         assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "ping")), "Didn't get ping datapoints"


### PR DESCRIPTION
This is to make it work better when running the agent on the command line and using Ctrl+c

Also adding integration test to make sure shutdown and recreation works