### PR TITLE
Account for -e and pipefail for diff check and update ansible test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,8 @@ jobs:
           make dev-image
           docker run --rm \
             signalfx-agent-ansible-dev \
-            ansible-playbook -i inventory example-playbook.yml --connection=local > ~/testresults/ansible.out
+            ansible-playbook -i inventory example-playbook.yml --connection=local \
+            -e '{"sfx_agent_config": {"signalFxAccessToken": "MyToken"}}' > ~/testresults/ansible.out
 
           docker run --rm \
             signalfx-agent-ansible-dev \

--- a/scripts/changes-include-dir
+++ b/scripts/changes-include-dir
@@ -12,8 +12,7 @@ set -euo pipefail
 DIRS=$@
 
 for DIR in $DIRS; do
-    git diff origin/master...$CIRCLE_BRANCH --name-status | awk '{print $2}' | grep "^$DIR"
-    if [ $? -eq 0 ]; then
+    if [ $(git diff signalfx/master...$CIRCLE_BRANCH --name-status | awk '{print $2}' | grep -c "^$DIR") -gt 0 ]; then
         exit 0
     fi
 done


### PR DESCRIPTION
The changes-include-dir check was exiting early on the initial grep when no matches were found.  Since we only care about the return value for grep the pipefail is also unnecessary.