### PR TITLE
Support Redhat image certification process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,8 +10,8 @@ internal/monitors/**/template.go
 internal/monitors/collectd/collectd.conf.go
 packaging/*/output
 tests/**/__pycache__
+**/virtualenv
 vendor_orig/**
-python/virtualenv
 **/boxcutter/**
 **/.vagrant/**
 .circleci/**

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,37 @@
+FROM registry.access.redhat.com/rhel7-atomic
+
+ARG AGENT_VERSION="4.5.1"
+LABEL name="SignalFx Smart Agent" \
+	  maintainer="SignalFx, Inc." \
+	  vendor="SignalFx, Inc." \
+	  version="${AGENT_VERSION}" \
+	  release="1" \
+	  summary="The SignalFx Smart Agent" \
+	  description="The SignalFx Smart Agent" \
+	  io.k8s.display-name="SignalFx Smart Agent" \
+	  io.k8s.description="The SignalFx Smart Agent" \
+	  io.openshift.tags=""
+	
+RUN mkdir -p /licenses
+COPY LICENSE /licenses/
+
+USER root
+
+CMD ["/usr/bin/signalfx-agent"]
+
+COPY packaging/rpm/signalfx-agent.repo /etc/yum.repos.d/signalfx-agent.repo
+
+RUN microdnf install --enablerepo=rhel-7-server-rpms signalfx-agent-${AGENT_VERSION}-1 &&\
+    microdnf clean all
+
+RUN setcap -r /usr/lib/signalfx-agent/bin/signalfx-agent &&\
+    mkdir -p /var/run/signalfx-agent &&\
+    chown signalfx-agent.signalfx-agent /var/run/signalfx-agent &&\
+    chmod 777 /var/run/signalfx-agent
+
+COPY deployments/docker/agent.yaml /tmp/agent.yaml
+RUN sed -e 's#/lib/whitelist.json#/usr/lib/signalfx-agent/whitelist.json#' /tmp/agent.yaml > /etc/signalfx/agent.yaml
+
+COPY whitelist.json /usr/lib/signalfx-agent/whitelist.json
+
+USER signalfx-agent

--- a/packaging/rpm/signalfx-agent.repo
+++ b/packaging/rpm/signalfx-agent.repo
@@ -1,0 +1,6 @@
+[signalfx-agent]
+name=SignalFx Agent Repository
+baseurl=https://dl.signalfx.com/rpms/signalfx-agent/final
+gpgcheck=1
+gpgkey=https://dl.signalfx.com/yum-rpm.key
+enabled=1

--- a/scripts/release-redhat
+++ b/scripts/release-redhat
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -euo pipefail
+set -x
+
+# Updates the ${build_branch} branch on github with the newer version of the
+# agent baked into the Dockerfile.rhel.  We can't use build args or run any
+# scripts on the RHEL build service so we have to have the Dockerfile be as
+# self-contained as possible.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+usage() {
+  echo "$0 <version> <project_id> [redhat_tag]"
+}
+
+if [[ "$#" -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+version=${1-$(scripts/latest-final-release)}
+project_id=$2
+redhat_tag=${3-$version}
+build_branch="redhat-project"
+
+update_dockerfile() {
+  sed --in-place='' --regexp-extended -e "s/[4-9]+\.[0-9]+\.[0-9]+/$version/g" Dockerfile.rhel
+}
+
+# Reset the ${build_branch} branch to the specified version's tag and ensure the
+# Dockerfile.rhel has the right version on the remote repo for the RHEL builder
+# service to pick up.
+update_branch() {
+  rm -rf /tmp/redhat-project
+  git worktree add -f -B ${build_branch} /tmp/redhat-project v$version
+  pushd /tmp/redhat-project
+
+  update_dockerfile
+  read -n1 -p "Press key"
+
+  git add Dockerfile.rhel
+  git commit -m "Update RHEL Dockerfile version to $version"
+  git push -f origin ${build_branch}
+
+  popd
+  git worktree remove /tmp/redhat-project
+}
+
+trigger_build() {
+  curl -H "Content-Type: application/json" -X POST -d "{\"tag\":\"${redhat_tag}\"}" https://connect.redhat.com/api/v2/projects/${project_id}/build
+}
+
+update_branch
+trigger_build

--- a/scripts/update-deployments-version
+++ b/scripts/update-deployments-version
@@ -10,6 +10,7 @@ files_to_update=(
   deployments/k8s/helm/signalfx-agent/values.yaml
   deployments/ecs/signalfx-agent-task.json
   deployments/fargate/signalfx-agent-fargate-task.json
+  Dockerfile.rhel
 )
 
 new_version=$1


### PR DESCRIPTION
 - Add a new Dockerfile.rhel that uses a RHEL base image and installs
   the agent via its RPM package.
 - Add a release script to maintain a separate branch called
   `redhat-cert` that can be used to build against using the Redhat build
   service.