### PR TITLE
Ensure Chef package cache is busted before installing agent package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,15 +330,13 @@ jobs:
           make dev-image
           case "$DEPLOYMENT" in
           chef)
-              docker run --rm \
-                  signalfx-agent-chef-dev \
-                  chef exec rspec --format RspecJunitFormatter > ~/testresults/chefspec.xml
-              docker run --rm \
-                  signalfx-agent-chef-dev \
-                  foodcritic .
-              docker run --rm \
-                  signalfx-agent-chef-dev \
-                  cookstyle .
+              CHEF_DEV="docker run --rm \
+                  --workdir /chef-repo/cookbooks/signalfx_agent \
+                  signalfx-agent-chef-dev"
+
+              $CHEF_DEV chef exec rspec --format RspecJunitFormatter > ~/testresults/chefspec.xml
+              $CHEF_DEV foodcritic .
+              $CHEF_DEV cookstyle .
               ;;
           puppet)
               docker run --rm \

--- a/deployments/chef/Dockerfile
+++ b/deployments/chef/Dockerfile
@@ -6,5 +6,7 @@ RUN apt update &&\
 RUN wget -O /tmp/chefdk.deb https://packages.chef.io/files/stable/chefdk/3.7.23/ubuntu/16.04/chefdk_3.7.23-1_amd64.deb &&\
     dpkg -i /tmp/chefdk.deb
 
-WORKDIR /chef-repo/cookbooks/signalfx_agent
-COPY ./ ./
+COPY ./ /tmp/cookbook
+WORKDIR /chef-repo
+
+RUN berks vendor -b /tmp/cookbook/Berksfile cookbooks/

--- a/deployments/chef/Dockerfile.centos
+++ b/deployments/chef/Dockerfile.centos
@@ -5,5 +5,7 @@ RUN yum install -y wget
 RUN wget -O /tmp/chefdk.rpm https://packages.chef.io/files/stable/chefdk/3.7.23/el/7/chefdk-3.7.23-1.el7.x86_64.rpm &&\
     rpm -i /tmp/chefdk.rpm
 
-WORKDIR /chef-repo/cookbooks/signalfx_agent
-COPY ./ ./
+COPY ./ /tmp/cookbook
+WORKDIR /chef-repo
+
+RUN berks vendor -b /tmp/cookbook/Berksfile cookbooks/

--- a/deployments/chef/recipes/default.rb
+++ b/deployments/chef/recipes/default.rb
@@ -35,6 +35,7 @@ else
   package 'signalfx-agent' do # ~FC009
     action :install
     version node['signalfx_agent']['package_version'] unless node['signalfx_agent']['package_version'].nil?
+    flush_cache [ :before ] if platform_family?('rhel')
     options '--allow-downgrades' if platform_family?('debian') \
       && node['packages']['apt'] \
       && Gem::Version.new(node['packages']['apt']['version']) >= Gem::Version.new('1.1.0')

--- a/deployments/chef/release
+++ b/deployments/chef/release
@@ -9,13 +9,13 @@ version_from_metadata() {
 }
 
 run_knife_command() {
-	docker run \
-		--rm \
-		-v $SCRIPT_DIR:/chef-repo/cookbooks/signalfx_agent \
-		-v $HOME/.chef:/root/.chef \
-    --workdir /chef-repo \
-		signalfx-agent-chef-dev \
-    knife $@
+  docker run \
+      --rm \
+      -v $SCRIPT_DIR:/chef-repo/cookbooks/signalfx_agent \
+      -v $HOME/.chef:/root/.chef \
+      --workdir /chef-repo \
+      signalfx-agent-chef-dev \
+      knife $@
 }
 
 has_existing_version() {


### PR DESCRIPTION
It will not get busted fast enough (if at all) if the repo gets added and quickly is attempted to be installed.

Also adding dependent cookbooks to the helper Docker images for dev.