### PR TITLE
Make init.d script status command exit with 1 when not running

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,8 +293,8 @@ jobs:
     steps:
       - checkout
       - run: |
-          if ! scripts/changes-include-dir Dockerfile packaging/<< parameters.package_type >> tests/packaging; then
-              echo "<< parameters.package_type >> packaging code has not changed, skipping tests!"
+          if ! scripts/changes-include-dir Dockerfile packaging tests/packaging; then
+              echo "packaging code has not changed, skipping tests!"
               touch ~/.skip
               exit 0
           fi

--- a/packaging/etc/init.d/signalfx-agent.debian
+++ b/packaging/etc/init.d/signalfx-agent.debian
@@ -105,6 +105,7 @@ case "$1" in
         echo "Running with pid `get_pid`"
       else
         echo "Not running"
+        exit 1
       fi
     ;;
 

--- a/packaging/etc/init.d/signalfx-agent.rhel
+++ b/packaging/etc/init.d/signalfx-agent.rhel
@@ -103,6 +103,7 @@ case "$1" in
       echo "Running with pid `get_pid`"
     else
       echo "Not running"
+      exit 1
     fi
     ;;
 


### PR DESCRIPTION
Some orchestration tools (e.g. Puppet) rely on this behavior.