### PR TITLE
Allow envvars to map to dimensions in docker-container-stats

### DIFF
--- a/docs/monitors/docker-container-stats.md
+++ b/docs/monitors/docker-container-stats.md
@@ -32,6 +32,7 @@ Monitor Type: `docker-container-stats`
 | `dockerURL` | no | `string` | The URL of the docker server (**default:** `unix:///var/run/docker.sock`) |
 | `timeoutSeconds` | no | `integer` | The maximum amount of time to wait for docker API requests (**default:** `5`) |
 | `labelsToDimensions` | no | `map of string` | A mapping of container label names to dimension names. The corresponding label values will become the dimension value for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a dimension called `container_spec_name` that has the value of the `io.kubernetes.container.name` container label. |
+| `envToDimensions` | no | `map of string` | A mapping of container environment variable names to dimension names.  The corresponding env var values become the dimension values on the emitted metrics.  E.g. `APP_VERSION: version` would result in datapoints having a dimension called `version` whose value is the value of the `APP_VERSION` envvar configured for that particular container, if present. |
 | `excludedImages` | no | `list of string` | A list of filters of images to exclude.  Supports literals, globs, and regex. |
 
 

--- a/internal/monitors/docker/conversion.go
+++ b/internal/monitors/docker/conversion.go
@@ -47,6 +47,7 @@ func convertStatsToMetrics(container *dtypes.ContainerJSON, cstats *dtypes.Conta
 		dps[i].Dimensions["plugin_instance"] = name
 		dps[i].Dimensions["container_image"] = container.Config.Image
 		dps[i].Dimensions["container_id"] = container.ID
+		dps[i].Dimensions["container_hostname"] = container.Config.Hostname
 	}
 
 	return dps, nil

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -9898,6 +9898,14 @@
           "elementKind": "string"
         },
         {
+          "yamlName": "envToDimensions",
+          "doc": "A mapping of container environment variable names to dimension names.  The corresponding env var values become the dimension values on the emitted metrics.  E.g. `APP_VERSION: version` would result in datapoints having a dimension called `version` whose value is the value of the `APP_VERSION` envvar configured for that particular container, if present.",
+          "default": null,
+          "required": false,
+          "type": "map",
+          "elementKind": "string"
+        },
+        {
           "yamlName": "excludedImages",
           "doc": "A list of filters of images to exclude.  Supports literals, globs, and regex.",
           "default": null,

--- a/tests/monitors/docker_container_stats/docker_container_stats_test.py
+++ b/tests/monitors/docker_container_stats/docker_container_stats_test.py
@@ -60,6 +60,22 @@ def test_docker_label_dimensions():
             ), "Didn't get datapoint with service dim"
 
 
+def test_docker_envvar_dimensions():
+    with run_service("nginx", environment={"APP": "myserver"}):
+        with run_agent(
+            """
+    monitors:
+      - type: docker-container-stats
+        envToDimensions:
+          APP: app
+
+    """
+        ) as [backend, _, _]:
+            assert wait_for(
+                p(has_datapoint_with_dim, backend, "app", "myserver")
+            ), "Didn't get datapoint with service app"
+
+
 def test_docker_detects_new_containers():
     with run_agent(
         """


### PR DESCRIPTION
Also adding `docker_hostname` dimension that maps to the hostname of the docker container itself.