### PR TITLE
fix using downgrades on old apt versions

### DIFF
--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'SignalFx, Inc.'
 maintainer_email 'support@signalfx.com'
 license 'Apache-2.0'
 description 'Installs/Configures the SignalFx Agent'
-version '0.1.0'
+version '0.1.1'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 supports 'amazon'

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -33,7 +33,9 @@ end
 package 'signalfx-agent' do  # ~FC009
   action :install
   version node['signalfx_agent']['package_version'] if !node['signalfx_agent']['package_version'].nil?
-  options '--allow-downgrades' if platform_family?('debian')
+  options '--allow-downgrades' if platform_family?('debian') \
+    && node['packages']['apt'] \
+    && Gem::Version.new(node['packages']['apt']['version']) >= Gem::Version.new('1.1.0')
   allow_downgrade true if platform_family?('rhel', 'amazon', 'fedora')
   notifies :restart, 'service[signalfx-agent]', :delayed
 end


### PR DESCRIPTION
`--allow-downgrades` was introduces in apt 1.1

Closes #581 