### PR TITLE
Enable sendTraceHostCorrelationMetrics by default

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -138,7 +138,7 @@ The **nested** `writer` config object has the following fields:
 | `logEvents` | no | bool | The analogue of `logDatapoints` for events. (**default:** `false`) |
 | `logTraceSpans` | no | bool | The analogue of `logDatapoints` for trace spans. (**default:** `false`) |
 | `logDroppedDatapoints` | no | bool | If true, and the log level is `debug`, filtered out datapoints will be logged. (**default:** `false`) |
-| `sendTraceHostCorrelationMetrics` | no | bool | Whether to send host correlation metrics to correlation traced services with the underlying host (**default:** `false`) |
+| `sendTraceHostCorrelationMetrics` | no | bool | Whether to send host correlation metrics to correlation traced services with the underlying host (**default:** `true`) |
 | `staleServiceTimeout` | no | int64 | How long to wait after a trace span's service name is last seen to continue sending the correlation datapoints for that service.  This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if `sendTraceHostCorrelationMetrics` is false. (**default:** `"5m"`) |
 | `traceHostCorrelationMetricsInterval` | no | int64 | How frequently to send host correlation metrics that are generated from the service name seen in trace spans sent through or by the agent.  This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if `sendTraceHostCorrelationMetrics` is false. (**default:** `"1m"`) |
 | `maxTraceSpansInFlight` | no | unsigned integer | How many trace spans are allowed to be in the process of sending.  While this number is exceeded, existing pending spans will be randomly dropped if possible to accommodate new spans generated to avoid memory exhaustion.  If you see log messages about "Aborting pending trace requests..." or "Dropping new trace spans..." it means that the downstream target for traces is not able to accept them fast enough. Usually if the downstream is offline you will get connection refused errors and most likely spans will not build up in the agent (there is no retry mechanism). In the case of slow downstreams, you might be able to increase `maxRequests` to increase the concurrent stream of spans downstream (if the target can make efficient use of additional connections) or, less likely, increase `traceSpanMaxBatchSize` if your batches are maxing out (turn on debug logging to see the batch sizes being sent) and being split up too much. If neither of those options helps, your downstream is likely too slow to handle the volume of trace spans and should be upgraded to more powerful hardware/networking. (**default:** `100000`) |
@@ -338,7 +338,7 @@ where applicable:
     logEvents: false
     logTraceSpans: false
     logDroppedDatapoints: false
-    sendTraceHostCorrelationMetrics: false
+    sendTraceHostCorrelationMetrics: true
     staleServiceTimeout: "5m"
     traceHostCorrelationMetricsInterval: "1m"
     maxTraceSpansInFlight: 100000

--- a/internal/core/config/writer.go
+++ b/internal/core/config/writer.go
@@ -67,7 +67,7 @@ type WriterConfig struct {
 	LogDroppedDatapoints bool `yaml:"logDroppedDatapoints"`
 	// Whether to send host correlation metrics to correlation traced services
 	// with the underlying host
-	SendTraceHostCorrelationMetrics *bool `yaml:"sendTraceHostCorrelationMetrics" default:"false"`
+	SendTraceHostCorrelationMetrics *bool `yaml:"sendTraceHostCorrelationMetrics" default:"true"`
 	// How long to wait after a trace span's service name is last seen to
 	// continue sending the correlation datapoints for that service.  This
 	// should be a duration string that is accepted by

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -18119,7 +18119,7 @@
             {
               "yamlName": "sendTraceHostCorrelationMetrics",
               "doc": "Whether to send host correlation metrics to correlation traced services with the underlying host",
-              "default": false,
+              "default": true,
               "required": false,
               "type": "bool",
               "elementKind": ""

--- a/tests/basic/traces_test.py
+++ b/tests/basic/traces_test.py
@@ -49,7 +49,6 @@ def test_tracing_output():
             f"""
         hostname: "testhost"
         writer:
-            sendTraceHostCorrelationMetrics: true
             traceHostCorrelationMetricsInterval: 1s
             staleServiceTimeout: 5s
         monitors:


### PR DESCRIPTION
There isn't much reason to disable this if doing tracing now that it is pretty well established that we are going to use it on the backend.