### PR TITLE
Make agent-status alias command work properly with args

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -193,8 +193,8 @@ func main() {
 
 	// Make it so the symlink from agent-status to this binary invokes the
 	// status command
-	if len(os.Args) == 1 && strings.HasSuffix(os.Args[0], "agent-status") {
-		os.Args = append(os.Args, "status")
+	if strings.HasSuffix(os.Args[0], "agent-status") {
+		os.Args = append([]string{os.Args[0], "status"}, os.Args[1:]...)
 	}
 
 	var firstArg string


### PR DESCRIPTION
The Docker container includes a symlink in `/bin` called `agent-status` that links directly to the agent bin and invokes the status output.