### PR TITLE
adding support for timerCount statsd config

### DIFF
--- a/docs/monitors/collectd-statsd.md
+++ b/docs/monitors/collectd-statsd.md
@@ -92,6 +92,7 @@ Monitor Type: `collectd/statsd`
 | `deleteGauges` | no | `bool` |  (**default:** `false`) |
 | `timerPercentile` | no | `float64` |  (**default:** `0`) |
 | `timerUpper` | no | `bool` |  (**default:** `false`) |
+| `timerCopunt` | no | `bool` |  (**default:** `false`) |
 | `timerSum` | no | `bool` |  (**default:** `false`) |
 | `timerLower` | no | `bool` |  (**default:** `false`) |
 | `counterSum` | no | `bool` |  (**default:** `false`) |

--- a/docs/monitors/collectd-statsd.md
+++ b/docs/monitors/collectd-statsd.md
@@ -92,7 +92,7 @@ Monitor Type: `collectd/statsd`
 | `deleteGauges` | no | `bool` |  (**default:** `false`) |
 | `timerPercentile` | no | `float64` |  (**default:** `0`) |
 | `timerUpper` | no | `bool` |  (**default:** `false`) |
-| `timerCopunt` | no | `bool` |  (**default:** `false`) |
+| `timerCount` | no | `bool` |  (**default:** `false`) |
 | `timerSum` | no | `bool` |  (**default:** `false`) |
 | `timerLower` | no | `bool` |  (**default:** `false`) |
 | `counterSum` | no | `bool` |  (**default:** `false`) |

--- a/internal/monitors/collectd/statsd/statsd.go
+++ b/internal/monitors/collectd/statsd/statsd.go
@@ -33,6 +33,7 @@ type Config struct {
 	DeleteGauges    bool    `yaml:"deleteGauges"`
 	TimerPercentile float64 `yaml:"timerPercentile"`
 	TimerUpper      bool    `yaml:"timerUpper"`
+	TimerCount      bool    `yaml:"timerCount"`
 	TimerSum        bool    `yaml:"timerSum"`
 	TimerLower      bool    `yaml:"timerLower"`
 	CounterSum      bool    `yaml:"counterSum"`

--- a/internal/monitors/collectd/statsd/statsd.tmpl
+++ b/internal/monitors/collectd/statsd/statsd.tmpl
@@ -8,6 +8,7 @@ LoadPlugin "statsd"
   {{if .DeleteGauges}}DeleteGauges true{{end}}
   {{with .TimerPercentile}}TimerPercentile {{.}}{{end}}
   {{if .TimerUpper}}TimerUpper true{{end}}
+  {{if .TimerCount}}TimerCount true{{end}}
   {{if .TimerSum}}TimerSum true{{end}}
   {{if .TimerLower}}TimerLower true{{end}}
   {{if .CounterSum }}CounterSum true{{end}}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -13102,6 +13102,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "timerCount",
+            "doc": "",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
             "yamlName": "timerSum",
             "doc": "",
             "default": false,


### PR DESCRIPTION
Looks like timerCount config for statsd was missed.

you can see it as an option for collectd here:
https://github.com/collectd/collectd/blob/d1c056161220ce78dedefccf90c876cbea64e9d4/src/statsd.c#L86

I *think* I found all the relevant places that needed updating