### PR TITLE
Service tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,41 @@ jobs:
       - store_artifacts:
           path: ~/testresults/k8s_integration_tests.html
 
+  installer_tests:
+    <<: *executor
+    steps:
+      - checkout
+      - run: |
+          if ! scripts/changes-include-dir deployments/installer; then
+              echo "Installer code has not changed, skipping tests!"
+              touch ~/.skip
+              exit 0
+          fi
+      - *install_pytest
+      - run:
+          no_output_timeout: 30m
+          command: |
+            if [ -f ~/.skip ]; then
+                echo "Installer code has not changed, skipping tests!"
+                exit 0
+            fi
+            mkdir /tmp/scratch
+            mkdir ~/testresults
+            pytest \
+                -n auto \
+                -m "installer" \
+                --verbose \
+                --junitxml=~/testresults/installer.xml \
+                --html=~/testresults/installer.html \
+                --self-contained-html \
+                ./tests/packaging/
+
+      - store_test_results:
+          path: ~/testresults
+
+      - store_artifacts:
+          path: ~/testresults/installer.html
+
   rpm_package_tests:
     <<: *executor
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          if ! scripts/changes-include-dir deployments/installer tests/packaging; then
+          if ! scripts/changes-include-dir deployments/installer tests/packaging/installer_test.py tests/packaging/common.py tests/packaging/images; then
               echo "Installer code has not changed, skipping tests!"
               touch ~/.skip
               exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
           export TEST_SERVICES_DIR=$(pwd)/test-services
           sudo -E pytest \
               --verbose \
-              -n6 \
+              -n 4 \
               --junitxml=~/testresults/integration_tests.xml \
               --html=~/testresults/integration_tests.html \
               --self-contained-html \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,12 +169,13 @@ jobs:
           export AGENT_BIN=$(pwd)/bundle/bin/signalfx-agent
           export TEST_SERVICES_DIR=$(pwd)/test-services
           sudo -E pytest \
+              -n4 \
+              -m "not packaging and not installer and not k8s" \
+              --reruns=3 \
               --verbose \
-              -n 4 \
               --junitxml=~/testresults/integration_tests.xml \
               --html=~/testresults/integration_tests.html \
               --self-contained-html \
-              -m "not packaging and not installer and not k8s" \
               tests
       - store_test_results:
           path: ~/testresults
@@ -272,6 +273,7 @@ jobs:
             pytest \
                 -n auto \
                 -m "installer" \
+                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/installer.xml \
                 --html=~/testresults/installer.html \
@@ -309,6 +311,7 @@ jobs:
             pytest \
                 -n auto \
                 -m "rpm" \
+                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/rpm.xml \
                 --html=~/testresults/rpm.html \
@@ -350,6 +353,7 @@ jobs:
             pytest \
                 -n auto \
                 -m "deb" \
+                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/deb.xml \
                 --html=~/testresults/deb.html \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,6 +489,7 @@ workflows:
         requires:
          - build
      - docs_test
+     - installer_tests
      - rpm_package_tests
      - deb_package_tests
      - chef_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,6 @@ jobs:
           sudo -E pytest \
               -n4 \
               -m "not packaging and not installer and not k8s" \
-              --reruns=3 \
               --verbose \
               --junitxml=~/testresults/integration_tests.xml \
               --html=~/testresults/integration_tests.html \
@@ -273,7 +272,6 @@ jobs:
             pytest \
                 -n auto \
                 -m "installer" \
-                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/installer.xml \
                 --html=~/testresults/installer.html \
@@ -311,7 +309,6 @@ jobs:
             pytest \
                 -n auto \
                 -m "rpm" \
-                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/rpm.xml \
                 --html=~/testresults/rpm.html \
@@ -353,7 +350,6 @@ jobs:
             pytest \
                 -n auto \
                 -m "deb" \
-                --reruns=3 \
                 --verbose \
                 --junitxml=~/testresults/deb.xml \
                 --html=~/testresults/deb.html \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,7 +254,7 @@ jobs:
     steps:
       - checkout
       - run: |
-          if ! scripts/changes-include-dir deployments/installer; then
+          if ! scripts/changes-include-dir deployments/installer tests/packaging; then
               echo "Installer code has not changed, skipping tests!"
               touch ~/.skip
               exit 0

--- a/packaging/etc/init.d/signalfx-agent.debian
+++ b/packaging/etc/init.d/signalfx-agent.debian
@@ -21,7 +21,7 @@ user="signalfx-agent"
 group="signalfx-agent"
 rundir="/var/run/signalfx-agent"
 
-name=`basename $0`
+name="signalfx-agent"
 pidfile="/var/run/$name.pid"
 logfile="/var/log/$name.log"
 

--- a/packaging/etc/init.d/signalfx-agent.rhel
+++ b/packaging/etc/init.d/signalfx-agent.rhel
@@ -23,7 +23,7 @@ user="signalfx-agent"
 group="signalfx-agent"
 rundir="/var/run/signalfx-agent"
 
-name=`basename $0`
+name="signalfx-agent"
 pidfile="/var/run/$name.pid"
 logfile="/var/log/$name.log"
 

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
 import io
+import netifaces as ni
 import os
 import select
 import subprocess
@@ -165,7 +166,7 @@ def run_service(service_name, name=None, buildargs={}, print_logs=True, **kwargs
 
 def get_monitor_metrics_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
     metrics = set()
-    with open(json_path, "r") as fd:
+    with open(json_path, "r", encoding='utf-8') as fd:
         doc = yaml.load(fd.read())
         for mon in doc['Monitors']:
             if monitor == mon['monitorType'] and 'metrics' in mon.keys() and mon['metrics']:
@@ -176,7 +177,7 @@ def get_monitor_metrics_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
 
 def get_monitor_dims_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
     dims = set()
-    with open(json_path, "r") as fd:
+    with open(json_path, "r", encoding="utf-8") as fd:
         doc = yaml.load(fd.read())
         for mon in doc['Monitors']:
             if monitor == mon['monitorType'] and 'dimensions' in mon.keys() and mon['dimensions']:
@@ -187,10 +188,16 @@ def get_monitor_dims_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
 
 def get_observer_dims_from_selfdescribe(observer, json_path=SELFDESCRIBE_JSON):
     dims = set()
-    with open(json_path, "r") as fd:
+    with open(json_path, "r", encoding="utf-8") as fd:
         doc = yaml.load(fd.read())
         for obs in doc['Observers']:
             if observer == obs['observerType'] and 'dimensions' in obs.keys() and obs['dimensions']:
                 dims = set([dim['name'] for dim in obs['dimensions']])
                 break
     return dims
+
+
+def get_host_ip():
+    gws = ni.gateways()
+    interface = gws['default'][ni.AF_INET][1]
+    return ni.ifaddresses(interface)[ni.AF_INET][0]['addr']

--- a/tests/kubernetes/utils.py
+++ b/tests/kubernetes/utils.py
@@ -4,7 +4,6 @@ from kubernetes.client.rest import ApiException
 from tests.helpers.assertions import *
 from tests.helpers.util import *
 import docker
-import netifaces as ni
 import os
 import re
 import socket
@@ -94,12 +93,6 @@ def run_k8s_with_agent(agent_image, minikube, monitors, observer=None, namespace
                 image_tag=agent_image["tag"],
                 namespace=namespace) as agent:
                 yield [backend, agent]
-
-
-def get_host_ip():
-    gws = ni.gateways()
-    interface = gws['default'][ni.AF_INET][1]
-    return ni.ifaddresses(interface)[ni.AF_INET][0]['addr']
 
 
 def has_namespace(name):

--- a/tests/monitors/cassandra/cassandra_test.py
+++ b/tests/monitors/cassandra/cassandra_test.py
@@ -26,6 +26,7 @@ monitors:
     password: cassandra
 """)
 
+@pytest.mark.flaky(reruns=2)
 def test_cassandra():
     with run_service("cassandra") as cassandra_cont:
         config = cassandra_config.substitute(host=container_ip(cassandra_cont))

--- a/tests/monitors/couchbase/couchbase_test.py
+++ b/tests/monitors/couchbase/couchbase_test.py
@@ -27,6 +27,7 @@ monitors:
 """)
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("tag", [
     "enterprise-4.0.0",
     "enterprise-5.1.0"

--- a/tests/monitors/jenkins/jenkins_test.py
+++ b/tests/monitors/jenkins/jenkins_test.py
@@ -25,6 +25,7 @@ monitors:
 """)
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("version", [
     # technically we support 1.580.3, but the scripts needed to programmatically
     # setup jenkins do not work prior to 1.651.3

--- a/tests/monitors/kafka/kafka_test.py
+++ b/tests/monitors/kafka/kafka_test.py
@@ -58,6 +58,7 @@ def test_omitting_kafka_metrics(version="1.0.1"):
 
 versions = ["0.9.0.0", "0.10.0", "0.11.0", "1.0.0", "1.0.1", "1.1.1"]
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("version", versions)
 def test_all_kafka_monitors(version):
     with run_kafka(version) as kafka:

--- a/tests/monitors/marathon/marathon_test.py
+++ b/tests/monitors/marathon/marathon_test.py
@@ -15,6 +15,7 @@ monitors:
 """)
 
 
+@pytest.mark.flaky(reruns=2)
 @pytest.mark.parametrize("marathon_image", [
     "mesosphere/marathon:v1.1.1",
     "mesosphere/marathon:v1.6.352"

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -174,7 +174,7 @@ def run_init_system_image(base_image):
                 "api.signalfx.com": '127.0.0.2',
             },
         }
-        with run_container(image_id, wait_for_ip=False, **container_options) as cont:
+        with run_container(image_id, wait_for_ip=True, **container_options) as cont:
             # Proxy the backend calls through a fake HTTPS endpoint so that we
             # don't have to change the default configuration included by the
             # package.  The base_image used should trust the self-signed certs

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -11,7 +11,7 @@ import threading
 import time
 
 from tests.helpers import fake_backend
-from tests.helpers.util import get_docker_client, run_container, wait_for
+from tests.helpers.util import get_docker_client, run_container, wait_for, get_host_ip
 from tests.helpers.assertions import *
 
 PROJECT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
@@ -24,6 +24,9 @@ DOCKERFILES_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "image
 INIT_SYSV = "sysv"
 INIT_UPSTART = "upstart"
 INIT_SYSTEMD = "systemd"
+
+AGENT_YAML_PATH = "/etc/signalfx/agent.yaml"
+PIDFILE_PATH = "/var/run/signalfx-agent.pid"
 
 basic_config = """
 monitors:
@@ -156,10 +159,14 @@ def copy_file_into_container(path, container, target_path):
 
 
 @contextmanager
-def run_init_system_image(base_image):
+def run_init_system_image(base_image, with_socat=True):
     image_id = build_base_image(base_image)
     print("Image ID: %s" % image_id)
-    with fake_backend.start() as backend:
+    if with_socat:
+        backend_ip = '127.0.0.1'
+    else:
+        backend_ip = get_host_ip()
+    with fake_backend.start(ip=backend_ip) as backend:
         container_options = {
             # Init systems running in the container want permissions
             "privileged": True,
@@ -170,16 +177,35 @@ def run_init_system_image(base_image):
             "extra_hosts": {
                 # Socat will be running on localhost to forward requests to
                 # these hosts to the fake backend
-                "ingest.signalfx.com": '127.0.0.1',
-                "api.signalfx.com": '127.0.0.2',
-            },
+                "ingest.signalfx.com": backend.ingest_host,
+                "api.signalfx.com": backend.api_host,
+            }
         }
         with run_container(image_id, wait_for_ip=True, **container_options) as cont:
-            # Proxy the backend calls through a fake HTTPS endpoint so that we
-            # don't have to change the default configuration included by the
-            # package.  The base_image used should trust the self-signed certs
-            # included in the images dir so that the agent doesn't throw TLS
-            # verification errors.
-            with socat_https_proxy(cont, backend.ingest_host, backend.ingest_port, "ingest.signalfx.com", "127.0.0.1"), \
-                 socat_https_proxy(cont, backend.api_host, backend.api_port, "api.signalfx.com", "127.0.0.2"):
+            if with_socat:
+                # Proxy the backend calls through a fake HTTPS endpoint so that we
+                # don't have to change the default configuration included by the
+                # package.  The base_image used should trust the self-signed certs
+                # included in the images dir so that the agent doesn't throw TLS
+                # verification errors.
+                with socat_https_proxy(cont, backend.ingest_host, backend.ingest_port, "ingest.signalfx.com", "127.0.0.1"), \
+                     socat_https_proxy(cont, backend.api_host, backend.api_port, "api.signalfx.com", "127.0.0.2"):
+                    yield [cont, backend]
+            else:
                 yield [cont, backend]
+
+
+def is_agent_running_as_non_root(container):
+    code, output = container.exec_run("pgrep -u signalfx-agent signalfx-agent")
+    print("pgrep check: %s" % output)
+    return code == 0
+
+
+def path_exists_in_container(container, path):
+    code, _ = container.exec_run("test -e %s" % path)
+    return code == 0
+
+
+def get_container_file_content(container, path):
+    assert path_exists_in_container(container, path), "File %s does not exist!" % path
+    return container.exec_run("cat %s" % path)[1].decode('utf-8')

--- a/tests/packaging/images/Dockerfile.debian-9-stretch
+++ b/tests/packaging/images/Dockerfile.debian-9-stretch
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https
+    apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https systemd-sysv
 
 COPY socat /bin/socat
 

--- a/tests/packaging/images/Dockerfile.debian-9-stretch
+++ b/tests/packaging/images/Dockerfile.debian-9-stretch
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https systemd-sysv
+    apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https
 
 COPY socat /bin/socat
 

--- a/tests/packaging/installer_test.py
+++ b/tests/packaging/installer_test.py
@@ -25,7 +25,6 @@ from tests.helpers.assertions import *
 from tests.helpers.util import run_container, wait_for, print_lines
 
 pytestmark = pytest.mark.installer
-pytest.skip("installer tests are skipped by default", allow_module_level=True)
 
 
 def is_agent_running_as_non_root(container):
@@ -46,7 +45,6 @@ supported_distros = [
     ("centos7", INIT_SYSTEMD),
 ]
 
-@pytest.mark.installer
 @pytest.mark.parametrize("base_image,init_system", supported_distros)
 def test_intaller(base_image, init_system):
     with run_init_system_image(base_image) as [cont, backend]:

--- a/tests/packaging/installer_test.py
+++ b/tests/packaging/installer_test.py
@@ -6,31 +6,13 @@ import os
 import pytest
 import time
 
-from .common import (
-    INSTALLER_PATH,
-    INIT_SYSV,
-    INIT_UPSTART,
-    INIT_SYSTEMD,
-    build_base_image,
-    get_agent_logs,
-    get_rpm_package_to_test,
-    get_deb_package_to_test,
-    socat_https_proxy,
-    run_init_system_image,
-    copy_file_into_container,
-)
+from .common import *
 
 from tests.helpers import fake_backend
 from tests.helpers.assertions import *
 from tests.helpers.util import run_container, wait_for, print_lines
 
 pytestmark = pytest.mark.installer
-
-
-def is_agent_running_as_non_root(container):
-    code, output = container.exec_run("pgrep -u signalfx-agent signalfx-agent")
-    print("pgrep check: %s" % output)
-    return code == 0
 
 supported_distros = [
     ("debian-7-wheezy", INIT_SYSV),
@@ -61,14 +43,6 @@ def test_intaller(base_image, init_system):
         try:
             assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
             assert is_agent_running_as_non_root(cont), "Agent is not running as non-root user"
-
-            cont.stop(timeout=3)
-            cont.start()
-
-            backend.datapoints.clear()
-
-            assert wait_for(p(is_agent_running_as_non_root, cont)), "Agent is not running as non-root user"
-            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through after restart"
         finally:
             print("Agent log:")
             print_lines(get_agent_logs(cont, init_system))

--- a/tests/packaging/installer_test.py
+++ b/tests/packaging/installer_test.py
@@ -39,12 +39,14 @@ supported_distros = [
     ("debian-9-stretch", INIT_SYSTEMD),
     ("ubuntu1404", INIT_UPSTART),
     ("ubuntu1604", INIT_SYSTEMD),
+    ("ubuntu1804", INIT_SYSTEMD),
     ("amazonlinux1", INIT_UPSTART),
     ("amazonlinux2", INIT_SYSTEMD),
     ("centos6", INIT_UPSTART),
     ("centos7", INIT_SYSTEMD),
 ]
 
+@pytest.mark.installer
 @pytest.mark.parametrize("base_image,init_system", supported_distros)
 def test_intaller(base_image, init_system):
     with run_init_system_image(base_image) as [cont, backend]:

--- a/tests/packaging/package_test.py
+++ b/tests/packaging/package_test.py
@@ -6,19 +6,7 @@ import pytest
 import re
 import time
 
-from .common import (
-    build_base_image,
-    get_agent_logs,
-    get_rpm_package_to_test,
-    get_deb_package_to_test,
-    socat_https_proxy,
-    copy_file_into_container,
-    run_init_system_image,
-    INIT_SYSV,
-    INIT_UPSTART,
-    INIT_SYSTEMD,
-    INSTALLER_PATH,
-)
+from .common import *
 
 from tests.helpers import fake_backend
 from tests.helpers.assertions import *
@@ -30,9 +18,6 @@ PACKAGE_UTIL = {
     ".deb": "dpkg",
     ".rpm": "rpm",
 }
-
-AGENT_YAML_PATH = "/etc/signalfx/agent.yaml"
-PIDFILE_PATH = "/var/run/signalfx-agent.pid"
 
 INIT_START_TIMEOUT = 5
 INIT_STOP_TIMEOUT = 11
@@ -75,12 +60,6 @@ INIT_STATUS_OUTPUT = {
 }
 
 
-def is_agent_running_as_non_root(container):
-    code, output = container.exec_run("pgrep -u signalfx-agent signalfx-agent")
-    print("pgrep check: %s" % output)
-    return code == 0
-
-
 def get_agent_pid(container):
     command = "pgrep -u signalfx-agent -f /usr/bin/signalfx-agent"
     code, output = container.exec_run(command)
@@ -99,11 +78,6 @@ def agent_has_new_pid(container, old_pid):
     return wait_for(_new_pid, timeout_seconds=INIT_RESTART_TIMEOUT)
 
 
-def path_exists_in_container(container, path):
-    code, _ = container.exec_run("test -e %s" % path)
-    return code == 0
-
-
 def get_agent_yaml_diff(old_agent_yaml, new_agent_yaml):
     diff = "\n".join(
         difflib.unified_diff(
@@ -113,6 +87,25 @@ def get_agent_yaml_diff(old_agent_yaml, new_agent_yaml):
             tofile=AGENT_YAML_PATH,
             lineterm='')).strip()
     return diff
+
+
+def update_agent_yaml(container, backend, hostname="test-hostname"):
+    def set_option(name, value):
+        code, _ = container.exec_run("grep '^%s:' %s" % (name, AGENT_YAML_PATH))
+        if code == 0:
+            _, _ = container.exec_run("sed -i 's|^%s:.*|%s: %s|' %s" % (name, name, value, AGENT_YAML_PATH))
+        else:
+            _, _ = container.exec_run("bash -ec 'echo >> %s'" % AGENT_YAML_PATH)
+            _, _ = container.exec_run("bash -ec 'echo \"%s: %s\" >> %s'" % (name, value, AGENT_YAML_PATH))
+
+    assert path_exists_in_container(container, AGENT_YAML_PATH), "File %s does not exist!" % AGENT_YAML_PATH
+    if hostname:
+        set_option("hostname", hostname)
+    ingest_url = "http://%s:%d" % (backend.ingest_host, backend.ingest_port)
+    set_option("ingestUrl", ingest_url)
+    api_url = "http://%s:%d" % (backend.api_host, backend.api_port)
+    set_option("apiUrl", api_url)
+    return get_container_file_content(container, AGENT_YAML_PATH)
 
 
 def _test_service_status(container, init_system, expected_status):
@@ -166,23 +159,16 @@ def _test_service_stop(container, init_system, backend):
 
 def _test_system_restart(container, init_system, backend):
     print("Restarting container")
-    try:
-        container.stop(timeout=3)
-        backend.datapoints.clear()
-        container.start()
-        assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_RESTART_TIMEOUT)
-        _test_service_status(container, init_system, 'active')
-        assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
-    except docker.errors.APIError as e:
-        if not "id already in use" in str(e).lower():
-            raise e
-        else:
-            # possible intermittent bug with docker daemon not restarting containers correctly
-            print("Container failed to restart:\n%s" % str(e))
+    container.stop(timeout=3)
+    backend.datapoints.clear()
+    container.start()
+    assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_RESTART_TIMEOUT)
+    _test_service_status(container, init_system, 'active')
+    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
 
 
 def _test_package_install(base_image, package_path, init_system):
-    with run_init_system_image(base_image) as [cont, backend]:
+    with run_init_system_image(base_image, with_socat=False) as [cont, backend]:
         _, package_ext = os.path.splitext(package_path)
         copy_file_into_container(package_path, cont, "/opt/signalfx-agent%s" % package_ext)
 
@@ -196,16 +182,18 @@ def _test_package_install(base_image, package_path, init_system):
         print_lines(output)
         assert code == 0, "Package could not be installed!"
 
-        cont.exec_run("bash -ec 'echo -n testing > /etc/signalfx/token'")
+        cont.exec_run("bash -ec 'echo -n testing123 > /etc/signalfx/token'")
+        agent_yaml = update_agent_yaml(cont, backend, hostname="test-"+base_image)
 
         try:
             _test_service_list(cont, init_system)
-            _test_service_start(cont, init_system, backend)
-            _test_service_status(cont, init_system, 'active')
             _test_service_restart(cont, init_system, backend)
             _test_service_status(cont, init_system, 'active')
             _test_service_stop(cont, init_system, backend)
             _test_service_status(cont, init_system, 'inactive')
+            _test_service_start(cont, init_system, backend)
+            _test_service_status(cont, init_system, 'active')
+            _test_service_stop(cont, init_system, backend)
             _test_system_restart(cont, init_system, backend)
         finally:
             cont.reload()
@@ -215,25 +203,23 @@ def _test_package_install(base_image, package_path, init_system):
 
 
 def _test_package_upgrade(base_image, package_path, init_system):
-    with run_init_system_image(base_image) as [cont, backend]:
+    with run_init_system_image(base_image, with_socat=False) as [cont, backend]:
         _, package_ext = os.path.splitext(package_path)
         copy_file_into_container(package_path, cont, "/opt/signalfx-agent%s" % package_ext)
-        copy_file_into_container(INSTALLER_PATH, cont, "/opt/install.sh")
 
-        INSTALL_COMMAND = "sh /opt/install.sh testing123 --insecure --package-version 3.0.1-1"
+        INSTALL_COMMAND = {
+            ".rpm": "yum install -y https://s3.amazonaws.com/public-downloads--signalfuse-com/rpms/signalfx-agent/final/signalfx-agent-3.0.1-1.x86_64.rpm",
+            ".deb": "bash -ec 'wget -nv https://s3.amazonaws.com/public-downloads--signalfuse-com/debs/signalfx-agent/final/pool/signalfx-agent_3.0.1-1_amd64.deb && dpkg -i signalfx-agent_3.0.1-1_amd64.deb'"
+        }
 
-        code, output = cont.exec_run(INSTALL_COMMAND)
+        code, output = cont.exec_run(INSTALL_COMMAND[package_ext])
         print("Output of old package install:")
         print_lines(output)
         assert code == 0, "Old package could not be installed!"
 
-        assert path_exists_in_container(cont, AGENT_YAML_PATH), "%s does not exist!" % AGENT_YAML_PATH
-
-        _, _ = cont.exec_run("bash -ec 'echo >> %s'" % AGENT_YAML_PATH)
-        _, _ = cont.exec_run("bash -ec 'echo \"hostname: test-host\" >> %s'" % AGENT_YAML_PATH)
+        cont.exec_run("bash -ec 'echo -n testing123 > /etc/signalfx/token'")
+        old_agent_yaml = update_agent_yaml(cont, backend, hostname="test-"+base_image)
         _, _ = cont.exec_run("cp -f %s %s.orig" % (AGENT_YAML_PATH, AGENT_YAML_PATH))
-        _, output = cont.exec_run("cat %s" % AGENT_YAML_PATH)
-        old_agent_yaml = output.decode('utf-8')
 
         UPGRADE_COMMAND = {
             ".rpm": "yum --nogpgcheck update -y /opt/signalfx-agent.rpm",
@@ -245,15 +231,12 @@ def _test_package_upgrade(base_image, package_path, init_system):
         print_lines(output)
         assert code == 0, "Package could not be upgraded!"
 
-        assert path_exists_in_container(cont, AGENT_YAML_PATH), "%s does not exist after upgrade!" % AGENT_YAML_PATH
-
-        new_agent_yaml = cont.exec_run("cat %s" % AGENT_YAML_PATH)[1].decode('utf-8')
+        new_agent_yaml = get_container_file_content(cont, AGENT_YAML_PATH)
         diff = get_agent_yaml_diff(old_agent_yaml, new_agent_yaml)
         assert len(diff) == 0, "%s different after upgrade!\n%s" % (AGENT_YAML_PATH, diff)
 
         try:
             _test_service_list(cont, init_system)
-            _test_service_status(cont, init_system, 'active')
             _test_service_restart(cont, init_system, backend)
             _test_service_status(cont, init_system, 'active')
             _test_service_stop(cont, init_system, backend)

--- a/tests/packaging/package_test.py
+++ b/tests/packaging/package_test.py
@@ -2,6 +2,7 @@ from functools import partial as p
 import difflib
 import os
 import pytest
+import re
 import time
 
 from .common import (
@@ -29,10 +30,29 @@ PACKAGE_UTIL = {
     ".rpm": "rpm",
 }
 
+AGENT_YAML_PATH = "/etc/signalfx/agent.yaml"
+PIDFILE_PATH = "/var/run/signalfx-agent.pid"
+
+INIT_START_TIMEOUT = 5
+INIT_STOP_TIMEOUT = 11
+INIT_RESTART_TIMEOUT = INIT_STOP_TIMEOUT + INIT_START_TIMEOUT
+
 INIT_START_COMMAND = {
     INIT_SYSV: "service signalfx-agent start",
     INIT_UPSTART: "/etc/init.d/signalfx-agent start",
     INIT_SYSTEMD: "systemctl start signalfx-agent",
+}
+
+INIT_RESTART_COMMAND = {
+    INIT_SYSV: "service signalfx-agent restart",
+    INIT_UPSTART: "/etc/init.d/signalfx-agent restart",
+    INIT_SYSTEMD: "systemctl restart signalfx-agent",
+}
+
+INIT_STOP_COMMAND = {
+    INIT_SYSV: "service signalfx-agent stop",
+    INIT_UPSTART: "/etc/init.d/signalfx-agent stop",
+    INIT_SYSTEMD: "systemctl stop signalfx-agent",
 }
 
 INIT_LIST_COMMAND = {
@@ -47,11 +67,86 @@ INIT_STATUS_COMMAND = {
     INIT_SYSTEMD: "systemctl status signalfx-agent",
 }
 
+INIT_STATUS_OUTPUT = {
+    INIT_SYSV: {'active': "Running with pid", 'inactive': 'Not running'},
+    INIT_UPSTART: {'active': "Running with pid", 'inactive': 'Not running'},
+    INIT_SYSTEMD: {'active': 'Active: active (running)', 'inactive': 'Active: inactive (dead)'},
+}
+
 
 def is_agent_running_as_non_root(container):
     code, output = container.exec_run("pgrep -u signalfx-agent signalfx-agent")
     print("pgrep check: %s" % output)
     return code == 0
+
+
+def get_agent_pid(container):
+    command = "pgrep -u signalfx-agent -f /usr/bin/signalfx-agent"
+    code, output = container.exec_run(command)
+    output = output.decode('utf-8').strip()
+    if code == 0:
+        assert re.match('\d+', output), "Unexpected output from command '%s':\n%s" % (command, output)
+        return output
+    return None
+
+
+def agent_has_new_pid(container, old_pid):
+    def _new_pid():
+        pid = get_agent_pid(container)
+        return pid and pid != old_pid
+
+    return wait_for(_new_pid, timeout_seconds=INIT_RESTART_TIMEOUT)
+
+
+def container_file_exists(container, path):
+    code, _ = container.exec_run("test -f %s" % path)
+    return code == 0
+
+
+def _test_service_status(container, init_system, expected_status):
+    code, output = container.exec_run(INIT_STATUS_COMMAND[init_system])
+    print("Init status command output:")
+    print_lines(output)
+    assert INIT_STATUS_OUTPUT[init_system][expected_status] in output.decode('utf-8'), \
+        "'%s' expected in status output" % INIT_STATUS_OUTPUT[init_system][expected_status]
+
+
+def _test_service_list(container, init_system, service_name="signalfx-agent"):
+    code, output = container.exec_run(INIT_LIST_COMMAND[init_system])
+    print("Init list command output:")
+    print_lines(output)
+    assert code == 0, "Failed to get service list"
+    assert service_name in output.decode('utf-8'), "Agent service not registered"
+
+
+def _test_service_start(container, init_system, backend):
+    code, output = container.exec_run(INIT_START_COMMAND[init_system])
+    print("Init start command output:")
+    print_lines(output)
+    assert code == 0, "Agent could not be started"
+    assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_START_TIMEOUT)
+    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
+
+
+def _test_service_restart(container, init_system, backend):
+    old_pid = get_agent_pid(container)
+    code, output = container.exec_run(INIT_RESTART_COMMAND[init_system])
+    print("Init restart command output:")
+    print_lines(output)
+    assert code == 0, "Agent could not be restarted"
+    assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_RESTART_TIMEOUT)
+    assert agent_has_new_pid(container, old_pid), "Agent pid the same after service restart"
+    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
+
+
+def _test_service_stop(container, init_system):
+    code, output = container.exec_run(INIT_STOP_COMMAND[init_system])
+    print("Init stop command output:")
+    print_lines(output)
+    assert code == 0, "Agent could not be stop"
+    assert wait_for(lambda: not get_agent_pid(container), timeout_seconds=INIT_STOP_TIMEOUT), "Timed out waiting for agent process to stop"
+    if init_system in [INIT_SYSV, INIT_UPSTART]:
+        assert not container_file_exists(container, PIDFILE_PATH), "%s exists when agent is stopped" % PIDFILE_PATH
 
 
 def _test_package_install(base_image, package_path, init_system):
@@ -71,13 +166,14 @@ def _test_package_install(base_image, package_path, init_system):
 
         cont.exec_run("bash -ec 'echo -n testing > /etc/signalfx/token'")
 
-        code, output = cont.exec_run(INIT_START_COMMAND[init_system])
-        print("Init start command output:")
-        print_lines(output)
         try:
-            assert code == 0, "Agent could not be started"
-            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
-            assert is_agent_running_as_non_root(cont)
+            _test_service_list(cont, init_system)
+            _test_service_start(cont, init_system, backend)
+            _test_service_status(cont, init_system, 'active')
+            _test_service_restart(cont, init_system, backend)
+            _test_service_status(cont, init_system, 'active')
+            _test_service_stop(cont, init_system)
+            _test_service_status(cont, init_system, 'inactive')
         finally:
             print("Agent log:")
             print_lines(get_agent_logs(cont, init_system))
@@ -96,13 +192,12 @@ def _test_package_upgrade(base_image, package_path, init_system):
         print_lines(output)
         assert code == 0, "Old package could not be installed!"
 
-        code, output = cont.exec_run("test -f /etc/signalfx/agent.yaml")
-        assert code == 0, "/etc/signalfx/agent.yaml does not exist!"
+        assert container_file_exists(cont, AGENT_YAML_PATH), "%s does not exist!" % AGENT_YAML_PATH
 
-        _, _ = cont.exec_run("bash -ec 'echo >> /etc/signalfx/agent.yaml'")
-        _, _ = cont.exec_run("bash -ec 'echo \"hostname: test-host\" >> /etc/signalfx/agent.yaml'")
-        _, _ = cont.exec_run("cp -f /etc/signalfx/agent.yaml /etc/signalfx/agent.yaml.orig")
-        _, output = cont.exec_run("cat /etc/signalfx/agent.yaml")
+        _, _ = cont.exec_run("bash -ec 'echo >> %s'" % AGENT_YAML_PATH)
+        _, _ = cont.exec_run("bash -ec 'echo \"hostname: test-host\" >> %s'" % AGENT_YAML_PATH)
+        _, _ = cont.exec_run("cp -f %s %s.orig" % (AGENT_YAML_PATH, AGENT_YAML_PATH))
+        _, output = cont.exec_run("cat %s" % AGENT_YAML_PATH)
         old_agent_yaml = output.decode('utf-8')
 
         UPGRADE_COMMAND = {
@@ -115,31 +210,28 @@ def _test_package_upgrade(base_image, package_path, init_system):
         print_lines(output)
         assert code == 0, "Package could not be upgraded!"
 
-        code, output = cont.exec_run(INIT_STATUS_COMMAND[init_system])
-        print("Init status command output:")
-        print_lines(output)
-        assert code == 0, "Agent service not started after upgrade!"
+        assert container_file_exists(cont, AGENT_YAML_PATH), "%s does not exist after upgrade!" % AGENT_YAML_PATH
 
-        code, output = cont.exec_run(INIT_LIST_COMMAND[init_system])
-        print("Init list command output:")
-        print_lines(output)
-        assert code == 0, "Failed to get service list!"
-        assert "signalfx-agent" in output.decode('utf-8'), "Agent service not registered"
-
-        _, output = cont.exec_run("cat /etc/signalfx/agent.yaml")
+        _, output = cont.exec_run("cat %s" % AGENT_YAML_PATH)
         new_agent_yaml = output.decode('utf-8')
         diff = "\n".join(
             difflib.unified_diff(
                 old_agent_yaml.splitlines(),
                 new_agent_yaml.splitlines(),
-                fromfile="/etc/signalfx/agent.yaml.orig",
-                tofile="/etc/signalfx/agent.yaml",
+                fromfile="%s.orig" % AGENT_YAML_PATH,
+                tofile=AGENT_YAML_PATH,
                 lineterm='')).strip()
-        assert len(diff) == 0, "/etc/signalfx/agent.yaml different after upgrade!\n%s" % diff
+        assert len(diff) == 0, "%s different after upgrade!\n%s" % (AGENT_YAML_PATH, diff)
 
         try:
-            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
-            assert is_agent_running_as_non_root(cont)
+            _test_service_list(cont, init_system)
+            _test_service_status(cont, init_system, 'active')
+            _test_service_restart(cont, init_system, backend)
+            _test_service_status(cont, init_system, 'active')
+            _test_service_stop(cont, init_system)
+            _test_service_status(cont, init_system, 'inactive')
+            _test_service_start(cont, init_system, backend)
+            _test_service_status(cont, init_system, 'active')
         finally:
             print("Agent log:")
             print_lines(get_agent_logs(cont, init_system))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,3 +10,4 @@ pytest-html
 semver==2.8.0
 redis==2.10.6
 requests==2.19.1
+pytest-rerunfailures==4.1


### PR DESCRIPTION
- Added service and system (container) restart tests.
- Added installer_tests to circleci workflow.
- Marked flaky integration tests to allow re-runs.
- Includes an update to the sysv/upstart service files that pins the names of the pid and log files to "signalfx-agent" on system reboot (see https://signalfuse.atlassian.net/browse/INT-689).