### PR TITLE
Make docker memory.percent metric exclude page cache usage

### DIFF
--- a/docs/monitors/docker-container-stats.md
+++ b/docs/monitors/docker-container-stats.md
@@ -63,6 +63,7 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `cpu.usage.system` | cumulative |  | Jiffies of CPU time used by the system |
 | `cpu.usage.total` | cumulative |  | Jiffies of CPU time used by the container |
 | `cpu.usage.usermode` | cumulative | X | Jiffies of CPU time spent in user mode by the container |
+| `memory.percent` | gauge | X | Percent of memory (0-100) used by the container relative to its limit (excludes page cache usage) |
 | `memory.stats.swap` | gauge | X | Bytes of swap memory used by container |
 | `memory.usage.limit` | gauge |  | Memory usage limit of the container, in bytes |
 | `memory.usage.max` | gauge | X | Maximum measured memory usage of the container, in bytes |
@@ -96,6 +97,7 @@ metricsToExclude:
   - cpu.throttling_data.throttled_time
   - cpu.usage.kernelmode
   - cpu.usage.usermode
+  - memory.percent
   - memory.stats.swap
   - memory.usage.max
   - network.usage.rx_dropped

--- a/internal/monitors/docker/conversion.go
+++ b/internal/monitors/docker/conversion.go
@@ -133,7 +133,8 @@ func convertMemoryStats(stats *dtypes.MemoryStats) []*datapoint.Datapoint {
 		sfxclient.Gauge("memory.usage.max", nil, int64(stats.MaxUsage)),
 		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage)),
 		sfxclient.GaugeF("memory.percent", nil,
-			100.0*float64(stats.Usage)/float64(stats.Limit)),
+			// If cache is not present it will use the default value of 0
+			100.0*(float64(stats.Usage)-float64(stats.Stats["cache"]))/float64(stats.Limit)),
 	}...)
 
 	for k, v := range stats.Stats {

--- a/internal/monitors/docker/metricdoc.go
+++ b/internal/monitors/docker/metricdoc.go
@@ -40,6 +40,9 @@ package docker
 
 // CUMULATIVE(cpu.usage.usermode): Jiffies of CPU time spent in user mode by the container
 
+// GAUGE(memory.percent): Percent of memory (0-100) used by the container
+// relative to its limit (excludes page cache usage)
+
 // GAUGE(memory.stats.swap): Bytes of swap memory used by container
 
 // GAUGE(memory.usage.limit): Memory usage limit of the container, in bytes

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -9912,6 +9912,11 @@
           "description": "Jiffies of CPU time spent in user mode by the container"
         },
         {
+          "name": "memory.percent",
+          "type": "gauge",
+          "description": "Percent of memory (0-100) used by the container relative to its limit (excludes page cache usage)"
+        },
+        {
           "name": "memory.stats.swap",
           "type": "gauge",
           "description": "Bytes of swap memory used by container"

--- a/tests/monitors/docker_container_stats/docker_container_stats_test.py
+++ b/tests/monitors/docker_container_stats/docker_container_stats_test.py
@@ -18,7 +18,12 @@ def test_docker_container_stats():
 
     """
         ) as [backend, _, _]:
-            assert wait_for(p(has_datapoint_with_metric_name, backend, "cpu.percent")), "Didn't get docker datapoints"
+            assert wait_for(
+                p(has_datapoint_with_metric_name, backend, "cpu.percent")
+            ), "Didn't get docker cpu datapoints"
+            assert wait_for(
+                p(has_datapoint_with_metric_name, backend, "memory.percent")
+            ), "Didn't get docker memory datapoints"
             assert wait_for(
                 p(has_datapoint_with_dim, backend, "container_id", nginx_container.id)
             ), "Didn't get nginx datapoints"


### PR DESCRIPTION
This corresponds to https://github.com/signalfx/docker-collectd-plugin/pull/35 in the collectd plugin for docker.