### PR TITLE
Minor wording fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Kubernetes](https://docs.signalfx.com/en/latest/integrations/kubernetes-quicksta
 for more information.
 
 #### AWS Elastic Container Service (ECS)
-See the [ECS directory in this repo](./deployments/ecs) that includes a sample
+See the [ECS directory](./deployments/ecs), which includes a sample
 config and task definition for the agent.
 
 ### Bundles


### PR DESCRIPTION
Removed "in this repo", since it doesn't make sense when the file is ported to the user docs. No need to fix and re-run script before this week's push.