### PR TITLE
Fixing has_datapoint assertion func

### DIFF
--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -53,8 +53,17 @@ def has_datapoint(fake_services, metric_name=None, dimensions=None, value=None):
             continue
         if dimensions and not has_all_dims(dp, dimensions):
             continue
-        if value and dp.value != value:
-            continue
+        if value is not None:
+            if dp.value.HasField("intValue"):
+                if dp.value.intValue != value:
+                    continue
+            elif dp.value.HasField("doubleValue"):
+                if dp.value.doubleValue != value:
+                    continue
+            else:
+                # Non-numeric values aren't supported, so they always fail to
+                # match
+                continue
         return True
     return False
 

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -47,22 +47,22 @@ def test_resource_quota_metrics(agent_image, minikube, k8s_test_timeout, k8s_nam
         namespace=k8s_namespace,
         yamls=[os.path.join(os.path.dirname(os.path.realpath(__file__)), "resource_quota.yaml")]) as [backend, _]:
 
-        wait_for(p(has_datapoint, backend,
+        assert wait_for(p(has_datapoint, backend,
             metric_name="kubernetes.resource_quota_hard",
             dimensions={"quota_name": "object-quota-demo", "resource": "requests.cpu"},
             value=100000))
 
-        wait_for(p(has_datapoint, backend,
+        assert wait_for(p(has_datapoint, backend,
             metric_name="kubernetes.resource_quota_hard",
             dimensions={"quota_name": "object-quota-demo", "resource": "persistentvolumeclaims"},
             value=4))
 
-        wait_for(p(has_datapoint, backend,
+        assert wait_for(p(has_datapoint, backend,
             metric_name="kubernetes.resource_quota_used",
             dimensions={"quota_name": "object-quota-demo", "resource": "persistentvolumeclaims"},
             value=0))
 
-        wait_for(p(has_datapoint, backend,
+        assert wait_for(p(has_datapoint, backend,
             metric_name="kubernetes.resource_quota_hard",
             dimensions={"quota_name": "object-quota-demo", "resource": "services.loadbalancers"},
             value=2))


### PR DESCRIPTION
Making k8s cluster tests actually assert that datapoints are coming in properly