### PR TITLE
Rework the status output to be more compact and useful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -344,6 +344,7 @@ ENV SIGNALFX_BUNDLE_DIR=/bundle \
     TEST_SERVICES_DIR=/usr/src/signalfx-agent/test-services \
     AGENT_BIN=/usr/src/signalfx-agent/signalfx-agent \
     PYTHONPATH=/usr/src/signalfx-agent/python \
+    AGENT_VERSION=latest \
     BUILD_TIME=2017-01-25T13:17:17-0500 \
     GOOS=linux \
     LC_ALL=C.UTF-8 \

--- a/README.md
+++ b/README.md
@@ -364,35 +364,11 @@ Then execute `systemctl daemon-reload` and `systemctl restart signalfx-agent.ser
 to restart the agent service with proxy support.
 
 ## Diagnostics
-The agent serves diagnostic information on a UNIX domain socket at the path
-configured by the `diagnosticsSocketPath` option.  The socket takes no input,
-but simply dumps its current status back upon connection.  As a convenience,
-the command `signalfx-agent status` will read this socket and dump out its
-contents.
-
-The agent status output has the following sections:
-
- - **Version**: The agent version and build time
- - **Agent Configuration**: The current configuration in use by the agent, with
-	 secret values replaced by `*`s.  Default values will be shown here if they
-	 were not set in the agent config file.
- - **Writer Status**: The status and metrics about the writer component which
-	 writes datapoints to SignalFx.
- - **Observers**: The active observers in the agent
- - **Monitor Configurations (Not necessarily active)**: A list of monitor
-	 configurations that are in place.  If a configuration has a discovery rule
-	 but no discovered endpoints match that rule, there will not be any active
-	 instances of this monitor.
- - **Active Monitors**: Monitors instances that are actively monitoring
-	 something.  There may be multiple instances of these per configuration
-	 above if there is a discovery rule that matches multiple services.
- - **Discovered Endpoints**: A list of the endpoints discovered by the agent's
-	 observers.  The fields shown there will be the fields used when matching
-	 discovery rules to a discovered endpoint.
- - **Bad Monitor Configurations**: This will be a set of monitor configurations
-	 that did not validate and the associated error.  Bad monitor configuration
-	 generally does not prevent the agent from starting up, but will prevent
-	 that monitor from ever instantiating.
+The agent serves diagnostic information on an HTTP server at the address
+configured by the `internalStatusHost` and `internalStatusPort` option.  As a
+convenience, the command `signalfx-agent status` will read this server and dump
+out its contents.  That command will also explain how to get further diagnostic
+information.
 
 Also see our [FAQ](./docs/faq.md) for more troubleshooting help.
 

--- a/docs/auto-discovery.md
+++ b/docs/auto-discovery.md
@@ -97,10 +97,9 @@ monitors:
 
 ## Troubleshooting
 
-The simplest way to see what services an instance of the agent has discovered,
-along with the variables that can be matched against this service, is to run
-the command `signalfx-agent status`.  Near the end of this output will be a
-list of discovered endpoints that the agent knows about.
+The simplest way to see what services an instance of the agent has discovered
+is to run the command `signalfx-agent status endpoints`.  The fields shown will
+be the same values that can be used in discovery rules.
 
 ## Manually Defined Services
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -69,11 +69,11 @@ Run the following command on the host with the agent. (If you are using the
 containerized agent, you don't need to use `sudo`.)
 
 ```sh
-$ sudo signalfx-agent status
+$ sudo signalfx-agent status endpoints
 ```
 
-This command dumps out some text that includes a section listing the discovered
-service endpoints that the agent knows about.
+This command dumps out some text listing the discovered service endpoints that
+the agent knows about.
 
 
 ## Why do other pods in my Kubernetes cluster get stuck terminating?

--- a/docs/signalfx-agent.1.man
+++ b/docs/signalfx-agent.1.man
@@ -8,7 +8,7 @@
 
 | **signalfx-agent** \[**-config** path] \[**-debug**] \[**-version**]
 
-| **signalfx-agent** **status**
+| **signalfx-agent** **status** \[all | config | monitors | endpoints]
 
 # DESCRIPTION
 
@@ -19,7 +19,9 @@ SignalFx backend for processing.
 The agent does not fork to the background and has no such option to do so.
 
 If the **status** subcommand is invoked it connects to the configured diagnostic
-socket and dumps diagnostic information about the agent to stdout.
+server and dumps diagnostic information about the agent to stdout.  An optional
+section can be provided that provides extended output about a certain aspect of
+the agent.  If no section is specified, a short summary of the agent is output.
 
 See https://github.com/signalfx/signalfx-agent for more information and
 configuration documentation, as well as to file bug reports or ask questions.

--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -179,7 +179,7 @@ func Startup(configPath string) (context.CancelFunc, <-chan struct{}) {
 }
 
 // Status reads the text from the diagnostic socket and returns it if available.
-func Status(configPath string) ([]byte, error) {
+func Status(configPath string, section string) ([]byte, error) {
 	configLoads, err := config.LoadConfig(context.Background(), configPath)
 	if err != nil {
 		return nil, err
@@ -187,6 +187,6 @@ func Status(configPath string) ([]byte, error) {
 
 	select {
 	case conf := <-configLoads:
-		return readStatusInfo(conf.InternalStatusHost, conf.InternalStatusPort)
+		return readStatusInfo(conf.InternalStatusHost, conf.InternalStatusPort, section)
 	}
 }

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -71,9 +71,9 @@ type Config struct {
 	// machine-id value.
 	SendMachineID bool `yaml:"sendMachineID"`
 	// A list of observers to use (see observer config)
-	Observers []ObserverConfig `yaml:"observers" default:"[]" neverLog:"omit"`
+	Observers []ObserverConfig `yaml:"observers" default:"[]"`
 	// A list of monitors to use (see monitor config)
-	Monitors []MonitorConfig `yaml:"monitors" default:"[]" neverLog:"omit"`
+	Monitors []MonitorConfig `yaml:"monitors" default:"[]"`
 	// Configuration of the datapoint/event writer
 	Writer WriterConfig `yaml:"writer"`
 	// Log configuration

--- a/internal/core/diagnostics.go
+++ b/internal/core/diagnostics.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/sfxclient"
-	"github.com/signalfx/signalfx-agent/internal/core/config"
-	"github.com/signalfx/signalfx-agent/internal/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -54,37 +52,14 @@ func (a *Agent) serveDiagnosticInfo(host string, port uint16) error {
 	return nil
 }
 
-func readStatusInfo(host string, port uint16) ([]byte, error) {
-	resp, err := http.Get(fmt.Sprintf("http://%s:%d/", host, port))
+func readStatusInfo(host string, port uint16, section string) ([]byte, error) {
+	resp, err := http.Get(fmt.Sprintf("http://%s:%d/?section=%s", host, port, section))
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	return ioutil.ReadAll(resp.Body)
-}
-
-func (a *Agent) diagnosticTextHandler(rw http.ResponseWriter, req *http.Request) {
-	rw.Write([]byte(a.DiagnosticText()))
-}
-
-// DiagnosticText returns a simple textual output of the agent's status
-func (a *Agent) DiagnosticText() string {
-	return fmt.Sprintf(
-		"SignalFx Agent Status"+
-			"\n=====================\n"+
-			"\nVersion: %s"+
-			"\nAgent Configuration:"+
-			"\n%s\n\n"+
-			"%s\n"+
-			"%s\n"+
-			"%s",
-		VersionLine,
-		utils.IndentLines(config.ToString(a.lastConfig), 2),
-		a.writer.DiagnosticText(),
-		a.observers.DiagnosticText(),
-		a.monitors.DiagnosticText())
-
 }
 
 func (a *Agent) internalMetricsHandler(rw http.ResponseWriter, req *http.Request) {

--- a/internal/core/status.go
+++ b/internal/core/status.go
@@ -1,0 +1,67 @@
+package core
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/signalfx/signalfx-agent/internal/core/common/constants"
+	"github.com/signalfx/signalfx-agent/internal/core/config"
+	"github.com/signalfx/signalfx-agent/internal/monitors/kubernetes/leadership"
+	"github.com/signalfx/signalfx-agent/internal/utils"
+)
+
+func (a *Agent) diagnosticTextHandler(rw http.ResponseWriter, req *http.Request) {
+	section := req.URL.Query().Get("section")
+	rw.Write([]byte(a.DiagnosticText(section)))
+}
+
+var startTime time.Time
+
+func init() {
+	startTime = time.Now()
+}
+
+// DiagnosticText returns a simple textual output of the agent's status
+func (a *Agent) DiagnosticText(section string) string {
+	var out string
+	if section == "" || section == "all" {
+		uptime := time.Now().Sub(startTime).Round(1 * time.Second).String()
+		out +=
+			"SignalFx Agent version:           " + constants.Version + "\n" +
+				"Agent uptime:                     " + uptime + "\n" +
+				a.observers.DiagnosticText() + "\n" +
+				a.monitors.SummaryDiagnosticText() + "\n" +
+				a.writer.DiagnosticText() + "\n"
+
+		k8sLeader := leadership.CurrentLeader()
+		if k8sLeader != "" {
+			out += "Kubernetes Leader Node:           %s\n"
+		}
+
+		if section == "" {
+			out += "\n" + utils.StripIndent(`
+			  Additional status commands:
+
+			  signalfx-agent status config - show resolved config in use by agent
+			  signalfx-agent status endpoints - show discovered endpoints
+			  signalfx-agent status monitors - show active monitors
+			  signalfx-agent status all - show everything
+			  `)
+		}
+	}
+
+	if section == "config" || section == "all" {
+		out += "Agent Configuration:\n" +
+			utils.IndentLines(config.ToString(a.lastConfig), 2) + "\n"
+	}
+
+	if section == "monitors" || section == "all" {
+		out += a.monitors.DiagnosticText() + "\n"
+	}
+
+	if section == "endpoints" || section == "all" {
+		out += a.monitors.EndpointsDiagnosticText()
+	}
+
+	return out
+}

--- a/internal/core/writer/writer.go
+++ b/internal/core/writer/writer.go
@@ -70,6 +70,13 @@ type SignalFxWriter struct {
 	// emitted by the agent
 	serviceTracker *tracetracker.ActiveServiceTracker
 
+	// Datapoints sent in the last minute
+	datapointsLastMinute int64
+	// Events sent in the last minute
+	eventsLastMinute int64
+	// Spans sent in the last minute
+	spansLastMinute int64
+
 	dpRequestsActive        int64
 	dpRequestsWaiting       int64
 	dpsInFlight             int64
@@ -121,6 +128,8 @@ func New(conf *config.WriterConfig, dpChan chan *datapoint.Datapoint, eventChan 
 			},
 		},
 	}
+	go sw.maintainLastMinuteActivity()
+
 	sw.client.AuthToken = conf.SignalFxAccessToken
 
 	sw.client.Client.Transport = &http.Transport{

--- a/internal/observers/diagnostics.go
+++ b/internal/observers/diagnostics.go
@@ -2,6 +2,7 @@ package observers
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/signalfx/golib/datapoint"
 	"github.com/signalfx/golib/sfxclient"
@@ -9,14 +10,11 @@ import (
 
 // DiagnosticText outputs human-readable text about the active observers.
 func (om *ObserverManager) DiagnosticText() string {
-	var out string
-	out += "Observers:\n"
+	var observerTypes []string
 	for i := range om.observers {
-		out += fmt.Sprintf(
-			" - %s\n",
-			om.observers[i]._type)
+		observerTypes = append(observerTypes, om.observers[i]._type)
 	}
-	return out
+	return fmt.Sprintf("Observers active:                 %s", strings.Join(observerTypes, ", "))
 }
 
 // InternalMetrics returns a list of datapoints relevant to the internal status

--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -139,3 +139,19 @@ func StringInterfaceMapToAllInterfaceMap(in map[string]interface{}) map[interfac
 	}
 	return out
 }
+
+// FormatStringMapCompact formats a string map as a string in a compact form
+func FormatStringMapCompact(in map[string]string) string {
+	out := "{"
+
+	for k, v := range in {
+		out += k + ": " + v + ", "
+	}
+
+	if len(in) > 0 {
+		// Strip last comma
+		out = out[:len(out)-2]
+	}
+
+	return out + "}"
+}


### PR DESCRIPTION
 - There are several sub-sections that can be selected now, the default
 section being a short summary of the agent that fits on a single page.

 - Also adding a sampler that tracks activity of datapoints, events, and
 spans sent over the previous one minute, sampled every ten seconds.
 This is used by the status output to give a rough idea of the volume
 pushed currently through the agent.