### PR TITLE
Reduce HTTP Keep-Alive time to 30 seconds

### DIFF
--- a/internal/core/writer/properties/client.go
+++ b/internal/core/writer/properties/client.go
@@ -72,12 +72,12 @@ func NewDimensionPropertyClient(ctx context.Context, conf *config.WriterConfig) 
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
 				Timeout:   5 * time.Second,
-				KeepAlive: 90 * time.Second,
+				KeepAlive: 30 * time.Second,
 				DualStack: true,
 			}).DialContext,
 			MaxIdleConns:        int(conf.PropertiesMaxRequests),
 			MaxIdleConnsPerHost: int(conf.PropertiesMaxRequests),
-			IdleConnTimeout:     90 * time.Second,
+			IdleConnTimeout:     30 * time.Second,
 			TLSHandshakeTimeout: 10 * time.Second,
 		},
 	}

--- a/internal/core/writer/writer.go
+++ b/internal/core/writer/writer.go
@@ -127,12 +127,12 @@ func New(conf *config.WriterConfig, dpChan chan *datapoint.Datapoint, eventChan 
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   3 * time.Second,
-			KeepAlive: 90 * time.Second,
+			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: conf.MaxRequests,
-		IdleConnTimeout:     90 * time.Second,
+		IdleConnTimeout:     30 * time.Second,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}
 


### PR DESCRIPTION
For both Ingest and API clients