### PR TITLE
Sync deployment name and UID to kubernetes_pod_uid

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/cache.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cache.go
@@ -32,6 +32,7 @@ type DatapointCache struct {
 	uidKindCache               map[types.UID]string
 	podCache                   *k8sutil.PodCache
 	serviceCache               *k8sutil.ServiceCache
+	replicaSetCache            *k8sutil.ReplicaSetCache
 	useNodeName                bool
 	nodeConditionTypesToReport []string
 }
@@ -44,6 +45,7 @@ func NewDatapointCache(useNodeName bool, nodeConditionTypesToReport []string) *D
 		uidKindCache:               make(map[types.UID]string),
 		podCache:                   k8sutil.NewPodCache(),
 		serviceCache:               k8sutil.NewServiceCache(),
+		replicaSetCache:            k8sutil.NewReplicaSetCache(),
 		useNodeName:                useNodeName,
 		nodeConditionTypesToReport: nodeConditionTypesToReport,
 	}
@@ -68,6 +70,8 @@ func (dc *DatapointCache) DeleteByKey(key interface{}) {
 		dc.podCache.DeleteByKey(cacheKey)
 	case "Service":
 		dc.handleDeleteService(cacheKey)
+	case "ReplicaSet":
+		dc.replicaSetCache.DeleteByKey(cacheKey)
 	}
 	delete(dc.uidKindCache, cacheKey)
 	delete(dc.dpCache, cacheKey)
@@ -114,8 +118,7 @@ func (dc *DatapointCache) HandleAdd(newObj runtime.Object) interface{} {
 		dimProps = dimPropsForDeployment(o)
 		kind = "Deployment"
 	case *v1beta1.ReplicaSet:
-		dps = datapointsForReplicaSet(o)
-		dimProps = dimPropsForReplicaSet(o)
+		dps, dimProps = dc.handleAddReplicaSet(o)
 		kind = "ReplicaSet"
 	case *v1.ResourceQuota:
 		dps = datapointsForResourceQuota(o)
@@ -156,15 +159,6 @@ func (dc *DatapointCache) HandleAdd(newObj runtime.Object) interface{} {
 	return key
 }
 
-type propertyLink struct {
-	SourceProperty string
-	SourceKind     string
-	SourceJoinKey  string
-	TargetProperty string
-	TargetKind     string
-	TargetJoinKey  string
-}
-
 // addDimPropsToCache maps and syncs properties from different resources together and adds
 // them to the cache
 func (dc *DatapointCache) addDimPropsToCache(key types.UID, dimProps *atypes.DimProperties) {
@@ -181,7 +175,7 @@ func (dc *DatapointCache) handleAddPod(pod *v1.Pod) ([]*datapoint.Datapoint,
 	cachedPod := dc.podCache.GetCachedPod(pod.UID)
 	dps := datapointsForPod(pod)
 	if cachedPod != nil {
-		dimProps := dimPropsForPod(cachedPod, dc.serviceCache)
+		dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
 		return dps, dimProps
 	}
 	return dps, nil
@@ -197,7 +191,7 @@ func (dc *DatapointCache) handleAddService(svc *v1.Service) {
 			for _, podUID := range dc.podCache.GetPodsInNamespace(svc.Namespace) {
 				cachedPod := dc.podCache.GetCachedPod(podUID)
 				if cachedPod != nil {
-					dimProps := dimPropsForPod(cachedPod, dc.serviceCache)
+					dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
 					if dimProps != nil {
 						dc.addDimPropsToCache(podUID, dimProps)
 					}
@@ -210,16 +204,35 @@ func (dc *DatapointCache) handleAddService(svc *v1.Service) {
 // handleDeleteService will remove a service from the internal cache
 // and remove the service tags on it's matching pods.
 func (dc *DatapointCache) handleDeleteService(svcUID types.UID) {
-	pods := dc.serviceCache.DeleteByKey(svcUID)
-	for _, podUID := range pods {
+	for _, podUID := range dc.serviceCache.DeleteByKey(svcUID) {
 		cachedPod := dc.podCache.GetCachedPod(podUID)
 		if cachedPod != nil {
-			dimProps := dimPropsForPod(cachedPod, dc.serviceCache)
+			dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
 			if dimProps != nil {
 				dc.addDimPropsToCache(podUID, dimProps)
 			}
 		}
 	}
+}
+
+// handleAddReplicaSet adds a replicaset to the internal cache and
+// returns the datapoints and dimProps for the replicaset.
+func (dc *DatapointCache) handleAddReplicaSet(rs *v1beta1.ReplicaSet) ([]*datapoint.Datapoint, *atypes.DimProperties) {
+	if !dc.replicaSetCache.IsCached(rs) {
+		dc.replicaSetCache.AddReplicaSet(rs)
+		for _, podUID := range dc.podCache.GetPodsInNamespace(rs.Namespace) {
+			cachedPod := dc.podCache.GetCachedPod(podUID)
+			if cachedPod != nil {
+				dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
+				if dimProps != nil {
+					dc.addDimPropsToCache(podUID, dimProps)
+				}
+			}
+		}
+	}
+	dps := datapointsForReplicaSet(rs)
+	dimProps := dimPropsForReplicaSet(rs)
+	return dps, dimProps
 }
 
 // AllDatapoints returns all of the cached datapoints.

--- a/internal/monitors/kubernetes/cluster/metrics/deployments.go
+++ b/internal/monitors/kubernetes/cluster/metrics/deployments.go
@@ -32,7 +32,7 @@ func datapointsForDeployment(dep *v1beta1.Deployment) []*datapoint.Datapoint {
 
 func dimPropsForDeployment(dep *v1beta1.Deployment) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(dep.Labels)
-	props["name"] = dep.Name
+	props["deployment"] = dep.Name
 
 	for _, or := range dep.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/utils/podcache.go
+++ b/internal/monitors/kubernetes/utils/podcache.go
@@ -69,6 +69,9 @@ func (pc *PodCache) AddPod(pod *v1.Pod) {
 func (pc *PodCache) DeleteByKey(key types.UID) {
 	namespace := pc.cachedPods[key].Namespace
 	delete(pc.namespacePodUIDCache[namespace], key)
+	if len(pc.namespacePodUIDCache[namespace]) == 0 {
+		delete(pc.namespacePodUIDCache, namespace)
+	}
 	delete(pc.cachedPods, key)
 }
 

--- a/internal/monitors/kubernetes/utils/replicasetcache.go
+++ b/internal/monitors/kubernetes/utils/replicasetcache.go
@@ -1,0 +1,103 @@
+package utils
+
+import (
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type replicasetSet map[types.UID]bool
+
+// ReplicaSetCache is used for holding values we care about from a replicaset
+// for quicker lookup than querying the API for them each time.
+type ReplicaSetCache struct {
+	namespaceRsUIDCache map[string]replicasetSet
+	cachedReplicaSets   map[types.UID]*CachedReplicaSet
+}
+
+// NewReplicaSetCache creates a new replicaset cache
+func NewReplicaSetCache() *ReplicaSetCache {
+	return &ReplicaSetCache{
+		namespaceRsUIDCache: make(map[string]replicasetSet),
+		cachedReplicaSets:   make(map[types.UID]*CachedReplicaSet),
+	}
+}
+
+// CachedReplicaSet is used for holding only the neccesarry fields we need
+// for syncing deployment name and UID to pods
+type CachedReplicaSet struct {
+	UID           types.UID
+	Name          string
+	Namespace     string
+	Deployment    *string
+	DeploymentUID types.UID
+}
+
+func newCachedReplicaSet(rs *v1beta1.ReplicaSet) *CachedReplicaSet {
+	var deployment *string
+	var deploymentUID types.UID
+	for _, or := range rs.OwnerReferences {
+		if or.Kind == "Deployment" {
+			deployment = &or.Name
+			deploymentUID = or.UID
+			break
+		}
+	}
+
+	return &CachedReplicaSet{
+		UID:           rs.UID,
+		Name:          rs.Name,
+		Namespace:     rs.Namespace,
+		Deployment:    deployment,
+		DeploymentUID: deploymentUID,
+	}
+}
+
+// IsCached checks if a replicaset is already in the cache or if any of the
+// the cached fields have changed.
+func (rsc *ReplicaSetCache) IsCached(rs *v1beta1.ReplicaSet) bool {
+	cachedRs, exists := rsc.cachedReplicaSets[rs.UID]
+
+	return exists &&
+		(cachedRs.Name == rs.Name) &&
+		(cachedRs.Namespace == rs.Namespace)
+}
+
+// AddReplicaSet adds or updates a replicaset in the cache
+// This function should only be called after rs.IsCached
+// to prevent unneccesary updates to the internal cache.
+func (rsc *ReplicaSetCache) AddReplicaSet(rs *v1beta1.ReplicaSet) {
+	// check if any replicaset exist in this replicaset namespace yet
+	if _, exists := rsc.namespaceRsUIDCache[rs.Namespace]; !exists {
+		rsc.namespaceRsUIDCache[rs.Namespace] = make(map[types.UID]bool)
+	}
+	rsc.cachedReplicaSets[rs.UID] = newCachedReplicaSet(rs)
+	rsc.namespaceRsUIDCache[rs.Namespace][rs.UID] = true
+}
+
+// Delete removes a replicaset from the cache
+func (rsc *ReplicaSetCache) Delete(rs *v1beta1.ReplicaSet) {
+	rsc.DeleteByKey(rs.UID)
+}
+
+// DeleteByKey removes a replicaset from the cache given a UID
+func (rsc *ReplicaSetCache) DeleteByKey(rsUID types.UID) {
+	namespace := rsc.cachedReplicaSets[rsUID].Namespace
+	delete(rsc.namespaceRsUIDCache[namespace], rsUID)
+	delete(rsc.cachedReplicaSets, rsUID)
+}
+
+// GetMatchingDeployment finds a matching replicaset given
+// a namespace and a replicaSet name
+func (rsc *ReplicaSetCache) GetMatchingDeployment(namespace string, replicaSetName string) (*string, types.UID) {
+	var dpName *string
+	var dpUID types.UID
+	for rsUID := range rsc.namespaceRsUIDCache[namespace] {
+		cachedRs := rsc.cachedReplicaSets[rsUID]
+		if cachedRs.Name == replicaSetName {
+			dpName = cachedRs.Deployment
+			dpUID = cachedRs.DeploymentUID
+			break
+		}
+	}
+	return dpName, dpUID
+}

--- a/internal/monitors/kubernetes/utils/servicecache.go
+++ b/internal/monitors/kubernetes/utils/servicecache.go
@@ -96,6 +96,9 @@ func (sc *ServiceCache) DeleteByKey(svcUID types.UID) []types.UID {
 	}
 	namespace := sc.cachedServices[svcUID].Namespace
 	delete(sc.namespaceSvcUIDCache[namespace], svcUID)
+	if len(sc.namespaceSvcUIDCache[namespace]) == 0 {
+		delete(sc.namespaceSvcUIDCache, namespace)
+	}
 	delete(sc.cachedServices, svcUID)
 
 	return pods

--- a/internal/neotest/k8s/testhelpers/fakek8s/fakek8s.go
+++ b/internal/neotest/k8s/testhelpers/fakek8s/fakek8s.go
@@ -56,6 +56,11 @@ func NewFakeK8s() *FakeK8s {
 	}
 
 	r := mux.NewRouter()
+
+	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("POST")
+	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("PUT")
+	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("DELETE")
+
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
 	r.HandleFunc(`/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
 
@@ -63,6 +68,9 @@ func NewFakeK8s() *FakeK8s {
 	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
 	r.HandleFunc("/apis/extensions/v1beta1/{resource}", f.handleListResource).Methods("GET")
 	r.HandleFunc("/api/v1/{resource}", f.handleListResource).Methods("GET")
+
+	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleCreateOrReplaceResource).Methods("POST")
+	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}", f.handleDeleteResource).Methods("DELETE")
 
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}`, f.handleCreateOrReplaceResource).Methods("POST")
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleCreateOrReplaceResource).Methods("PUT")

--- a/tests/helpers/assertions.py
+++ b/tests/helpers/assertions.py
@@ -312,7 +312,7 @@ def has_dim_prop(fake_services, dim_name, dim_value, prop_name, prop_value=None)
     Tests if the given dimension has a property.  If prop_value is None, tests
     for the presence of the property regardless of value.
     """
-    dim = fake_services.dims[dim_name][dim_value]
+    dim = fake_services.dims[dim_name].get(dim_value, {})
     props = dim.get("customProperties", {})
     if props is not None:
         return prop_name in props and props.get(prop_name) == prop_value

--- a/tests/helpers/profiling.py
+++ b/tests/helpers/profiling.py
@@ -14,6 +14,10 @@ class PProfClient:
     def _base_url(self):
         return f"http://{self.host}:{self.port}"
 
+    def fetch_heap(self):
+        resp = requests.get(f"{self._base_url}/debug/pprof/heap")
+        return resp.content
+
     def fetch_goroutines(self):
         resp = requests.get(f"{self._base_url}/debug/pprof/goroutine")
         return resp.content
@@ -27,5 +31,16 @@ class PProfClient:
         with open(path, "wb") as fd:
             print(f"Saving goroutines to {path}")
             fd.write(self.fetch_goroutines())
+
+        return path
+
+    def save_heap(self):
+        """
+        Saves the pprof heap stack output to a tmpfile and returns the
+        path
+        """
+        path = f"/tmp/pprof/heap.{self.host}-{self.port}"
+        with open(path, "wb") as fd:
+            fd.write(self.fetch_heap())
 
         return path

--- a/tests/monitors/kubernetes_cluster/perf_test.py
+++ b/tests/monitors/kubernetes_cluster/perf_test.py
@@ -229,3 +229,185 @@ def test_service_tag_sync():
             assert (
                 backend.datapoints_by_metric["sfxagent.go_heap_alloc"][-1].value.intValue < 200 * 1024 * 1024
             ), "too much memory used"
+
+
+# pylint: disable=too-many-locals
+def test_large_k8s_cluster_deployment_prop():
+    """
+    Creates 50 replica sets with 100 pods per replica set.
+    Check that the deployment name is being synced to
+    kubernetes_pod_uid, which is taken off the replica set's
+    owner references.
+    """
+    dp_count = 50
+    pods_per_dp = 100
+    with fake_k8s_api_server(print_logs=True) as [fake_k8s_client, k8s_envvars]:
+        v1_client = client.CoreV1Api(fake_k8s_client)
+        v1beta1_client = client.ExtensionsV1beta1Api(fake_k8s_client)
+
+        ## create small subset of resources in a different namespace to get baseline of heap usage
+        v1_client.create_namespace(body={"apiVersion": "v1", "kind": "Namespace", "metadata": {"name": "dev"}})
+        for i in range(0, 10):
+            v1_client.create_namespaced_pod(
+                body={
+                    "apiVersion": "v1",
+                    "kind": "Pod",
+                    "metadata": {"name": f"pod-{i}", "uid": f"abcpod{i}", "namespace": "dev"},
+                    "spec": {},
+                },
+                namespace="dev",
+            )
+
+        with run_agent(
+            dedent(
+                f"""
+          writer:
+            maxRequests: 100
+            propertiesMaxRequests: 100
+            propertiesHistorySize: 10000
+          monitors:
+           - type: internal-metrics
+             intervalSeconds: 1
+           - type: kubernetes-cluster
+             alwaysClusterReporter: true
+             intervalSeconds: 10
+             kubernetesAPI:
+                skipVerify: true
+                authType: none
+        """
+            ),
+            profile=True,
+            debug=False,
+            extra_env=k8s_envvars,
+        ) as [backend, _, _, pprof_client]:
+            assert wait_for(p(has_datapoint, backend, dimensions={"kubernetes_pod_name": "pod-0"}))
+            assert wait_for(p(has_datapoint, backend, dimensions={"kubernetes_pod_name": "pod-9"}))
+
+            ## get heap baseline heap usage
+            time.sleep(10)
+            pprof_client.save_goroutines()
+            heap_usage_baseline = backend.datapoints_by_metric["sfxagent.go_heap_alloc"][-1].value.intValue
+
+            ## create 50 replica sets with 100 pods each
+            replicaSets = {}
+            for i in range(0, dp_count):
+                dp_name = f"dp-{i}"
+                dp_uid = f"dpuid{i}"
+                rs_name = dp_name + "-replicaset"
+                rs_uid = dp_uid + "-rs"
+                replicaSets[rs_uid] = {
+                    "dp_name": dp_name,
+                    "dp_uid": dp_uid,
+                    "rs_name": rs_name,
+                    "rs_uid": rs_uid,
+                    "pod_uids": [],
+                    "pod_names": [],
+                }
+
+                v1beta1_client.create_namespaced_replica_set(
+                    body={
+                        "apiVersion": "extensions/v1beta1",
+                        "kind": "ReplicaSet",
+                        "metadata": {
+                            "name": rs_name,
+                            "uid": rs_uid,
+                            "namespace": "default",
+                            "ownerReferences": [{"kind": "Deployment", "name": dp_name, "uid": dp_uid}],
+                        },
+                        "spec": {},
+                        "status": {},
+                    },
+                    namespace="default",
+                )
+
+                for j in range(0, pods_per_dp):
+                    pod_name = f"pod-{rs_name}-{j}"
+                    pod_uid = f"abcdef{i}-{j}"
+                    replicaSets[rs_uid]["pod_uids"].append(pod_uid)
+                    replicaSets[rs_uid]["pod_names"].append(pod_name)
+                    v1_client.create_namespaced_pod(
+                        body={
+                            "apiVersion": "v1",
+                            "kind": "Pod",
+                            "metadata": {
+                                "name": pod_name,
+                                "uid": pod_uid,
+                                "namespace": "default",
+                                "labels": {"app": "my-app"},
+                                "ownerReferences": [{"kind": "ReplicaSet", "name": rs_name, "uid": rs_uid}],
+                            },
+                            "spec": {},
+                        },
+                        namespace="default",
+                    )
+
+            def has_all_deployment_props():
+                for _, rs in replicaSets.items():
+                    for pod_uid in rs["pod_uids"]:
+                        if not has_dim_prop(
+                            backend,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="deployment",
+                            prop_value=rs["dp_name"],
+                        ):
+                            return False
+                        if not has_dim_prop(
+                            backend,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="deployment_uid",
+                            prop_value=rs["dp_uid"],
+                        ):
+                            return False
+                    return True
+
+            def has_all_replicaSet_props():
+                for _, rs in replicaSets.items():
+                    for pod_uid in rs["pod_uids"]:
+                        if not has_dim_prop(
+                            backend,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="replicaSet",
+                            prop_value=rs["rs_name"],
+                        ):
+                            return False
+                        if not has_dim_prop(
+                            backend,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="replicaSet_uid",
+                            prop_value=rs["rs_uid"],
+                        ):
+                            return False
+                    return True
+
+            assert wait_for(p(has_datapoint, backend, dimensions={"kubernetes_pod_name": "pod-dp-0-replicaset-0"}))
+            assert wait_for(p(has_datapoint, backend, dimensions={"kubernetes_pod_name": "pod-dp-49-replicaset-99"}))
+
+            assert wait_for(has_all_deployment_props, interval_seconds=2)
+
+            for _, rs in replicaSets.items():
+                v1beta1_client.delete_namespaced_replica_set(name=rs["rs_name"], namespace="default", body={})
+                for pod_name in rs["pod_names"]:
+                    v1_client.delete_namespaced_pod(name=pod_name, namespace="default", body={})
+
+            def go_routines():
+                pprof_client.save_goroutines()
+                return backend.datapoints_by_metric["sfxagent.go_num_goroutine"][-1].value.intValue < 100
+
+            assert wait_for(go_routines, interval_seconds=2, timeout_seconds=60)
+
+            def heap_baselined():
+                pprof_client.save_goroutines()
+                heap_usage = backend.datapoints_by_metric["sfxagent.go_heap_alloc"][-1].value.intValue
+                print("-------------------------")
+                print(heap_usage_baseline)
+                print(heap_usage)
+                return (
+                    backend.datapoints_by_metric["sfxagent.go_heap_alloc"][-1].value.intValue
+                    < 1.25 * heap_usage_baseline
+                )
+
+            assert wait_for(heap_baselined, interval_seconds=2, timeout_seconds=60)


### PR DESCRIPTION
This adds a new internal ReplicaSet cache for the Kubernetes cluster monitor.

Since we cache Pods and their OwnerReferences already (which may be a ReplicaSet), using a ReplicaSet cache we can look up a Pods deployment by looking at the pod's owners owner, aka a deployment.

New properties syncing to `kubernetes_pod_uid`: `deployment` and `deployment_uid`

Change in property syncing to `kubernetes_uid` for deployment metrics: `name` --> `deployment` so that we can filter in the UI pods and deployments using the same property

