### PR TITLE
Build monitor docs in parallel

### DIFF
--- a/scripts/code-gen-helpers.sh
+++ b/scripts/code-gen-helpers.sh
@@ -6,6 +6,19 @@ AGENT_BIN=${AGENT_BIN:-signalfx-agent}
 
 MY_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 selfdescribe_json="$MY_SCRIPT_DIR/../selfdescribe.json"
+NUM_CORES=$(getconf _NPROCESSORS_ONLN)
+
+doc_types=$(cat <<EOH
+{
+  "slice": "list",
+  "uint16": "integer",
+  "uint": "unsigned integer",
+  "int": "integer",
+  "struct": "object",
+  "interface": "any"
+}
+EOH
+)
 
 generate_selfdescribe_json() {
   $AGENT_BIN selfdescribe > $selfdescribe_json

--- a/scripts/docs/make-docs
+++ b/scripts/docs/make-docs
@@ -8,18 +8,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 generate_selfdescribe_json
 
-doc_types=$(cat <<EOH
-{
-  "slice": "list",
-  "uint16": "integer",
-  "uint": "unsigned integer",
-  "int": "integer",
-  "struct": "object",
-  "interface": "any"
-}
-EOH
-)
-
 j "." | \
   inject_to_obj "doc_types" "$doc_types" | \
   gomplate --file $SCRIPT_DIR/templates/monitor-main.md.tmpl --datasource agent=stdin:///agent.json > $SCRIPT_DIR/../../docs/monitor-config.md
@@ -43,13 +31,4 @@ for i in $(seq 0 $(($(j '.Observers | length')-1))); do
     gomplate --file $SCRIPT_DIR/templates/observer-page.md.tmpl --datasource observer=stdin:///observer.json > $obs_dir/${observerType//\//-}.md
 done
 
-mon_dir=$SCRIPT_DIR/../../docs/monitors
-mkdir -p $mon_dir
-
-for i in $(seq 0 $(($(j '.Monitors | length')-1))); do
-  monitorType=$(j ".Monitors[$i].monitorType")
-
-  j ".Monitors[$i]" |\
-    inject_to_obj "doc_types" "$doc_types" | \
-    gomplate --file $SCRIPT_DIR/templates/monitor-page.md.tmpl --datasource monitor=stdin:///monitor.json > $mon_dir/${monitorType//\//-}.md
-done
+j ".Monitors[].monitorType" | xargs -P${NUM_CORES} -I% -n1 scripts/make-monitor-doc %

--- a/scripts/make-monitor-doc
+++ b/scripts/make-monitor-doc
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Usage: make-monitor-doc <monitor type>
+#
+# Generates markdown file for a monitor.
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+. $SCRIPT_DIR/code-gen-helpers.sh
+
+mon_dir=$SCRIPT_DIR/../docs/monitors
+mkdir -p $mon_dir
+
+monitorType=$1
+
+j ".Monitors[] | select(.monitorType==\"${monitorType}\")" | \
+    inject_to_obj "doc_types" "$doc_types" | \
+    gomplate --file $SCRIPT_DIR/docs/templates/monitor-page.md.tmpl --datasource monitor=stdin:///monitor.json > $mon_dir/${monitorType//\//-}.md


### PR DESCRIPTION
This cuts down `make docs` from 42s to 18s on my machine. Also makes it easier
to test generating a single monitor doc for testing with
`scripts/make-monitor-doc <monitorType>`.