### PR TITLE
Fix race in collectd shutdown logic

### DIFF
--- a/internal/monitors/collectd/collectd.go
+++ b/internal/monitors/collectd/collectd.go
@@ -264,7 +264,9 @@ func (cm *Manager) manageCollectd(initCh chan<- struct{}, terminated chan struct
 
 		case Uninitialized:
 			restartDebounced, restartDebouncedStop = utils.Debounce0(func() {
-				restart <- struct{}{}
+				if state != ShuttingDown {
+					restart <- struct{}{}
+				}
 			}, restartDelay)
 
 			go func() {
@@ -340,7 +342,7 @@ func (cm *Manager) manageCollectd(initCh chan<- struct{}, terminated chan struct
 			state = Stopped
 
 		case Stopped:
-			restartDebouncedStop <- struct{}{}
+			close(restartDebouncedStop)
 			writeServer.Shutdown()
 			close(terminated)
 			return

--- a/internal/utils/time.go
+++ b/internal/utils/time.go
@@ -18,7 +18,6 @@ func Debounce0(fn func(), duration time.Duration) (func(), chan<- struct{}) {
 		for {
 			select {
 			case <-stop:
-				close(stop)
 				return
 			case <-timer.C:
 				if callRequested {


### PR DESCRIPTION
The shutdown was getting blocked when the agent was stopped by ctrl+c on
the command line due to a race between collectd restarting due to it
being killed by the ctrl+c (because it is in the same process group as
the agent) and the collectd instance being shutdown, causing a hang on
the restart which caused a hang on the shutdown