### PR TITLE
Allow use of K8s annotations in discovery rules

### DIFF
--- a/docs/observers/k8s-api.md
+++ b/docs/observers/k8s-api.md
@@ -26,6 +26,7 @@ Observer Type: `k8s-api`
 | --- | --- | --- | --- |
 | `namespace` | no | `string` | If specified, only pods within the given namespace on the same node as the agent will be discovered. If blank, all pods on the same node as the agent will be discovered. |
 | `kubernetesAPI` | no | `object (see below)` | Configuration for the K8s API client |
+| `additionalPortAnnotations` | no | `list of strings` | A list of annotation names that should be used to infer additional ports to be discovered on a particular pod.  The pod's annotation value should be a port number.  This is useful for annotations like `prometheus.io/port: 9230`.  If you don't already have preexisting annotations like this, we recommend using the [SignalFx-specific annotations](https://docs.signalfx.com/en/latest/integrations/agent/kubernetes-setup.html#config-via-k8s-annotations). |
 
 
 The **nested** `kubernetesAPI` config object has the following fields:

--- a/internal/core/services/endpointcore.go
+++ b/internal/core/services/endpointcore.go
@@ -38,8 +38,9 @@ type EndpointCore struct {
 	// The type of monitor that this endpoint has requested.  This is populated
 	// by observers that pull configuration directly from the platform they are
 	// observing.
-	MonitorType     string            `yaml:"-"`
-	extraDimensions map[string]string `yaml:"-"`
+	MonitorType     string                 `yaml:"-"`
+	extraDimensions map[string]string      `yaml:"-"`
+	extraFields     map[string]interface{} `yaml:"-"`
 }
 
 // NewEndpointCore returns a new initialized endpoint core struct
@@ -54,6 +55,7 @@ func NewEndpointCore(id string, name string, discoveredBy string, dims map[strin
 		Name:            name,
 		DiscoveredBy:    discoveredBy,
 		extraDimensions: dims,
+		extraFields:     map[string]interface{}{},
 	}
 
 	return ec
@@ -77,7 +79,7 @@ func (e *EndpointCore) DerivedFields() map[string]interface{} {
 	if ipAddrRegexp.MatchString(e.Host) {
 		out["ip_address"] = e.Host
 	}
-	return utils.MergeInterfaceMaps(utils.StringMapToInterfaceMap(e.Dimensions()), out)
+	return utils.MergeInterfaceMaps(utils.CloneInterfaceMap(e.extraFields), utils.StringMapToInterfaceMap(e.Dimensions()), out)
 }
 
 // ExtraConfig returns a map of values to be considered when configuring a monitor
@@ -114,4 +116,8 @@ func (e *EndpointCore) AddDimension(k string, v string) {
 // RemoveDimension removes a dimension from this endpoint
 func (e *EndpointCore) RemoveDimension(k string) {
 	delete(e.extraDimensions, k)
+}
+
+func (e *EndpointCore) AddExtraField(name string, val interface{}) {
+	e.extraFields[name] = val
 }

--- a/internal/core/services/rules_test.go
+++ b/internal/core/services/rules_test.go
@@ -16,38 +16,59 @@ func TestDoesServiceMatchRule(t *testing.T) {
 func TestMapFunctions(t *testing.T) {
 	interfacemap := map[interface{}]interface{}{"hello": "world", "good": "bye"}
 	stringmap := map[string]interface{}{"hello": "world", "good": "bye"}
-	t.Run("Get() wrong map type", func(t *testing.T) {
-		_, err := ruleFunctions["Get"](stringmap, "hello")
+
+	t.Run("Get() handles string -> interface{} map type", func(t *testing.T) {
+		val, err := ruleFunctions["Get"](stringmap, "hello")
+		assert.NoError(t, err, "should not error out if the map contains the desired value")
+		assert.Equal(t, "world", val, "should return the expected value")
+	})
+
+	t.Run("Get() returns string -> interface{} map type", func(t *testing.T) {
+		val, err := ruleFunctions["Get"](stringmap, "hello")
+		assert.NoError(t, err, "should not error out if the map contains the desired value")
+		assert.Equal(t, "world", val, "should return the expected value")
+	})
+
+	t.Run("Get() returns error on bad map type", func(t *testing.T) {
+		_, err := ruleFunctions["Get"]("string", 3)
 		assert.Error(t, err, "should error out when wrong map type is used")
 	})
-	t.Run("Get() wrong key type", func(t *testing.T) {
-		_, err := ruleFunctions["Get"](interfacemap, 3)
-		assert.Error(t, err, "should error out when wrong key type is used")
-	})
+
 	t.Run("Get() insufficient number of arguments", func(t *testing.T) {
 		_, err := ruleFunctions["Get"](interfacemap)
 		assert.Error(t, err, "should error out when not enough arguments are provided")
 	})
+
 	t.Run("Get() map does not contain key", func(t *testing.T) {
 		val, err := ruleFunctions["Get"](interfacemap, "nokey")
 		assert.NoError(t, err, "should not error out if the map does not contain the desired value")
 		assert.Nil(t, val, "should return nil if the map does not contain the desired value")
 	})
-	t.Run("Get() map contains desired value", func(t *testing.T) {
+
+	t.Run("Get() returns default if not in map", func(t *testing.T) {
+		val, err := ruleFunctions["Get"](interfacemap, "nokey", 50)
+		assert.NoError(t, err, "should not error out if the map does not contain the desired value")
+		assert.Equal(t, val, 50, "should return default if the map does not contain the desired value")
+	})
+
+	t.Run("Get() handles interface{} -> interface{} maps", func(t *testing.T) {
 		val, err := ruleFunctions["Get"](interfacemap, "hello")
 		assert.NoError(t, err, "should not error out if the map contains the desired value")
 		assert.Equal(t, "world", val, "should return the expected value")
 	})
+
 	t.Run("Contains() map does not contain key", func(t *testing.T) {
 		val, err := ruleFunctions["Contains"](interfacemap, "nokey")
 		assert.NoError(t, err, "should not error if the supplied arguments are the correct type")
 		assert.False(t, val.(bool), "should only return false if an error occured")
 	})
+
 	t.Run("Contains() incorrect argument types", func(t *testing.T) {
 		val, err := ruleFunctions["Contains"](stringmap)
 		assert.Error(t, err, "should error if the supplied arguments are the wrong type")
 		assert.False(t, val.(bool), "should return false when an error occurs")
 	})
+
 	t.Run("Contains() map contians desired value", func(t *testing.T) {
 		val, err := ruleFunctions["Contains"](interfacemap, "good")
 		assert.NoError(t, err, "should not error out if the map contains the desired value")

--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -78,6 +78,15 @@ func CloneStringMap(m map[string]string) map[string]string {
 	return m2
 }
 
+// CloneInterfaceMap makes a shallow copy of a map[string]interface{}
+func CloneInterfaceMap(m map[string]interface{}) map[string]interface{} {
+	m2 := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		m2[k] = v
+	}
+	return m2
+}
+
 // CloneAndFilterStringMapWithFunc clones a string map and only includes
 // key/value pairs for which the filter function returns true
 func CloneAndFilterStringMapWithFunc(in map[string]string, filter func(string, string) bool) (out map[string]string) {

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -28964,6 +28964,14 @@
               }
             ]
           }
+        },
+        {
+          "yamlName": "additionalPortAnnotations",
+          "doc": "A list of annotation names that should be used to infer additional ports to be discovered on a particular pod.  The pod's annotation value should be a port number.  This is useful for annotations like `prometheus.io/port: 9230`.  If you don't already have preexisting annotations like this, we recommend using the [SignalFx-specific annotations](https://docs.signalfx.com/en/latest/integrations/agent/kubernetes-setup.html#config-via-k8s-annotations).",
+          "default": null,
+          "required": false,
+          "type": "slice",
+          "elementKind": "string"
         }
       ],
       "observerType": "k8s-api",

--- a/test-services/consul/k8s.yaml
+++ b/test-services/consul/k8s.yaml
@@ -12,14 +12,22 @@ spec:
       app: consul
   template:
     metadata:
+      annotations:
+        prometheus.io/path: "/v1/agent/metrics?format=prometheus"
+        prometheus.io/port: "8500"
+        prometheus.io/scrape: "true"
       labels:
         app: consul
     spec:
       containers:
         - name: consul
-          image: consul:0.9.3
+          image: consul:1.4.4
           ports:
             - containerPort: 8500
+          env:
+            - name: CONSUL_LOCAL_CONFIG
+              value: |
+                {"telemetry": {"prometheus_retention_time": "1m", "disable_hostname": true}}
           readinessProbe:
             tcpSocket:
               port: 8500

--- a/test-services/nginx/nginx-k8s.yaml
+++ b/test-services/nginx/nginx-k8s.yaml
@@ -28,6 +28,8 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        allowScraping: "true"
       labels:
         app: nginx
     spec:

--- a/tests/helpers/kubernetes/agent.py
+++ b/tests/helpers/kubernetes/agent.py
@@ -105,6 +105,7 @@ class Agent:
                 print(f"Created agent configmap:\n{configmap_base}")
 
                 daemonset_base = load_resource_yaml(AGENT_DAEMONSET_PATH)
+                daemonset_base["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["image"] = self.agent_image_name
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["resources"] = {"requests": {"cpu": "50m"}}

--- a/tests/observers/k8s_api_test.py
+++ b/tests/observers/k8s_api_test.py
@@ -44,3 +44,43 @@ def test_config_from_annotations(k8s_cluster):
         """
         with k8s_cluster.run_agent(config) as agent:
             assert wait_for(p(has_datapoint, agent.fake_services, dimensions={"plugin": "nginx", "source": "myapp"}))
+
+
+@pytest.mark.kubernetes
+def test_k8s_annotations_in_discovery(k8s_cluster):
+    nginx_yaml = TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml"
+    with k8s_cluster.create_resources([nginx_yaml]):
+        config = """
+            observers:
+            - type: k8s-api
+
+            monitors:
+            - type: collectd/nginx
+              discoveryRule: 'Get(kubernetes_annotations, "allowScraping") == "true" && port == 80'
+        """
+        with k8s_cluster.run_agent(config) as agent:
+            assert wait_for(p(has_datapoint, agent.fake_services, dimensions={"plugin": "nginx"}))
+
+
+@pytest.mark.kubernetes
+def test_k8s_annotations_with_alt_ports(k8s_cluster):
+    consul_yaml = list(yaml.safe_load_all((TEST_SERVICES_DIR / "consul/k8s.yaml").read_bytes()))
+    # Remove the declared port so we make sure the additionalPortAnnotations is
+    # what is causing it to be discovered.
+    consul_yaml[0]["spec"]["template"]["spec"]["containers"][0]["ports"] = []
+
+    with k8s_cluster.create_resources([yaml.dump_all(consul_yaml)]):
+        config = """
+            observers:
+            - type: k8s-api
+              additionalPortAnnotations:
+               - prometheus.io/port
+
+            monitors:
+             - type: prometheus-exporter
+               discoveryRule: 'Get(kubernetes_annotations, "prometheus.io/scrape") == "true" && Get(kubernetes_annotations, "prometheus.io/port") == ToString(port)'
+               configEndpointMappings:
+                 metricPath: 'Get(kubernetes_annotations, "prometheus.io/path", "/metrics")'
+        """
+        with k8s_cluster.run_agent(config) as agent:
+            assert wait_for(p(has_datapoint, agent.fake_services, metric_name="consul_runtime_malloc_count"))


### PR DESCRIPTION
Had to rework the Get helper function used by govaulate in the rules to
make it work with any map type as well.