### PR TITLE
Fix/chef windows version

### DIFF
--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -22,10 +22,10 @@ when 'windows'
   default['signalfx_agent']['version_file'] = "#{node['signalfx_agent']['install_dir']}\\version.txt"
   default['signalfx_agent']['user'] = 'Administrator'
   default['signalfx_agent']['group'] = 'Administrator'
-  default['signalfx_agent']['package_url'] = "#{node['signalfx_agent']['windows_repo_url']}/#{node['signalfx_agent']['package_stage']}/zip/SignalFxAgent-#{node['signalfx_agent']['package_version']}-win64.zip"
   if node['signalfx_agent']['agent_version']
     default['signalfx_agent']['package_version'] = default['signalfx_agent']['agent_version'].sub('v', '')
   end
+  default['signalfx_agent']['package_url'] = "#{node['signalfx_agent']['windows_repo_url']}/#{node['signalfx_agent']['package_stage']}/zip/SignalFxAgent-#{node['signalfx_agent']['package_version']}-win64.zip"
 else
   default['signalfx_agent']['conf_file_path'] = '/etc/signalfx/agent.yaml'
   default['signalfx_agent']['user'] = 'signalfx-agent'

--- a/deployments/chef/attributes/default.rb
+++ b/deployments/chef/attributes/default.rb
@@ -23,7 +23,7 @@ when 'windows'
   default['signalfx_agent']['user'] = 'Administrator'
   default['signalfx_agent']['group'] = 'Administrator'
   if node['signalfx_agent']['agent_version']
-    default['signalfx_agent']['package_version'] = default['signalfx_agent']['agent_version'].sub('v', '')
+    default['signalfx_agent']['package_version'] = node['signalfx_agent']['agent_version'].sub('v', '')
   end
   default['signalfx_agent']['package_url'] = "#{node['signalfx_agent']['windows_repo_url']}/#{node['signalfx_agent']['package_stage']}/zip/SignalFxAgent-#{node['signalfx_agent']['package_version']}-win64.zip"
 else


### PR DESCRIPTION
#673 introduces a bug where `package_version` will be used before it's set for windows. It also introduces a bug for wrapping this cookbook as it's using `default` instead of `node` to consume `agent_version` for windows

cc @keitwb @jchengsfx 