### PR TITLE
Making puppet module more robust on Debian

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,8 +406,9 @@ jobs:
                 ;;
             puppet)
                 docker run --rm \
+                    -e "CI_SPEC_OPTIONS=--format RspecJunitFormatter -o ~/testresults/puppetspec.xml" \
                     signalfx-agent-puppet-dev \
-                    rspec spec --format RspecJunitFormatter | tee ~/testresults/puppetspec.xml
+                    rake spec
                 docker run --rm \
                     signalfx-agent-puppet-dev \
                     puppet-lint .

--- a/deployments/puppet/.fixtures.yml
+++ b/deployments/puppet/.fixtures.yml
@@ -1,9 +1,9 @@
 fixtures:
-  repositories:
+  forge_modules:
     stdlib:
-      repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
+      repo: "puppetlabs/stdlib"
       ref: "4.24.0"
     apt:
-      repo: "git://github.com/puppetlabs/puppetlabs-apt"
+      repo: "puppetlabs/apt"
       ref: "7.0.0"
 

--- a/deployments/puppet/.fixtures.yml
+++ b/deployments/puppet/.fixtures.yml
@@ -3,3 +3,7 @@ fixtures:
     stdlib:
       repo: "git://github.com/puppetlabs/puppetlabs-stdlib"
       ref: "4.24.0"
+    apt:
+      repo: "git://github.com/puppetlabs/puppetlabs-apt"
+      ref: "7.0.0"
+

--- a/deployments/puppet/Dockerfile
+++ b/deployments/puppet/Dockerfile
@@ -4,7 +4,7 @@ ENV PATH=$PATH:/opt/puppetlabs/bin:/opt/puppetlabs/pdk/bin
 
 WORKDIR /tmp
 RUN apt update &&\
-    apt install -y make wget vim gcc ruby ruby-dev libxml2 libxml2-dev libxslt1-dev &&\
+    apt install -y make wget vim gcc ruby ruby-dev libxml2 libxml2-dev libxslt1-dev git &&\
 	wget https://apt.puppetlabs.com/puppet5-release-xenial.deb &&\
 	dpkg -i puppet5-release-xenial.deb &&\
 	rm *.deb &&\

--- a/deployments/puppet/Gemfile
+++ b/deployments/puppet/Gemfile
@@ -32,6 +32,7 @@ group :development do
   gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "rspec_junit_formatter"
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/deployments/puppet/Gemfile.lock
+++ b/deployments/puppet/Gemfile.lock
@@ -154,9 +154,7 @@ DEPENDENCIES
   puppet-module-posix-dev-r2.3
   puppet-module-win-default-r2.3
   puppet-module-win-dev-r2.3
-  puppetlabs_spec_helper (~> 2.6.2)
-  rspec-puppet (~> 2.6.9)
-  rspec-puppet-facts (~> 1.9.0)
+  rspec_junit_formatter
 
 BUNDLED WITH
-   1.16.1
+   2.0.1

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -47,6 +47,12 @@ class accepts the following parameters:
 	 package revision > 1 contain changes to some aspect of the packaging
 	 scripts (e.g. init scripts) but contain the same agent bundle.
 
+## Dependencies
+
+On Debian-based systems, the
+[puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module is required to
+manage the SignalFx apt repository.
+
 ## Development
 
 To work on the module in development, you can use the provided dev image to

--- a/deployments/puppet/Rakefile
+++ b/deployments/puppet/Rakefile
@@ -1,5 +1,6 @@
 require 'rspec'
 require 'rspec-puppet/rake_task'
+require 'puppetlabs_spec_helper/rake_tasks'
 
 begin
   if Gem::Specification::find_by_name('puppet-lint')

--- a/deployments/puppet/manifests/debian_repo.pp
+++ b/deployments/puppet/manifests/debian_repo.pp
@@ -6,6 +6,7 @@ class signalfx_agent::debian_repo ($repo_base, $package_stage) {
   apt::source { 'signalfx-agent':
     location => "https://${repo_base}/debs/signalfx-agent/${package_stage}",
     release  => '/',
+    repos    => '',
     key      => {
       id     => '91668001288D1C6D2885D651185894C15AE495F6',
       source => "https://${repo_base}/debian.gpg",

--- a/deployments/puppet/manifests/debian_repo.pp
+++ b/deployments/puppet/manifests/debian_repo.pp
@@ -1,22 +1,14 @@
 # Installs the Debian package repository config
 class signalfx_agent::debian_repo ($repo_base, $package_stage) {
-  package { 'wget':
-    ensure => 'present',
-  }
 
-  exec { 'get gpg key':
-    path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
-    command => "wget -O /etc/apt/trusted.gpg.d/signalfx.gpg https://${repo_base}/debian.gpg",
-    creates => '/etc/apt/trusted.gpg.d/signalfx.gpg',
-  }
+  Exec['apt_update'] -> Package['signalfx-agent']
 
-  file { '/etc/apt/sources.list.d/signalfx-agent.list':
-    content => "deb https://${repo_base}/debs/signalfx-agent/${package_stage} /\n",
-    mode    => '0644',
-    notify  => Exec['/usr/bin/apt-get update'],
-  }
-
-  exec { '/usr/bin/apt-get update':
-    refreshonly => true
+  apt::source { 'signalfx-agent':
+    location => "https://${repo_base}/debs/signalfx-agent/${package_stage}",
+    release  => '/',
+    key      => {
+      id     => '91668001288D1C6D2885D651185894C15AE495F6',
+      source => "https://${repo_base}/debian.gpg",
+    },
   }
 }

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -28,17 +28,17 @@ class signalfx_agent (
     }
   }
 
-  package { 'signalfx-agent':
+  -> package { 'signalfx-agent':
     ensure => $version
   }
 
-  file { $config_file_path:
+  -> file { $config_file_path:
     ensure  => 'file',
     content => template('signalfx_agent/agent.yaml.erb'),
     mode    => '0600',
   }
 
-  service { 'signalfx-agent':
+  -> service { 'signalfx-agent':
     ensure => true,
     enable => true,
   }

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -56,6 +56,10 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.7.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 4.1.0 <= 7.0.0"
     }
   ],
   "pdk-version": "1.4.1",

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -6,6 +6,10 @@
   "license": "Apache-2.0",
   "source": "https://github.com/signalfx/signalfx-agent",
   "dependencies": [
+    {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 4.1.0 <= 7.0.0"
+    }
   ],
   "operatingsystem_support": [
     {
@@ -56,10 +60,6 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.7.0 < 6.0.0"
-    },
-    {
-      "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.1.0 <= 7.0.0"
     }
   ],
   "pdk-version": "1.4.1",

--- a/deployments/puppet/spec/fixtures/modules/signalfx_agent
+++ b/deployments/puppet/spec/fixtures/modules/signalfx_agent
@@ -1,1 +1,0 @@
-/etc/puppetlabs/code/modules/signalfx_agent

--- a/deployments/puppet/spec/spec_helper.rb
+++ b/deployments/puppet/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rspec-puppet'
 require 'rspec-puppet-facts'
+require 'puppetlabs_spec_helper/module_spec_helper'
 
 include RspecPuppetFacts
 


### PR DESCRIPTION
Hey folks. I'm working on migrating to SignalFx across our infrastructure, but ran in to a couple of problems with the Puppet module:

* The module was attempting to create `/etc/signalfx/agent.yaml` before the package was installed, therefore `/etc/signalfx` did not yet exist and provisioning errored out.
* The `Package['wget']` resource was duplicating our attempt to install wget elsewhere in our Puppet manifests.

This PR addresses the first problem by simply adding some chaining arrows.

To address the second problem, I've chosen to introduce a dependency on the `puppetlabs/apt` module to manage the apt repository. Happy to discuss alternatives for that, though.

Thanks!