### PR TITLE
Add metadata class

### DIFF
--- a/tests/helpers/metadata.py
+++ b/tests/helpers/metadata.py
@@ -1,0 +1,68 @@
+import os
+
+import yaml
+
+from tests.helpers.util import REPO_ROOT_DIR
+
+
+def get_metadata(monitor_package_path):
+    """Get monitor metadata from the given path"""
+    return Metadata(monitor_package_path)
+
+
+class Metadata:
+    """Metadata information like metrics and dimensions for a monitor"""
+
+    def __init__(self, monitor_package_path, mon_type=None):
+        with open(
+            os.path.join(REPO_ROOT_DIR, "internal", "monitors", monitor_package_path, "metadata.yaml"),
+            "r",
+            encoding="utf-8",
+        ) as fd:
+            doc = yaml.safe_load(fd)
+            monitor = _find_monitor(doc["monitors"], mon_type)
+
+            self.monitor_type = monitor["monitorType"]
+            self.included_metrics = frozenset(_get_monitor_metrics(monitor, included=True))
+            self.nonincluded_mertics = frozenset(_get_monitor_metrics(monitor, included=False))
+            self.all_metrics = self.included_metrics | self.nonincluded_mertics
+            self.dims = frozenset(_get_monitor_dims(doc))
+
+
+def _find_monitor(monitors, mon_type):
+    if len(monitors) == 1:
+        return monitors[0]
+
+    if mon_type is None:
+        raise ValueError("mon_type kwarg must be provided when there is more than one monitor in a metadata.yaml file")
+
+    for monitor in monitors:
+        if monitor["monitorType"] == mon_type:
+            return monitor
+
+    raise ValueError(f"mon_type {mon_type} was not found")
+
+
+def _get_monitor_metrics(monitor, included=True):
+    for metric in monitor["metrics"] or []:
+        if metric["included"] == included:
+            yield metric["name"]
+
+
+def _get_monitor_dims(doc, mon_type=None):
+    def filter_dims(dimensions):
+        return (dim["name"] for dim in dimensions or [])
+
+    monitors = doc["monitors"]
+
+    if len(monitors) == 1:
+        return filter_dims(monitors[0].get("dimensions"))
+
+    if mon_type is None:
+        raise ValueError("mon_type kwarg must be provided when there is more than one monitor in a metadata.yaml file")
+
+    for monitor in monitors:
+        if monitor["monitorType"] == mon_type:
+            return filter_dims(monitor.get("dimensions"))
+
+    raise ValueError(f"mon_type {mon_type} was not found")

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -283,55 +283,6 @@ def get_monitor_metrics_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
     return metrics
 
 
-def get_monitor_metrics_from_metadata_yaml(monitor_package_path, mon_type=None):
-    with open(os.path.join(REPO_ROOT_DIR, monitor_package_path, "metadata.yaml"), "r", encoding="utf-8") as fd:
-        doc = yaml.safe_load(fd.read())
-        monitors = doc["monitors"]
-
-        if len(monitors) == 1:
-            return monitors[0].get("metrics")
-
-        if mon_type is None:
-            raise ValueError(
-                "mon_type kwarg must be provided when there is more than one monitor in a metadata.yaml file"
-            )
-        for monitor in monitors:
-            if monitor["monitorType"] == mon_type:
-                return monitor.get("metrics")
-    return None
-
-
-def get_monitor_default_metrics_list_from_metadata_yaml(monitor_package_path, mon_type=None):
-    metrics = get_monitor_metrics_from_metadata_yaml(monitor_package_path, mon_type)
-    ret = []
-    for metric in metrics:
-        if metric.get("included"):
-            ret.append(metric.get("name"))
-    return ret
-
-
-def get_monitor_dimensions_list_from_metadata_yaml(monitor_package_path, mon_type=None):
-    with open(os.path.join(REPO_ROOT_DIR, monitor_package_path, "metadata.yaml"), "r", encoding="utf-8") as fd:
-        doc = yaml.safe_load(fd.read())
-        out = []
-        monitors = doc["monitors"]
-        if len(monitors) == 1:
-            for dim in monitors[0].get("dimensions"):
-                out.append(dim.get("name"))
-            return out
-
-        if mon_type is None:
-            raise ValueError(
-                "mon_type kwarg must be provided when there is more than one monitor in a metadata.yaml file"
-            )
-        for monitor in monitors:
-            if monitor["monitorType"] == mon_type:
-                for dim in monitor[0].get("dimensions"):
-                    out.append(dim.get("name"))
-                return out
-    return out
-
-
 def get_monitor_dims_from_selfdescribe(monitor, json_path=SELFDESCRIBE_JSON):
     dims = set()
     with open(json_path, "r", encoding="utf-8") as fd:

--- a/tests/monitors/elasticsearch/elasticsearch_test.py
+++ b/tests/monitors/elasticsearch/elasticsearch_test.py
@@ -3,16 +3,12 @@ from textwrap import dedent
 import pytest
 
 from tests.helpers.assertions import has_datapoint_with_dim, http_status, has_log_message, any_metric_has_any_dim_key
-from tests.helpers.util import (
-    run_service,
-    run_agent,
-    container_ip,
-    wait_for,
-    get_monitor_default_metrics_list_from_metadata_yaml,
-    get_monitor_dimensions_list_from_metadata_yaml,
-)
+from tests.helpers.metadata import get_metadata
+from tests.helpers.util import run_service, run_agent, container_ip, wait_for
 
 pytestmark = [pytest.mark.collectd, pytest.mark.elasticsearch, pytest.mark.monitor_with_endpoints]
+
+METADATA = get_metadata("elasticsearch")
 
 
 @pytest.mark.flaky(reruns=2)
@@ -134,9 +130,9 @@ def test_elasticsearch_with_threadpool():
             assert not has_log_message(get_output().lower(), "error"), "error found in agent output!"
 
 
-DEFAULT_METRICS = get_monitor_default_metrics_list_from_metadata_yaml("internal/monitors/elasticsearch")
+DEFAULT_METRICS = METADATA.included_metrics
 
-DEFAULT_DIMENSIONS = get_monitor_dimensions_list_from_metadata_yaml("internal/monitors/elasticsearch")
+DEFAULT_DIMENSIONS = METADATA.dims
 
 
 @pytest.mark.flaky(reruns=2)

--- a/tests/monitors/expvar/expvar_test.py
+++ b/tests/monitors/expvar/expvar_test.py
@@ -6,9 +6,12 @@ from textwrap import dedent
 
 import pytest
 from tests.helpers.assertions import has_datapoint, tcp_socket_open
-from tests.helpers.util import container_ip, get_monitor_metrics_from_metadata_yaml, run_agent, run_service, wait_for
+from tests.helpers.metadata import get_metadata
+from tests.helpers.util import container_ip, run_agent, run_service, wait_for
 
 pytestmark = [pytest.mark.expvar, pytest.mark.monitor_with_endpoints]
+
+METADATA = get_metadata("expvar")
 
 
 def test_nginx():
@@ -26,10 +29,6 @@ def test_nginx():
          """
             )
         ) as [backend, _, _]:
-            metrics_defined = get_monitor_metrics_from_metadata_yaml("internal/monitors/expvar")
-            for metric in metrics_defined:
-                if metric.get("included", False):
-                    print("Waiting for %s" % metric)
-                    assert wait_for(
-                        p(has_datapoint, backend, metric_name=metric["name"])
-                    ), "Didn't get included datapoints"
+            for metric in METADATA.included_metrics:
+                print("Waiting for %s" % metric)
+                assert wait_for(p(has_datapoint, backend, metric_name=metric)), "Didn't get included datapoints"


### PR DESCRIPTION
This consolidates the metadata.yaml helper functions into a single class to
make it easier for test functions to query it.