### PR TITLE
Force raw config to be a string instead of bytes

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -40,7 +40,8 @@ configuration files by adding the following monitor:
 ```yaml
 monitors:
   - type: collectd/custom
-    templates: {"#from": "/etc/collectd/managed_config/*.conf", raw: true}
+    templates:
+    - {"#from": "/etc/collectd/managed_config/*.conf", flatten: true, raw: true}
 ```
 
 We run collectd-python linked against Python 2.7 so any Python plugins will

--- a/internal/core/config/sources/resolve.go
+++ b/internal/core/config/sources/resolve.go
@@ -62,7 +62,7 @@ func convertFileBytesToValues(content map[string][]byte, raw bool) ([]interface{
 
 		var v interface{}
 		if raw {
-			v = content[path]
+			v = string(content[path])
 		} else {
 			err := yaml.Unmarshal(content[path], &v)
 			if err != nil {

--- a/internal/core/config/sources/walker.go
+++ b/internal/core/config/sources/walker.go
@@ -179,8 +179,10 @@ func mergeValues(v []interface{}) (interface{}, error) {
 		return mergeSlices(v)
 	} else if _, ok := v[0].(map[interface{}]interface{}); ok {
 		return mergeMaps(v)
-	} else {
+	} else if len(v) == 1 {
 		return v[0], nil
+	} else {
+		return nil, errors.New("value cannot be merged")
 	}
 }
 


### PR DESCRIPTION
Also make it an error to have a source with multiple values merged into a scalar value