### PR TITLE
Isolate variables, remove default config, and update for Galaxy

### DIFF
--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -1,0 +1,15 @@
+sfx_agent_config:
+  signalFxAccessToken: MyToken
+  monitors:
+    - type: collectd/cpu
+    - type: collectd/cpufreq
+    - type: collectd/df
+    - type: collectd/disk
+    - type: collectd/interface
+    - type: collectd/load
+    - type: collectd/memory
+    - type: collectd/protocols
+    - type: collectd/signalfx-metadata
+    - type: host-metadata
+    - type: collectd/uptime
+    - type: collectd/vmem

--- a/deployments/ansible/roles/signalfx-agent/defaults/main.yml
+++ b/deployments/ansible/roles/signalfx-agent/defaults/main.yml
@@ -1,24 +1,8 @@
 ---
 # Default values for for Signalfx Agent installation
 
-repo_base_url: https://dl.signalfx.com
-package_stage: final
-version: latest
+sfx_repo_base_url: https://dl.signalfx.com
+sfx_package_stage: final
+sfx_version: latest
 
-conf_file_path: /etc/signalfx/agent.yaml
-
-conf:
-  signalFxAccessToken: MY-TOKEN
-  monitors:
-    - type: collectd/cpu
-    - type: collectd/cpufreq
-    - type: collectd/df
-    - type: collectd/disk
-    - type: collectd/interface
-    - type: collectd/load
-    - type: collectd/memory
-    - type: collectd/protocols
-    - type: collectd/signalfx-metadata
-    - type: collectd/uptime
-    - type: collectd/vmem
-
+sfx_conf_file_path: /etc/signalfx/agent.yaml

--- a/deployments/ansible/roles/signalfx-agent/meta/main.yml
+++ b/deployments/ansible/roles/signalfx-agent/meta/main.yml
@@ -1,18 +1,33 @@
 ---
 galaxy_info:
-  author: SignalFx, Inc.
+  role_name: smart_agent
+  author: SignalFx
   description: Ansible role to install and configure the SignalFx Smart Agent
   company: SignalFx, Inc.
   license: Apache-2.0
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   platforms:
   - name: EL
+    versions:
+      - 7
+      - 6
   - name: Ubuntu
+    versions:
+      - bionic
+      - artful
+      - xenial
+      - trusty
   - name: Debian
+    versions:
+      - stretch
+      - jessie
+      - wheezy
+      - squeeze
   - name: Amazon
   galaxy_tags:
     - signalfx
     - metrics
     - agent
     - monitoring
-dependencies:
+
+dependencies: []

--- a/deployments/ansible/roles/signalfx-agent/tasks/debian_repo.yml
+++ b/deployments/ansible/roles/signalfx-agent/tasks/debian_repo.yml
@@ -1,20 +1,20 @@
 ---
 - name: Add an Apt signing key for Signalfx Agent
   apt_key:
-    url: "{{ repo_base_url }}/debian.gpg"
+    url: "{{ sfx_repo_base_url }}/debian.gpg"
     keyring: /etc/apt/trusted.gpg.d/signalfx.gpg
     state: present
 
 - name: Add Signalfx Agent repository into sources list
   apt_repository:
-    repo: "deb {{ repo_base_url }}/debs/signalfx-agent/{{ package_stage }} /"
+    repo: "deb {{ sfx_repo_base_url }}/debs/signalfx-agent/{{ sfx_package_stage }} /"
     filename: 'signalfx-agent'
     mode: 644
     state: present
 
 - name: Install signalfx-agent via apt package manager
   apt:
-    name: signalfx-agent{% if version is defined and version != "latest" %}={{ version }}{% endif %}
-    state: "{% if version is defined and version != 'latest' %}present{% else %}{{ version }}{% endif %}"
+    name: signalfx-agent{% if sfx_version is defined and sfx_version != "latest" %}={{ sfx_version }}{% endif %}
+    state: "{% if sfx_version is defined and sfx_version != 'latest' %}present{% else %}{{ sfx_version }}{% endif %}"
     force: yes
     update_cache: yes

--- a/deployments/ansible/roles/signalfx-agent/tasks/main.yml
+++ b/deployments/ansible/roles/signalfx-agent/tasks/main.yml
@@ -5,16 +5,19 @@
     rhel_distro: ['CentOS', 'RedHat', 'Red Hat Enterprise Linux', 'Amazon']
     cacheable: true
 
-- name: Check SignalFx Access Token is defined
-  fail: msg="Bailing out. This play requires 'signalFxAccessToken'"
-  when: (conf['signalFxAccessToken'] is undefined)
-          or
-        (conf['signalFxAccessToken'] is none)
-          or
-        (conf['signalFxAccessToken'] | trim == '')
+- name: Confirm agent configuration is provided
+  fail: msg='Please provide a populated sfx_agent_config'
+  when: not (sfx_agent_config | default(false))
+
+- name: Confirm SignalFx Access Token is defined
+  fail: msg='Please specify a signalFxAccessToken in your sfx_agent_config'
+  when: not (sfx_agent_config.signalFxAccessToken | default('') | trim | bool)
 
 - name: Acceptable distribution check
-  fail: msg="Bailing out. This play is supported on {{ debian_distro }}, {{ rhel_distro }}. Target server runs on {{ ansible_os_family }}"
+  fail: 
+    msg: >
+         Bailing out. This play is supported on {{ debian_distro }}, {{ rhel_distro }}.
+         Target server runs on {{ ansible_os_family }}.
   when: (ansible_os_family not in debian_distro)
           and
         (ansible_os_family not in rhel_distro)
@@ -29,8 +32,8 @@
 
 - name: write signalfx config
   copy:
-    content: "{{ conf | to_nice_yaml }}"
-    dest: "{{ conf_file_path }}"
+    content: "{{ sfx_agent_config | to_nice_yaml }}"
+    dest: "{{ sfx_conf_file_path }}"
     owner: signalfx-agent
     group: signalfx-agent
 

--- a/deployments/ansible/roles/signalfx-agent/tasks/yum_repo.yml
+++ b/deployments/ansible/roles/signalfx-agent/tasks/yum_repo.yml
@@ -3,15 +3,14 @@
   yum_repository:
     name: signalfx-agent
     description: SignalFx Agent Repository
-    baseurl: "{{ repo_base_url }}/rpms/signalfx-agent/{{ package_stage }}"
-    gpgkey: "{{ repo_base_url }}/yum-rpm.key"
+    baseurl: "{{ sfx_repo_base_url }}/rpms/signalfx-agent/{{ sfx_package_stage }}"
+    gpgkey: "{{ sfx_repo_base_url }}/yum-rpm.key"
     gpgcheck: yes
     enabled: yes
 
 - name: Install signalfx-agent via yum package manager
   yum: 
-    name: signalfx-agent{% if version is defined and version != "latest" %}-{{ version }}{% endif %}
-    state: "{% if version is defined and version != 'latest' %}present{% else %}{{ version }}{% endif %}"
+    name: signalfx-agent{% if sfx_version is defined and sfx_version != "latest" %}-{{ sfx_version }}{% endif %}
+    state: "{% if sfx_version is defined and sfx_version != 'latest' %}present{% else %}{{ sfx_version }}{% endif %}"
     allow_downgrade: yes
     update_cache: yes
-


### PR DESCRIPTION
Includes updates for valid Galaxy distribution, documentation clarifications, and prefixes variables with `sfx` to avoid potential collisions in usage.  These renames are a breaking change, but move us closer to best practices.

I suggest we push the role to a new repo `ansible-signalfx-agent` as a git subtree for Galaxy distribution.

link: https://github.com/signalfx/signalfx-agent/issues/261