### PR TITLE
Disable k8s deployment linking

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/cache.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cache.go
@@ -162,14 +162,16 @@ type propertyLink struct {
 // them to the cache
 func (dc *DatapointCache) addDimPropsToCache(key cachedResourceKey, dimProps *atypes.DimProperties) {
 	links := []propertyLink{
-		propertyLink{
-			SourceKind:     "ReplicaSet",
-			SourceProperty: "deployment",
-			SourceJoinKey:  "name",
-			TargetKind:     "Pod",
-			TargetProperty: "deployment",
-			TargetJoinKey:  "replicaSet",
-		},
+		// TODO: disable linking until we figure out a more efficient way of
+		// doing this.  This DOESN'T scale with 1000s of pods/resources.
+		//propertyLink{
+		//	SourceKind:     "ReplicaSet",
+		//	SourceProperty: "deployment",
+		//	SourceJoinKey:  "name",
+		//	TargetKind:     "Pod",
+		//	TargetProperty: "deployment",
+		//	TargetJoinKey:  "replicaSet",
+		//},
 	}
 
 	for _, link := range links {


### PR DESCRIPTION
It is not efficient at all and causes high CPU usage in large clusters

Will be reenabled when we figure out a good way to do it