### PR TITLE
Make perf_tests more robust

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -277,9 +277,6 @@ jobs:
             echo "export MARKERS='$MARKERS'" >> $BASH_ENV
       - run_pytest:
           pytest_options: "-n1 -m \"$MARKERS\""
-          with_sudo: true
-      - store_artifacts:
-          path: /tmp/pprof/
 
   k8s_integration_tests:
     executor: machine_image

--- a/tests/helpers/internalmetrics.py
+++ b/tests/helpers/internalmetrics.py
@@ -1,0 +1,15 @@
+import requests
+
+
+class InternalMetricsClient:
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def get(self):
+        """
+        Returns a dict mapping from an internal metric name to its value.
+        """
+        resp = requests.get(f"http://{self.host}:{self.port}/metrics")
+        metrics = resp.json()
+        return {m["metric"]: m["value"] for m in metrics}

--- a/tests/helpers/profiling.py
+++ b/tests/helpers/profiling.py
@@ -1,12 +1,32 @@
+import os
 import pathlib
+import re
+import string
+import subprocess
+from collections import namedtuple
 
-import requests
+Node = namedtuple("Node", ["flat", "flat_percent", "sum_percent", "cum", "cum_percent", "func", "src_line"])
+
+
+class Profile(
+    namedtuple(
+        "Profile", ["nodes", "sampled", "percent_sampled", "total", "nodes_dropped", "cum_dropped", "original_output"]
+    )
+):
+    pass
 
 
 class PProfClient:
+    """
+    Expects that `go tool pprof` is available on the system.
+    """
+
     def __init__(self, host: str, port: int):
         self.host = host
         self.port = port
+        self.goroutine_idx = 0
+        self.heap_idx = 0
+        self.test_name = re.search(r"::(.*?) \(.*\)$", os.environ.get("PYTEST_CURRENT_TEST", "unknown")).group(1)
 
         pathlib.Path("/tmp/pprof").mkdir(parents=True, exist_ok=True)
 
@@ -14,33 +34,74 @@ class PProfClient:
     def _base_url(self):
         return f"http://{self.host}:{self.port}"
 
-    def fetch_heap(self):
-        resp = requests.get(f"{self._base_url}/debug/pprof/heap")
-        return resp.content
+    def run_pprof(self, profile_type, sample_index=None, unit=""):
+        sample_index_flag = ""
+        if sample_index:
+            sample_index_flag = "-sample_index=" + sample_index
 
-    def fetch_goroutines(self):
-        resp = requests.get(f"{self._base_url}/debug/pprof/goroutine")
-        return resp.content
+        command = (
+            f'go tool pprof -text -compact_labels -lines {sample_index_flag} -unit "{unit}" '
+            + f"{self._base_url}/debug/pprof/{profile_type}"
+        )
 
-    def save_goroutines(self):
-        """
-        Saves the pprof goroutine stack output to a tmpfile and returns the
-        path
-        """
-        path = f"/tmp/pprof/goroutine.{self.host}-{self.port}"
-        with open(path, "wb") as fd:
-            print(f"Saving goroutines to {path}")
-            fd.write(self.fetch_goroutines())
+        profile_text = subprocess.check_output(command, shell=True)
+        return self._parse_profile(profile_text)
 
-        return path
+    @staticmethod
+    def _parse_profile(profile_output):
+        lines = profile_output.decode("utf-8").splitlines()
+        if not lines:
+            return None
 
-    def save_heap(self):
-        """
-        Saves the pprof heap stack output to a tmpfile and returns the
-        path
-        """
-        path = f"/tmp/pprof/heap.{self.host}-{self.port}"
-        with open(path, "wb") as fd:
-            fd.write(self.fetch_heap())
+        sampled, percent_sampled, total = re.match(
+            r"Showing nodes accounting for ([.\w]+), ([.\d]+)% of ([.\w]+) total", lines.pop(0)
+        ).groups()
 
-        return path
+        nodes_dropped = "0"
+        cum_dropped = "0"
+        if lines[0].startswith("Dropped"):
+            nodes_dropped, cum_dropped = re.match(r"Dropped (\d+) nodes \(cum <= ([.\w]+)\)", lines.pop(0)).groups()
+
+        assert lines.pop(0).split() == ["flat", "flat%", "sum%", "cum", "cum%"], "unexpected pprof header line"
+
+        nodes = [
+            Node(*[float(c.strip(string.ascii_letters + "%")) for c in li.split()[:5]], *li.split()[5:]) for li in lines
+        ]
+
+        return Profile(
+            sampled=float(sampled.strip(string.ascii_letters)),
+            percent_sampled=float(percent_sampled),
+            total=float(total.strip(string.ascii_letters)),
+            nodes_dropped=nodes_dropped,
+            cum_dropped=float(cum_dropped.strip(string.ascii_letters)),
+            nodes=nodes,
+            original_output=profile_output.decode("utf-8"),
+        )
+
+    def get_goroutine_profile(self):
+        return self.run_pprof("goroutine")
+
+    def get_heap_profile(self):
+        return self.run_pprof("heap", "inuse_space")
+
+    def assert_goroutine_count_under(self, count):
+        from .util import assert_wait_for
+
+        def check():
+            check.last_profile = self.get_goroutine_profile()
+            return check.last_profile.total < count
+
+        assert_wait_for(
+            check, interval_seconds=2, timeout_seconds=60, on_fail=lambda: print(check.last_profile.original_output)
+        )
+
+    def assert_heap_alloc_under(self, bytes_total):
+        from .util import assert_wait_for
+
+        def check():
+            check.last_profile = self.get_heap_profile()
+            return check.last_profile.total < (bytes_total * 1.5)
+
+        assert_wait_for(
+            check, interval_seconds=2, timeout_seconds=60, on_fail=lambda: print(check.last_profile.original_output)
+        )

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -137,6 +137,7 @@ disable=print-statement,
         missing-docstring,
         fixme,
         too-many-branches,
+        too-few-public-methods,
         bad-continuation  # We use black so this shouldn't ever be relevant
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
 - Get internal metrics directly from agent internal status endpoint
 instead of via internal-metrics monitor

 - Get heap/goroutine profile data directly from pprof tool instead of
 internal metrics.  This should be more reliable and more powerful for
 future testing

 - Increase goroutine threadholds to 200 where it exists