### PR TITLE
Add all libnss*.so files to bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
             BUNDLE_DIR="$(pwd)/bundle"
             AGENT_BIN="$BUNDLE_DIR/bin/signalfx-agent"
             TEST_SERVICES_DIR="$(pwd)/test-services"
-            MARKERS="not packaging and not installer and not k8s and not windows_only and not deployment and not perf_test"
+            MARKERS="not packaging and not installer and not k8s and not windows_only and not deployment and not perf_test and not bundle"
             mkdir -p "$BUNDLE_DIR"
             cid=$(docker create quay.io/signalfx/signalfx-agent-dev:latest true)
             docker export $cid | tar -C "$BUNDLE_DIR" -xf -
@@ -308,17 +308,23 @@ jobs:
       package_type:
         default: "rpm"
         type: enum
-        enum: ["rpm", "deb"]
+        enum: ["rpm", "deb", "bundle"]
+    environment:
+      PACKAGE_TYPE: "<< parameters.package_type >>"
     steps:
       - checkout
       - run: |
-          if ! scripts/changes-include-dir Dockerfile packaging tests/packaging; then
+          if ! scripts/changes-include-dir Dockerfile packaging tests/packaging scripts/patch-interpreter scripts/patch-rpath; then
               echo "packaging code has not changed, skipping tests!"
               touch ~/.skip
               exit 0
           fi
           export PULL_CACHE=yes
-          make << parameters.package_type >>-test-package
+          if [[ $PACKAGE_TYPE == "bundle" ]]; then
+              AGENT_VERSION=latest make bundle
+          else
+              make << parameters.package_type >>-test-package
+          fi
           # Run non-upgrade tests on node 0, and upgrade tests on node 1
           if [ $CIRCLE_NODE_INDEX -eq 0 ]; then
               echo "export TEST_MARKERS='<< parameters.package_type >> and not upgrade'" >> $BASH_ENV
@@ -326,7 +332,7 @@ jobs:
               echo "export TEST_MARKERS='<< parameters.package_type >> and upgrade'" >> $BASH_ENV
           fi
       - run_pytest:
-          pytest_options: "-n auto -m \"$TEST_MARKERS\""
+          pytest_options: "-n auto -m \"$TEST_MARKERS\" --test-bundle-path ./signalfx-agent-latest.tar.gz"
           tests_dir: "./tests/packaging"
 
   deployment_tests:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ To use the bundle:
 
 1) Unarchive it to a directory of your choice on the target system.
 
+2) Go into the unarchived `signalfx-agent` directory and run
+`bin/patch-interpreter $(pwd)`.  This ensures that the binaries in the bundle
+have the right loader set on them since your host's loader may not be
+compatible.
+
 2) Ensure a valid configuration file is available somewhere on the target
 system.  The main thing that the distro packages provide -- but that you will
 have to provide manually with the bundle -- is a run directory for the agent to

--- a/internal/core/writer/writer.go
+++ b/internal/core/writer/writer.go
@@ -192,6 +192,9 @@ func New(conf *config.WriterConfig, dpChan chan *datapoint.Datapoint, eventChan 
 	go sw.listenForEventsAndDimProps()
 	go sw.listenForTraceSpans()
 
+	log.Infof("Sending datapoints to %s", sw.client.DatapointEndpoint)
+	log.Infof("Sending trace spans to %s", sw.client.TraceEndpoint)
+
 	return sw, nil
 }
 

--- a/scripts/collect-libs
+++ b/scripts/collect-libs
@@ -51,7 +51,7 @@ all_links() {
 libs=$(find_deps $binary_paths)
 # Pulling one level of transitive deps is enough for now
 transitive_deps=$(find_deps $libs)
-for lib in /lib/`uname -m`-linux-gnu/libnss_{dns,files}* $libs $transitive_deps
+for lib in /lib/`uname -m`-linux-gnu/libnss_* /lib/`uname -m`-linux-gnu/libnsl* $libs $transitive_deps
 do
   cp -a $(all_links $lib) $target_path 
   echo "Pulled in $lib" # to $new_path"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,8 @@ import time
 from functools import partial as p
 
 import pytest
-
 from tests.helpers.kubernetes.minikube import Minikube, has_docker_image
-from tests.helpers.util import wait_for, get_docker_client, run_container
+from tests.helpers.util import get_docker_client, run_container, wait_for
 
 REPO_ROOT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), "..")
 K8S_DEFAULT_VERSION = "1.14.0"
@@ -63,6 +62,11 @@ def pytest_addoption(parser):
         "--k8s-skip-teardown",
         action="store_true",
         help="If specified, the minikube container will not be stopped/removed when the tests complete.",
+    )
+    parser.addoption(
+        "--test-bundle-path",
+        action="store",
+        help="Path to a bundle .tar.gz file for testing.  Required for tests that need a bundle.",
     )
 
 

--- a/tests/helpers/agent.py
+++ b/tests/helpers/agent.py
@@ -15,7 +15,9 @@ from .util import AGENT_BIN, get_unique_localhost, print_lines, run_subprocess
 
 
 class Agent:
-    def __init__(self, run_dir, config, fake_services, debug=True, host=None, env=None, profiling=False):
+    def __init__(
+        self, run_dir, config, fake_services, config_path=None, debug=True, host=None, env=None, profiling=False
+    ):
         assert host is not None
         self.run_dir = run_dir
         self.fake_services = fake_services
@@ -27,7 +29,7 @@ class Agent:
 
         self.env = env
         self.profiling = profiling
-        self.config_path = os.path.join(self.run_dir, "agent.yaml")
+        self.config_path = config_path or os.path.join(self.run_dir, "agent.yaml")
         self.config = yaml.safe_load(config)
 
     def fill_in_config(self):
@@ -39,8 +41,9 @@ class Agent:
         if self.config.get("signalFxAccessToken") is None:
             self.config["signalFxAccessToken"] = "testing123"
 
-        self.config["ingestUrl"] = self.fake_services.ingest_url
-        self.config["apiUrl"] = self.fake_services.api_url
+        if self.fake_services:
+            self.config["ingestUrl"] = self.fake_services.ingest_url
+            self.config["apiUrl"] = self.fake_services.api_url
 
         self.config["internalStatusHost"] = self.host
         self.config["internalStatusPort"] = 8095
@@ -59,10 +62,13 @@ class Agent:
         self.config["configSources"]["file"]["pollRateSeconds"] = 1
 
     def write_config(self):
-        self.fill_in_config()
         with open(self.config_path, "w") as fd:
             print("CONFIG: %s\n%s" % (self.config_path, self.config))
-            fd.write(yaml.dump(self.config))
+            fd.write(self.get_final_config_yaml())
+
+    def get_final_config_yaml(self):
+        self.fill_in_config()
+        return yaml.dump(self.config)
 
     def update_config(self, config_text):
         self.config = yaml.safe_load(config_text)

--- a/tests/packaging/bundle_test.py
+++ b/tests/packaging/bundle_test.py
@@ -1,0 +1,80 @@
+from functools import partial as p
+from textwrap import dedent
+
+import pytest
+from tests.helpers.agent import Agent
+from tests.helpers.assertions import has_datapoint
+from tests.helpers.util import container_ip, print_lines, run_service, wait_for
+
+from .common import copy_file_content_into_container, copy_file_into_container, run_init_system_image
+
+pytestmark = pytest.mark.bundle
+
+
+@pytest.mark.parametrize("base_image", ["alpine", "ubuntu1804"])
+def test_bundle(request, base_image):
+    # Get bundle path from command line flag to pytest
+    bundle_path = request.config.getoption("--test-bundle-path")
+    if not bundle_path:
+        raise ValueError("You must specify the --test-bundle-path flag to run bundle tests")
+
+    with run_service("activemq") as activemq_container:
+        with run_init_system_image(base_image, command="/usr/bin/tail -f /dev/null") as [cont, backend]:
+            copy_file_into_container(bundle_path, cont, "/opt/bundle.tar.gz")
+
+            code, output = cont.exec_run(f"tar -xf /opt/bundle.tar.gz -C /opt")
+            assert code == 0, f"Could not untar bundle: {output}"
+
+            code, output = cont.exec_run(f"/opt/signalfx-agent/bin/patch-interpreter /opt/signalfx-agent")
+            assert code == 0, f"Could not patch interpreter: {output}"
+
+            agent = Agent(
+                host="127.0.0.1",
+                fake_services=None,
+                run_dir="/tmp/signalfx",
+                config=dedent(
+                    f"""
+                signalFxRealm: us0
+                observers:
+                  - type: host
+
+                monitors:
+                  - type: host-metadata
+                  - type: collectd/cpu
+                  - type: collectd/cpufreq
+                  - type: collectd/df
+                  - type: collectd/disk
+                  - type: collectd/interface
+                  - type: collectd/load
+                  - type: collectd/memory
+                  # This is a Python plugin, so we test the bundled Python runtime
+                  - type: collectd/signalfx-metadata
+                  - type: collectd/vmem
+                  # This is a GenericJMX Java plugin, so we test the bundled Java runtime
+                  - type: collectd/activemq
+                    host: {container_ip(activemq_container)}
+                    port: 1099
+                    username: testuser
+                    password: testing123
+            """
+                ),
+            )
+            copy_file_content_into_container(agent.get_final_config_yaml(), cont, "/etc/signalfx/agent.yaml")
+
+            _, output = cont.exec_run(
+                ["/bin/sh", "-c", "exec /opt/signalfx-agent/bin/signalfx-agent > /var/log/signalfx-agent.log"],
+                detach=True,
+                stream=True,
+            )
+
+            try:
+                assert wait_for(
+                    p(has_datapoint, backend, dimensions={"plugin": "signalfx-metadata"}), timeout_seconds=10
+                ), "Python metadata datapoint didn't come through"
+                assert wait_for(
+                    p(has_datapoint, backend, metric_name="gauge.amq.queue.QueueSize")
+                ), "Didn't get activemq datapoint"
+            finally:
+                print("Agent log:")
+                _, output = cont.exec_run("cat /var/log/signalfx-agent.log")
+                print_lines(output)

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -109,6 +109,7 @@ def socat_https_proxy(container, target_host, target_port, source_host, bind_add
                     ]
                 )
             except docker.errors.APIError:
+                print("socat died, restarting...")
                 time.sleep(0.1)
 
     threading.Thread(target=keep_running_in_container, args=(container, socket_path)).start()
@@ -136,17 +137,24 @@ def socat_https_proxy(container, target_host, target_port, source_host, bind_add
         proc.kill()
 
 
+def copy_file_content_into_container(content, container, target_path):
+    copy_file_object_into_container(
+        BytesIO(content.encode("utf-8")), container, target_path, size=len(content.encode("utf-8"))
+    )
+
+
 # This is more convoluted that it should be but seems to be the simplest way in
 # the face of docker-in-docker environments where volume bind mounting is hard.
-def copy_file_into_container(path, container, target_path):
+def copy_file_object_into_container(fd, container, target_path, size=None):
     tario = BytesIO()
     tar = tarfile.TarFile(fileobj=tario, mode="w")
 
-    with open(path, "rb") as fd:
-        info = tarfile.TarInfo(name=target_path)
-        info.size = os.path.getsize(path)
+    info = tarfile.TarInfo(name=target_path)
+    if size is None:
+        size = os.fstat(fd.fileno()).st_size
+    info.size = size
 
-        tar.addfile(info, fd)
+    tar.addfile(info, fd)
 
     tar.close()
 
@@ -157,6 +165,11 @@ def copy_file_into_container(path, container, target_path):
     time.sleep(2)
 
 
+def copy_file_into_container(path, container, target_path):
+    with open(path, "rb") as fd:
+        copy_file_object_into_container(fd, container, target_path)
+
+
 @contextmanager
 def run_init_system_image(
     base_image,
@@ -165,6 +178,7 @@ def run_init_system_image(
     dockerfile=None,
     ingest_host="ingest.us0.signalfx.com",  # Whatever value is used here needs a self-signed cert in ./images/certs/
     api_host="api.us0.signalfx.com",  # Whatever value is used here needs a self-signed cert in ./images/certs/
+    command=None,
 ):
     image_id = retry(lambda: build_base_image(base_image, path, dockerfile), docker.errors.BuildError)
     print("Image ID: %s" % image_id)
@@ -187,6 +201,10 @@ def run_init_system_image(
                 api_host: backend.api_host,
             },
         }
+
+        if command:
+            container_options["command"] = command
+
         with run_container(image_id, wait_for_ip=True, **container_options) as cont:
             if with_socat:
                 # Proxy the backend calls through a fake HTTPS endpoint so that we

--- a/tests/packaging/images/Dockerfile.alpine
+++ b/tests/packaging/images/Dockerfile.alpine
@@ -1,0 +1,12 @@
+FROM alpine:3.9
+
+COPY socat /bin/socat
+
+RUN apk add --no-cache ca-certificates
+
+# Insert our fake certs to the system bundle so they are trusted
+COPY certs/*.signalfx.com.* /
+COPY certs/*.signalfx.com.* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+RUN echo "hosts: files dns" > /etc/nsswitch.conf


### PR DESCRIPTION
There was a subtle issue where the bundle's libc was dynamically loading
libnss_compat.so from the host's standard library path at runtime, which
was then chain loading libnss_files.so, which was causing linker errors
due to the bundle's interpreter being used to load it.  Now we include
all libnss libraries so that won't happen.

Also adding two integration tests for the raw bundle to hopefully catch
issues like this in the future.