### PR TITLE
Don't use host networking in dev image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,9 @@ run-dev-image:
 		$(extra_run_flags) \
 		--cap-add DAC_READ_SEARCH \
 		--cap-add SYS_PTRACE \
-		--net host \
 		-p 6060:6060 \
+		-p 9080:9080 \
+		-p 8095:8095 \
 		--name signalfx-agent-dev \
 		-v $(CURDIR)/local-etc:/etc/signalfx \
 		-v $(CURDIR):/go/src/github.com/signalfx/signalfx-agent:cached \


### PR DESCRIPTION
This allows forwarding ports to the host when using Docker for Mac