### PR TITLE
Remove host dims from k8s cluster metrics

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/node.go
+++ b/internal/monitors/kubernetes/cluster/metrics/node.go
@@ -29,7 +29,6 @@ var machineIDToNodeNameMap = make(map[string]string)
 
 func datapointsForNode(node *v1.Node, useNodeName bool) []*datapoint.Datapoint {
 	dims := map[string]string{
-		"host":            firstNodeHostname(node),
 		"kubernetes_node": node.Name,
 	}
 

--- a/internal/monitors/kubernetes/cluster/metrics/pods.go
+++ b/internal/monitors/kubernetes/cluster/metrics/pods.go
@@ -37,7 +37,7 @@ func datapointsForPod(pod *v1.Pod) []*datapoint.Datapoint {
 		"kubernetes_namespace": pod.Namespace,
 		"kubernetes_pod_uid":   string(pod.UID),
 		"kubernetes_pod_name":  pod.Name,
-		"host":                 pod.Spec.NodeName,
+		"kubernetes_node":      pod.Spec.NodeName,
 	}
 
 	dps := []*datapoint.Datapoint{


### PR DESCRIPTION
It is too hard to make them match the other host dims generically