### PR TITLE
Pass through enabledMetrics to monitor

### DIFF
--- a/internal/core/config/monitor.go
+++ b/internal/core/config/monitor.go
@@ -77,6 +77,7 @@ type MonitorConfig struct {
 	BundleDir       string          `yaml:"-" json:"-"`
 	ValidationError string          `yaml:"-" json:"-" hash:"ignore"`
 	MonitorID       types.MonitorID `yaml:"-" hash:"ignore"`
+	EnabledMetrics  []string        `yaml:"-" json:"-" hash:"ignore"`
 }
 
 var _ CustomConfigurable = &MonitorConfig{}

--- a/internal/monitors/activemonitor.go
+++ b/internal/monitors/activemonitor.go
@@ -60,6 +60,7 @@ func (am *ActiveMonitor) configureMonitor(monConfig config.MonitorCustomConfig) 
 
 	am.config = monConfig
 	am.config.MonitorConfigCore().MonitorID = am.id
+	am.config.MonitorConfigCore().EnabledMetrics = am.enabledMetrics
 	// Wipe out the other config that has already been decoded since it is not
 	// redundant.
 	am.config.MonitorConfigCore().OtherConfig = nil

--- a/internal/monitors/docker/docker.go
+++ b/internal/monitors/docker/docker.go
@@ -86,7 +86,7 @@ type dockerContainer struct {
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
 
-	enhancedMetricsConfig := EnableExtraGroups(conf.EnhancedMetricsConfig, conf.ExtraGroups, conf.ExtraMetrics)
+	enhancedMetricsConfig := EnableExtraGroups(conf.EnhancedMetricsConfig, conf.EnabledMetrics)
 
 	defaultHeaders := map[string]string{"User-Agent": "signalfx-agent"}
 
@@ -224,20 +224,17 @@ func parseContainerEnvSlice(env []string) map[string]string {
 
 // EnableExtraGroups enables extra metrics that were individually turned on
 // by ExtraMetrics/ExtraGroups configuration
-func EnableExtraGroups(initConf EnhancedMetricsConfig, extraGroups, extraMetrics []string) EnhancedMetricsConfig {
+func EnableExtraGroups(initConf EnhancedMetricsConfig, enabledMetrics []string) EnhancedMetricsConfig {
 	groupEnableMap := map[string]bool{
-		groupBlkio: initConf.EnableExtraBlockIOMetrics,
-		groupCPU: initConf.EnableExtraCPUMetrics,
-		groupMemory: initConf.EnableExtraMemoryMetrics,
+		groupBlkio:   initConf.EnableExtraBlockIOMetrics,
+		groupCPU:     initConf.EnableExtraCPUMetrics,
+		groupMemory:  initConf.EnableExtraMemoryMetrics,
 		groupNetwork: initConf.EnableExtraNetworkMetrics,
 	}
 
-	for _, group := range extraGroups {
-		groupEnableMap[group] = true
-	}
-	for _, metric := range extraMetrics {
-		if metricSet[metric].Group != "" {
-			groupEnableMap[metricSet[metric].Group] = true
+	for _, metric := range enabledMetrics {
+		if metricInfo, ok := metricSet[metric]; ok {
+			groupEnableMap[metricInfo.Group] = true
 		}
 	}
 

--- a/internal/monitors/ecs/ecs.go
+++ b/internal/monitors/ecs/ecs.go
@@ -88,7 +88,7 @@ func (m *Monitor) Configure(conf *Config) error {
 
 	isRegistered := false
 
-	enhancedMetricsConfig := dmonitor.EnableExtraGroups(conf.EnhancedMetricsConfig, conf.ExtraGroups, conf.ExtraMetrics)
+	enhancedMetricsConfig := dmonitor.EnableExtraGroups(conf.EnhancedMetricsConfig, conf.EnabledMetrics)
 
 	utils.RunOnInterval(m.ctx, func() {
 		if !isRegistered {


### PR DESCRIPTION
This passes through the precomputed set of enabled metrics (included + extra -
disabled) so that the monitor can determine which groups need to be implicitly
enabled due to metrics belonging to that group being enabled.

Not fully tested.