### PR TITLE
Remove unused default monitors

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -37,10 +37,8 @@ This role sources the following variables:
         - type: collectd/interface
         - type: collectd/load
         - type: collectd/memory
-        - type: collectd/protocols
         - type: collectd/signalfx-metadata
         - type: host-metadata
-        - type: collectd/uptime
         - type: collectd/vmem
     ```
 

--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -8,8 +8,6 @@ sfx_agent_config:
     - type: collectd/interface
     - type: collectd/load
     - type: collectd/memory
-    - type: collectd/protocols
     - type: collectd/signalfx-metadata
     - type: host-metadata
-    - type: collectd/uptime
     - type: collectd/vmem

--- a/deployments/docker/agent.yaml
+++ b/deployments/docker/agent.yaml
@@ -29,10 +29,8 @@ monitors:
   - type: collectd/interface
   - type: collectd/load
   - type: collectd/memory
-  - type: collectd/protocols
   - type: collectd/signalfx-metadata
   - type: host-metadata
-  - type: collectd/uptime
   - type: collectd/vmem
   - type: docker-container-stats
 

--- a/deployments/ecs/agent.yaml
+++ b/deployments/ecs/agent.yaml
@@ -43,10 +43,8 @@ monitors:
   - type: collectd/interface
   - type: collectd/load
   - type: collectd/memory
-  - type: collectd/protocols
   - type: collectd/signalfx-metadata
   - type: host-metadata
-  - type: collectd/uptime
   - type: collectd/vmem
 
   - type: docker-container-stats

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -38,10 +38,8 @@ data:
     - type: collectd/interface
     - type: collectd/load
     - type: collectd/memory
-    - type: collectd/protocols
     - type: collectd/signalfx-metadata
     - type: host-metadata
-    - type: collectd/uptime
     - type: collectd/vmem
 
     - type: collectd/processes

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -51,10 +51,8 @@ signalfx-agent:
       - type: collectd/interface
       - type: collectd/load
       - type: collectd/memory
-      - type: collectd/protocols
       - type: collectd/signalfx-metadata
       - type: host-metadata
-      - type: collectd/uptime
       - type: collectd/vmem
 ```
 

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -12,7 +12,5 @@ signalfx-agent:
       - type: collectd/interface
       - type: collectd/load
       - type: collectd/memory
-      - type: collectd/protocols
       - type: collectd/signalfx-metadata
-      - type: collectd/uptime
       - type: collectd/vmem

--- a/docs/monitors/collectd-protocols.md
+++ b/docs/monitors/collectd-protocols.md
@@ -30,7 +30,7 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Custom | Description |
 | ---  | ---  | ---    | ---         |
-| `protocol_counter.ActiveOpens` | cumulative |  | The number of times TCP connections transitioned from the CLOSED state to the SYN-SENT state. |
+| `protocol_counter.ActiveOpens` | cumulative | X | The number of times TCP connections transitioned from the CLOSED state to the SYN-SENT state. |
 | `protocol_counter.CurrEstab` | cumulative | X | The number of TCP connections currently in either ESTABLISHED or CLOSE-WAIT state. |
 | `protocol_counter.DelayedACKs` | cumulative | X | The number of acknowledgements delayed by TCP Delayed Acknowledgement |
 | `protocol_counter.InDestUnreachs` | cumulative | X | The number of ICMP Destination Unreachable messages received |
@@ -52,6 +52,7 @@ required for gathering additional metrics.
 
 metricsToInclude:
   - metricNames:
+    - protocol_counter.ActiveOpens
     - protocol_counter.CurrEstab
     - protocol_counter.DelayedACKs
     - protocol_counter.InDestUnreachs

--- a/docs/monitors/collectd-uptime.md
+++ b/docs/monitors/collectd-uptime.md
@@ -26,7 +26,7 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Custom | Description |
 | ---  | ---  | ---    | ---         |
-| `uptime` | gauge |  | Seconds since system boot |
+| `uptime` | gauge | X | Seconds since system boot |
 
 
 To specify custom metrics you want to monitor, add a `metricsToInclude` filter
@@ -43,6 +43,7 @@ required for gathering additional metrics.
 
 metricsToInclude:
   - metricNames:
+    - uptime
     monitorType: collectd/uptime
 ```
 

--- a/packaging/etc/agent.yaml
+++ b/packaging/etc/agent.yaml
@@ -24,9 +24,7 @@ monitors:
   - type: collectd/interface
   - type: collectd/load
   - type: collectd/memory
-  - type: collectd/protocols
   - type: collectd/signalfx-metadata
-  - type: collectd/uptime
   - type: collectd/vmem
 
 metricsToExclude:

--- a/whitelist.json
+++ b/whitelist.json
@@ -299,13 +299,6 @@
         ]
     },
     {
-        "monitorType": "collectd/protocols",
-        "negated": true,
-        "metricNames": [
-            "protocol_counter.ActiveOpens"
-        ]
-    },
-    {
         "monitorType": "collectd/consul",
         "negated": true,
         "metricNames": [
@@ -865,13 +858,6 @@
         "metricNames": [
             "vmpage_io.swap.in",
             "vmpage_io.swap.out"
-        ]
-    },
-    {
-        "monitorType": "collectd/uptime",
-        "negated": true,
-        "metricNames": [
-            "uptime"
         ]
     },
     {


### PR DESCRIPTION
Turns out collectd/uptime and collectd/protocols aren't used in our built in content anywhere.  In fact they each have 1 metric in the whitelist only because they're in our default configs and the script to generate from content didn't pick them up.  So they're effectively running for no reason on most deployments.  Let's remove these from our default configs.  Anyone who needs them can add them like they do with any other non-default monitor.