### PR TITLE
Fix regression in Redis key length config

### DIFF
--- a/internal/monitors/collectd/redis/redis.go
+++ b/internal/monitors/collectd/redis/redis.go
@@ -86,6 +86,14 @@ func (c *Config) PythonConfig() *python.Config {
 	return c.pyConf
 }
 
+func (c *Config) sendListLengthsTuples() [][]interface{} {
+	var out [][]interface{}
+	for _, ll := range c.SendListLengths {
+		out = append(out, []interface{}{ll.DBIndex, ll.KeyPattern})
+	}
+	return out
+}
+
 // Monitor is the main type that represents the monitor
 type Monitor struct {
 	python.PyMonitor
@@ -107,12 +115,15 @@ func (rm *Monitor) Configure(conf *Config) error {
 		ModulePaths:   []string{collectd.MakePath("redis")},
 		TypesDBPaths:  []string{collectd.MakePath("types.db")},
 		PluginConfig: map[string]interface{}{
-			"Host":                                 conf.Host,
-			"Port":                                 conf.Port,
-			"Instance":                             instanceID,
-			"Auth":                                 conf.Auth,
-			"Name":                                 conf.Name,
-			"SendListLength":                       conf.SendListLengths,
+			"Host":     conf.Host,
+			"Port":     conf.Port,
+			"Instance": instanceID,
+			"Auth":     conf.Auth,
+			"Name":     conf.Name,
+			"SendListLength": map[string]interface{}{
+				"#flatten": true,
+				"values":   conf.sendListLengthsTuples(),
+			},
 			"Verbose":                              false,
 			"Redis_uptime_in_seconds":              "gauge",
 			"Redis_used_cpu_sys":                   "counter",

--- a/tests/monitors/redis/redis_test.py
+++ b/tests/monitors/redis/redis_test.py
@@ -1,11 +1,13 @@
 import os
 import string
+from contextlib import contextmanager
 from functools import partial as p
+from textwrap import dedent
 
 import pytest
 import redis
 
-from helpers.assertions import has_datapoint_with_dim, tcp_socket_open
+from helpers.assertions import has_datapoint, tcp_socket_open
 from helpers.kubernetes.utils import get_discovery_rule, run_k8s_monitors_test
 from helpers.util import (
     container_ip,
@@ -24,25 +26,53 @@ monitors:
 - type: collectd/redis
   host: $host
   port: 6379
-  sendListLengths:
-  - databaseIndex: 0
-    keyPattern: '*'
 """
 )
 
 
-@pytest.mark.parametrize("image", ["redis:3-alpine", "redis:4-alpine"])
-def test_redis(image):
-    with run_container(image) as test_container:
-        host = container_ip(test_container)
-        config = MONITOR_CONFIG.substitute(host=host)
+@contextmanager
+def run_redis(image="redis:4-alpine"):
+    with run_container(image) as redis_container:
+        host = container_ip(redis_container)
         assert wait_for(p(tcp_socket_open, host, 6379), 60), "service not listening on port"
 
         redis_client = redis.StrictRedis(host=host, port=6379, db=0)
         assert wait_for(redis_client.ping, 60), "service didn't start"
 
+        yield [host, redis_client]
+
+
+@pytest.mark.parametrize("image", ["redis:3-alpine", "redis:4-alpine"])
+def test_redis(image):
+    with run_redis(image) as [hostname, _]:
+        config = MONITOR_CONFIG.substitute(host=hostname)
         with run_agent(config) as [backend, _, _]:
-            assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "redis_info")), "didn't get datapoints"
+            assert wait_for(p(has_datapoint, backend, dimensions={"plugin": "redis_info"})), "didn't get datapoints"
+
+
+def test_redis_key_lengths():
+    with run_redis() as [hostname, redis_client]:
+        redis_client.lpush("queue-1", *["a", "b", "c"])
+        redis_client.lpush("queue-2", *["x", "y"])
+
+        config = dedent(
+            f"""
+          monitors:
+           - type: collectd/redis
+             host: {hostname}
+             port: 6379
+             sendListLengths:
+              - databaseIndex: 0
+                keyPattern: queue-*
+        """
+        )
+        with run_agent(config) as [backend, _, _]:
+            assert wait_for(
+                p(has_datapoint, backend, metric_name="gauge.key_llen", dimensions={"key_name": "queue-1"}, value=3)
+            ), "didn't get datapoints"
+            assert wait_for(
+                p(has_datapoint, backend, metric_name="gauge.key_llen", dimensions={"key_name": "queue-2"}, value=2)
+            ), "didn't get datapoints"
 
 
 @pytest.mark.k8s


### PR DESCRIPTION
It didn't get converted properly when we switched to the custom Python runner.

Fixes #521 