### PR TITLE
Allow node name to stay in the env if referenced in config

### DIFF
--- a/internal/core/config/loader.go
+++ b/internal/core/config/loader.go
@@ -133,6 +133,10 @@ var envVarRE = regexp.MustCompile(`\${\s*([\w-]+?)\s*}`)
 // still get to them when we need to rerender config
 var envVarCache = make(map[string]string)
 
+var envVarWhitelist = map[string]bool{
+	"MY_NODE_NAME": true,
+}
+
 // Replaces envvar syntax with the actual envvars
 func preprocessConfig(content []byte) []byte {
 	return envVarRE.ReplaceAllFunc(content, func(bs []byte) []byte {
@@ -149,7 +153,9 @@ func preprocessConfig(content []byte) []byte {
 				"envvar": envvar,
 			}).Debug("Sanitizing envvar from agent")
 
-			os.Unsetenv(envvar)
+			if !envVarWhitelist[envvar] {
+				os.Unsetenv(envvar)
+			}
 		}
 
 		return []byte(val)


### PR DESCRIPTION
This is a quick workaround for being able to disable host networking and use the node name as the hostname and as the kubelet url without breaking the other k8s modules that look for this envvar.

It is not a sensitive secret value so whitelisting it should be fine.