### PR TITLE
Fix metric type conversions from pyrunner

### DIFF
--- a/internal/utils/collectdutil/conversion.go
+++ b/internal/utils/collectdutil/conversion.go
@@ -1,8 +1,11 @@
 package collectdutil
 
 import (
+	"strings"
+
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/event"
+	"github.com/signalfx/golib/pointer"
 	"github.com/signalfx/metricproxy/protocol/collectd"
 	"github.com/signalfx/signalfx-agent/internal/utils"
 )
@@ -16,6 +19,10 @@ func ConvertWriteFormat(f *collectd.JSONWriteFormat, dps *[]*datapoint.Datapoint
 		event := collectd.NewEvent(f, nil)
 		*events = append(*events, event)
 	} else {
+		// The converter below expects dstypes to be lower case
+		for i := range f.Dstypes {
+			f.Dstypes[i] = pointer.String(strings.ToLower(*f.Dstypes[i]))
+		}
 		for i := range f.Dsnames {
 			if i < len(f.Dstypes) && i < len(f.Values) && f.Values[i] != nil {
 				dp := collectd.NewDatapoint(f, uint(i), nil)

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -43,7 +43,7 @@ def has_datapoint_with_dim(fake_services, key, value):
     return has_datapoint_with_all_dims(fake_services, {key: value})
 
 
-def has_datapoint(fake_services, metric_name=None, dimensions=None, value=None):
+def has_datapoint(fake_services, metric_name=None, dimensions=None, value=None, metric_type=None):
     """
     Returns True if there is a datapoint seen in the fake_services backend that
     has the given attributes.  If a property is not specified it will not be
@@ -54,6 +54,8 @@ def has_datapoint(fake_services, metric_name=None, dimensions=None, value=None):
         if metric_name and dp.metric != metric_name:
             continue
         if dimensions and not has_all_dims(dp, dimensions):
+            continue
+        if metric_type and dp.metricType != metric_type:
             continue
         if value is not None:
             if dp.value.HasField("intValue"):


### PR DESCRIPTION
The converted in metricproxy code is case sensitive and we had upper case