### PR TITLE
Make internal-metrics monitor more generic

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -29,10 +29,8 @@ by the `-config` flag to the agent binary (`signalfx-agent`).
 | `metricsToExclude` | no | [list of object (see below)](#metricstoexclude) | A list of metric filters |
 | `propertiesToExclude` | no | [list of object (see below)](#propertiestoexclude) | A list of properties filters |
 | `pythonEnabled` | no | bool | (**NOT FUNCTIONAL**) Whether to enable the Python sub-agent ("neopy") that can directly use DataDog and Collectd Python plugins.  This is not the same as Collectd's Python plugin, which is always enabled. (**default:** `false`) |
-| `diagnosticsNamedPipePath` | no | string | The path where the agent will create a named pipe and serve diagnostic output (windows only) (**default:** `"\\\\.\\pipe\\signalfx-agent-diagnostics"`) |
-| `diagnosticsSocketPath` | no | string | The path where the agent will create UNIX socket and serve diagnostic output (linux only) (**default:** `"/var/run/signalfx-agent/diagnostics.sock"`) |
-| `internalMetricsNamedPipePath` | no | string | The path where the agent will create a named pipe that serves internal metrics (used by the internal-metrics monitor) (windows only) (**default:** `"\\\\.\\pipe\\signalfx-agent-internal-metrics"`) |
-| `internalMetricsSocketPath` | no | string | The path where the agent will create a socket that serves internal metrics (used by the internal-metrics monitor) (linux only) (**default:** `"/var/run/signalfx-agent/internal-metrics.sock"`) |
+| `internalStatusHost` | no | string | The host on which the internal status server will listen.  The internal status HTTP server serves internal metrics and diagnostic information about the agent and can be scraped by the `internal-metrics` monitor. Can be set to `0.0.0.0` if you want to monitor the agent from another host.  If you set this to blank/null, the internal status server will not be started. (**default:** `"localhost"`) |
+| `internalStatusPort` | no | integer | The port on which the internal status server will listen.  See `internalMetricsHost`. (**default:** `8095`) |
 | `profiling` | no | bool | Enables Go pprof endpoint on port 6060 that serves profiling data for development (**default:** `false`) |
 | `bundleDir` | no | string | Path to the directory holding the agent dependencies.  This will normally be derived automatically. Overrides the envvar SIGNALFX_BUNDLE_DIR if set. |
 | `scratch` | no | any | This exists purely to give the user a place to put common yaml values to reference in other parts of the config file. |
@@ -306,10 +304,8 @@ where applicable:
   metricsToExclude: []
   propertiesToExclude: []
   pythonEnabled: false
-  diagnosticsNamedPipePath: "\\\\.\\pipe\\signalfx-agent-diagnostics"
-  diagnosticsSocketPath: "/var/run/signalfx-agent/diagnostics.sock"
-  internalMetricsNamedPipePath: "\\\\.\\pipe\\signalfx-agent-internal-metrics"
-  internalMetricsSocketPath: "/var/run/signalfx-agent/internal-metrics.sock"
+  internalStatusHost: "localhost"
+  internalStatusPort: 8095
   profiling: false
   bundleDir: 
   scratch: 

--- a/docs/monitors/internal-metrics.md
+++ b/docs/monitors/internal-metrics.md
@@ -6,6 +6,11 @@
 agent.  Useful for debugging performance issues with the agent and to ensure
 the agent isn't overloaded.
 
+This can also scrape any HTTP endpoint that exposes metrics as a JSON array
+containing JSON-formatted SignalFx datapoint objects.  It is roughly
+analogous to the `prometheus-exporter` monitor except for SignalFx
+datapoints.
+
 ```yaml
 monitors:
   - type: internal-metrics
@@ -22,7 +27,13 @@ Monitor Type: `internal-metrics`
 
 ## Configuration
 
-This monitor has no configuration options.
+| Config option | Required | Type | Description |
+| --- | --- | --- | --- |
+| `host` | no | `string` | Defaults to the top-level `internalStatusHost` option |
+| `port` | no | `integer` | Defaults to the top-level `internalStatusPort` option |
+| `path` | no | `string` | The HTTP request path to use to retrieve the metrics (**default:** `/metrics`) |
+
+
 
 
 ## Metrics

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -84,19 +84,16 @@ type Config struct {
 	// the same as Collectd's Python plugin, which is always enabled.
 	PythonEnabled bool `yaml:"pythonEnabled" default:"false"`
 
-	DiagnosticsServerPath string `yaml:"-"`
-	// The path where the agent will create a named pipe and serve diagnostic output (windows only)
-	DiagnosticsServerNamedPipePath string `yaml:"diagnosticsNamedPipePath" default:"\\\\.\\pipe\\signalfx-agent-diagnostics" copyTo:"DiagnosticsServerPath,GOOS=windows"`
-	// The path where the agent will create UNIX socket and serve diagnostic output (linux only)
-	DiagnosticsSocketPath string `yaml:"diagnosticsSocketPath" default:"/var/run/signalfx-agent/diagnostics.sock" copyTo:"DiagnosticsServerPath,GOOS=!windows"`
-
-	InternalMetricsServerPath string `yaml:"-"`
-	// The path where the agent will create a named pipe that serves internal
-	// metrics (used by the internal-metrics monitor) (windows only)
-	InternalMetricsServerNamedPipePath string `yaml:"internalMetricsNamedPipePath" default:"\\\\.\\pipe\\signalfx-agent-internal-metrics" copyTo:"InternalMetricsServerPath,GOOS=windows"`
-	// The path where the agent will create a socket that serves internal
-	// metrics (used by the internal-metrics monitor) (linux only)
-	InternalMetricsSocketPath string `yaml:"internalMetricsSocketPath" default:"/var/run/signalfx-agent/internal-metrics.sock" copyTo:"InternalMetricsServerPath,GOOS=!windows"`
+	// The host on which the internal status server will listen.  The internal
+	// status HTTP server serves internal metrics and diagnostic information
+	// about the agent and can be scraped by the `internal-metrics` monitor.
+	// Can be set to `0.0.0.0` if you want to monitor the agent from another
+	// host.  If you set this to blank/null, the internal status server will
+	// not be started.
+	InternalStatusHost string `yaml:"internalStatusHost" default:"localhost"`
+	// The port on which the internal status server will listen.  See
+	// `internalMetricsHost`.
+	InternalStatusPort uint16 `yaml:"internalStatusPort" default:"8095"`
 
 	// Enables Go pprof endpoint on port 6060 that serves profiling data for
 	// development

--- a/internal/core/meta/meta.go
+++ b/internal/core/meta/meta.go
@@ -6,5 +6,6 @@ package meta
 // access.
 // TODO: get rid of this since it's hacky
 type AgentMeta struct {
-	InternalMetricsServerPath string
+	InternalStatusHost string
+	InternalStatusPort uint16
 }

--- a/internal/selfdescribe/reflect.go
+++ b/internal/selfdescribe/reflect.go
@@ -48,6 +48,9 @@ func getDefault(f reflect.StructField) interface{} {
 		return nil
 	}
 	if f.Type.Kind() != reflect.Struct {
+		if f.Tag.Get("noDefault") == "true" {
+			return nil
+		}
 		return reflect.Zero(f.Type).Interface()
 	}
 	return nil

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -10441,9 +10441,34 @@
     },
     {
       "name": "Config",
-      "doc": " Emits metrics about the internal state of the\nagent.  Useful for debugging performance issues with the agent and to ensure\nthe agent isn't overloaded.\n\n```yaml\nmonitors:\n  - type: internal-metrics\n```\n",
+      "doc": " Emits metrics about the internal state of the\nagent.  Useful for debugging performance issues with the agent and to ensure\nthe agent isn't overloaded.\n\nThis can also scrape any HTTP endpoint that exposes metrics as a JSON array\ncontaining JSON-formatted SignalFx datapoint objects.  It is roughly\nanalogous to the `prometheus-exporter` monitor except for SignalFx\ndatapoints.\n\n```yaml\nmonitors:\n  - type: internal-metrics\n```\n",
       "package": "internal/monitors/internalmetrics",
-      "fields": [],
+      "fields": [
+        {
+          "yamlName": "host",
+          "doc": "Defaults to the top-level `internalStatusHost` option",
+          "default": "",
+          "required": false,
+          "type": "string",
+          "elementKind": ""
+        },
+        {
+          "yamlName": "port",
+          "doc": "Defaults to the top-level `internalStatusPort` option",
+          "default": null,
+          "required": false,
+          "type": "uint16",
+          "elementKind": ""
+        },
+        {
+          "yamlName": "path",
+          "doc": "The HTTP request path to use to retrieve the metrics",
+          "default": "/metrics",
+          "required": false,
+          "type": "string",
+          "elementKind": ""
+        }
+      ],
       "monitorType": "internal-metrics",
       "acceptsEndpoints": false,
       "singleInstance": false,
@@ -13035,35 +13060,19 @@
         "elementKind": ""
       },
       {
-        "yamlName": "diagnosticsNamedPipePath",
-        "doc": "The path where the agent will create a named pipe and serve diagnostic output (windows only)",
-        "default": "\\\\.\\pipe\\signalfx-agent-diagnostics",
+        "yamlName": "internalStatusHost",
+        "doc": "The host on which the internal status server will listen.  The internal status HTTP server serves internal metrics and diagnostic information about the agent and can be scraped by the `internal-metrics` monitor. Can be set to `0.0.0.0` if you want to monitor the agent from another host.  If you set this to blank/null, the internal status server will not be started.",
+        "default": "localhost",
         "required": false,
         "type": "string",
         "elementKind": ""
       },
       {
-        "yamlName": "diagnosticsSocketPath",
-        "doc": "The path where the agent will create UNIX socket and serve diagnostic output (linux only)",
-        "default": "/var/run/signalfx-agent/diagnostics.sock",
+        "yamlName": "internalStatusPort",
+        "doc": "The port on which the internal status server will listen.  See `internalMetricsHost`.",
+        "default": 8095,
         "required": false,
-        "type": "string",
-        "elementKind": ""
-      },
-      {
-        "yamlName": "internalMetricsNamedPipePath",
-        "doc": "The path where the agent will create a named pipe that serves internal metrics (used by the internal-metrics monitor) (windows only)",
-        "default": "\\\\.\\pipe\\signalfx-agent-internal-metrics",
-        "required": false,
-        "type": "string",
-        "elementKind": ""
-      },
-      {
-        "yamlName": "internalMetricsSocketPath",
-        "doc": "The path where the agent will create a socket that serves internal metrics (used by the internal-metrics monitor) (linux only)",
-        "default": "/var/run/signalfx-agent/internal-metrics.sock",
-        "required": false,
-        "type": "string",
+        "type": "uint16",
         "elementKind": ""
       },
       {


### PR DESCRIPTION
It can pull any arbitrary HTTP server at any path.

As part of this I made the status and internal metrics served on an embedded HTTP server instead
of through separate unix domain sockets