### PR TITLE
Clarify the use of no authentication for GKE

### DIFF
--- a/docs/kubernetes-setup.md
+++ b/docs/kubernetes-setup.md
@@ -310,6 +310,7 @@ monitor to get container metrics.  The config for that monitor will look like:
 monitors:
  - type: kubelet-stats
    kubeletAPI:
+     authType: none
      url: http://localhost:10255
 ```
 


### PR DESCRIPTION
Make the default explicit for clarity.