### PR TITLE
Add missing metric docs for jmx plugins, hadoop, and legacy docker

### DIFF
--- a/docs/monitors/collectd-activemq.md
+++ b/docs/monitors/collectd-activemq.md
@@ -94,6 +94,14 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `gauge.amq.topic.ProducerCount` | gauge | ✔ | Number of producers publishing to this topic. |
 | `gauge.amq.topic.QueueSize` | gauge | ✔ | Number of messages in the topic that have yet to be consumed. |
 | `gauge.amq.topic.TotalBlockedTime` | gauge |  | The total time (ms) that messages have spent blocked by Flow Control |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
 
 
 To specify custom metrics you want to monitor, add a `metricsToInclude` filter

--- a/docs/monitors/collectd-cassandra.md
+++ b/docs/monitors/collectd-cassandra.md
@@ -85,6 +85,14 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `gauge.cassandra.Storage.Load.Count` | gauge | ✔ | Storage used for Cassandra data in bytes |
 | `gauge.cassandra.Storage.TotalHints.Count` | gauge |  | Total hints since node start |
 | `gauge.cassandra.Storage.TotalHintsInProgress.Count` | gauge | ✔ | Total pending hints |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
 
 
 To specify custom metrics you want to monitor, add a `metricsToInclude` filter

--- a/docs/monitors/collectd-docker.md
+++ b/docs/monitors/collectd-docker.md
@@ -32,6 +32,43 @@ Monitor Type: `collectd/docker`
 
 
 
+## Metrics
+
+The following table lists the metrics available for this monitor. Metrics that are marked as Included are standard metrics and are monitored by default.
+
+| Name | Type | Included | Description |
+| ---  | ---  | ---    | ---         |
+| `blkio.io_service_bytes_recursive.read` | cumulative | ✔ |  |
+| `blkio.io_service_bytes_recursive.write` | cumulative | ✔ |  |
+| `cpu.idle` | gauge | ✔ |  |
+| `cpu.usage.system` | gauge | ✔ |  |
+| `cpu.usage.total` | gauge | ✔ |  |
+| `memory.buffered` | gauge | ✔ |  |
+| `memory.cached` | gauge | ✔ |  |
+| `memory.free` | gauge | ✔ |  |
+| `memory.usage.limit` | gauge | ✔ |  |
+| `memory.usage.total` | gauge | ✔ |  |
+| `memory.used` | gauge | ✔ |  |
+| `network.usage.rx_bytes` | cumulative | ✔ |  |
+| `network.usage.tx_bytes` | cumulative | ✔ |  |
+
+
+To specify custom metrics you want to monitor, add a `metricsToInclude` filter
+to the agent configuration, as shown in the code snippet below. The snippet
+lists all available custom metrics. You can copy and paste the snippet into
+your configuration file, then delete any custom metrics that you do not want
+sent.
+
+Note that some of the custom metrics require you to set a flag as well as add
+them to the list. Check the monitor configuration file to see if a flag is
+required for gathering additional metrics.
+
+```yaml
+
+metricsToInclude:
+  - metricNames:
+    monitorType: collectd/docker
+```
 
 
 

--- a/docs/monitors/collectd-genericjmx.md
+++ b/docs/monitors/collectd-genericjmx.md
@@ -5,7 +5,7 @@
 Monitors Java services that expose metrics on
 JMX using collectd's GenericJMX plugin.
 
-See the following for more information 
+See the following for more information
 - https://github.com/signalfx/integrations/tree/master/collectd-genericjmx
 - https://collectd.org/documentation/manpages/collectd-java.5.shtml
 - https://collectd.org/wiki/index.php/Plugin:GenericJMX
@@ -138,6 +138,38 @@ The **nested** `values` config object has the following fields:
 
 
 
+## Metrics
+
+The following table lists the metrics available for this monitor. Metrics that are marked as Included are standard metrics and are monitored by default.
+
+| Name | Type | Included | Description |
+| ---  | ---  | ---    | ---         |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
+
+
+To specify custom metrics you want to monitor, add a `metricsToInclude` filter
+to the agent configuration, as shown in the code snippet below. The snippet
+lists all available custom metrics. You can copy and paste the snippet into
+your configuration file, then delete any custom metrics that you do not want
+sent.
+
+Note that some of the custom metrics require you to set a flag as well as add
+them to the list. Check the monitor configuration file to see if a flag is
+required for gathering additional metrics.
+
+```yaml
+
+metricsToInclude:
+  - metricNames:
+    monitorType: collectd/genericjmx
+```
 
 
 

--- a/docs/monitors/collectd-hadoop.md
+++ b/docs/monitors/collectd-hadoop.md
@@ -48,6 +48,63 @@ Monitor Type: `collectd/hadoop`
 
 
 
+## Metrics
+
+The following table lists the metrics available for this monitor. Metrics that are marked as Included are standard metrics and are monitored by default.
+
+| Name | Type | Included | Description |
+| ---  | ---  | ---    | ---         |
+| `gauge.hadoop.cluster.metrics.active_nodes` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.allocated_mb` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.allocated_virtual_cores` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.apps_completed` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.apps_failed` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.apps_running` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.apps_submitted` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.available_mb` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.available_virtual_cores` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.decommissioned_nodes` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.lost_nodes` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.rebooted_nodes` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.reserved_mb` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.reserved_virtual_cores` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.total_mb` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.total_virtual_cores` | gauge | ✔ |  |
+| `gauge.hadoop.cluster.metrics.unhealthy_nodes` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.elapsedTime` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.failedMapAttempts` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.failedReduceAttempts` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.mapsTotal` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.successfulMapAttempts` | gauge | ✔ |  |
+| `gauge.hadoop.mapreduce.job.successfulReduceAttempts` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.allocatedMB` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.allocatedVCores` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.clusterUsagePercentage` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.memorySeconds` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.priority` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.progress` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.queueUsagePercentage` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.runningContainers` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.apps.vcoreSeconds` | gauge | ✔ |  |
+| `gauge.hadoop.resource.manager.scheduler.leaf.queue.usedCapacity` | gauge | ✔ |  |
+
+
+To specify custom metrics you want to monitor, add a `metricsToInclude` filter
+to the agent configuration, as shown in the code snippet below. The snippet
+lists all available custom metrics. You can copy and paste the snippet into
+your configuration file, then delete any custom metrics that you do not want
+sent.
+
+Note that some of the custom metrics require you to set a flag as well as add
+them to the list. Check the monitor configuration file to see if a flag is
+required for gathering additional metrics.
+
+```yaml
+
+metricsToInclude:
+  - metricNames:
+    monitorType: collectd/hadoop
+```
 
 
 

--- a/docs/monitors/collectd-hadoopjmx.md
+++ b/docs/monitors/collectd-hadoopjmx.md
@@ -2,35 +2,33 @@
 
 # collectd/hadoopjmx
 
-Collects metrics about a Hadoop cluster using
-using collectd's GenericJMX plugin.
+Collects metrics about a Hadoop cluster using using collectd's GenericJMX plugin.
 
-Also see
-https://github.com/signalfx/integrations/tree/master/collectd-hadoop.
+Also see https://github.com/signalfx/integrations/tree/master/collectd-hadoop.
 
->To enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively
+To enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively
 
 **hadoop-env.sh:**
-```
+```sh
 export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS"
 export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS"
 ```
 
 **yarn-env.sh:**
-```
+```sh
 export YARN_NODEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS"
 export YARN_RESOURCEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS"
 ```
 
 This monitor has a set of built in MBeans configured for:
-- [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)
-- [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)
-- [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)
-- [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)
+  - [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)
+  - [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)
+  - [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)
+  - [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)
 
 Sample YAML configuration:
 
-	Name Node
+Name Node
 ```yaml
 monitors:
 - type: collectd/hadoopjmx
@@ -39,7 +37,7 @@ monitors:
   nodeType: nameNode
 ```
 
-	Resource Manager
+Resource Manager
 ```yaml
 monitors:
 - type: collectd/hadoopjmx
@@ -48,7 +46,7 @@ monitors:
   nodeType: resourceManager
 ```
 
-	Node Manager
+Node Manager
 ```yaml
 monitors:
 - type: collectd/hadoopjmx
@@ -57,7 +55,7 @@ monitors:
   nodeType: nodeManager
 ```
 
-	Data Node
+Data Node
 ```yaml
 monitors:
 - type: collectd/hadoopjmx
@@ -121,6 +119,64 @@ The **nested** `values` config object has the following fields:
 
 
 
+## Metrics
+
+The following table lists the metrics available for this monitor. Metrics that are marked as Included are standard metrics and are monitored by default.
+
+| Name | Type | Included | Description |
+| ---  | ---  | ---    | ---         |
+| `counter.hadoop-namenode-gc-count` | cumulative | ✔ |  |
+| `counter.hadoop-namenode-gc-time` | cumulative | ✔ |  |
+| `counter.hadoop-namenode-rpc-total-calls` | cumulative | ✔ |  |
+| `counter.hadoop-namenode-total-load` | cumulative | ✔ |  |
+| `counter.hadoop-namenode-volume-failures` | cumulative | ✔ |  |
+| `gauge.hadoop-datanode-fs-capacity` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-fs-dfs-remaining` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-fs-dfs-used` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-jvm-heap-used` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-rpc-call-queue-length` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-rpc-open-connections` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-rpc-processing-avg` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-rpc-queue-time-avg` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-capacity-total` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-capacity-used` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-current-heap-used` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-dead-datanodes` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-dfs-free` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-live-datanodes` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-max-heap` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-percent-remaining` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-rpc-avg-process-time` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-rpc-avg-queue` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-under-replicated-blocks` | gauge | ✔ |  |
+| `gauge.hadoop-resourceManager-allocated-vcores` | gauge | ✔ |  |
+| `gauge.hadoop-resourceManager-available-vcores` | gauge | ✔ |  |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
+
+
+To specify custom metrics you want to monitor, add a `metricsToInclude` filter
+to the agent configuration, as shown in the code snippet below. The snippet
+lists all available custom metrics. You can copy and paste the snippet into
+your configuration file, then delete any custom metrics that you do not want
+sent.
+
+Note that some of the custom metrics require you to set a flag as well as add
+them to the list. Check the monitor configuration file to see if a flag is
+required for gathering additional metrics.
+
+```yaml
+
+metricsToInclude:
+  - metricNames:
+    monitorType: collectd/hadoopjmx
+```
 
 
 

--- a/docs/monitors/collectd-kafka.md
+++ b/docs/monitors/collectd-kafka.md
@@ -87,6 +87,7 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `counter.kafka.produce.total-time.99th` | gauge |  | 99th percentile of time in milliseconds to process produce requests |
 | `counter.kafka.produce.total-time.count` | cumulative | ✔ | Number of producer requests |
 | `counter.kafka.produce.total-time.median` | gauge |  | Median time it takes to process a produce request |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
 | `gauge.kafka-active-controllers` | gauge | ✔ | Specifies if the broker an active controller |
 | `gauge.kafka-log-flush-time-ms` | gauge |  | Average number of milliseconds to flush a log |
 | `gauge.kafka-log-flush-time-ms-p95` | gauge |  | 95th percentile of log flush time in milliseconds |
@@ -96,12 +97,19 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `gauge.kafka.fetch-consumer.total-time.median` | gauge | ✔ | Median time it takes to process a fetch request from consumers |
 | `gauge.kafka.fetch-follower.total-time.99th` | gauge | ✔ | 99th percentile of time in milliseconds to process fetch requests from followers |
 | `gauge.kafka.fetch-follower.total-time.median` | gauge | ✔ | Median time it takes to process a fetch request from follower |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
 | `kafka-isr-expands` | cumulative |  | When a broker is brought up after a failure, it starts catching up by reading from the leader. Once it is caught up, it gets added back to the ISR. |
 | `kafka-isr-shrinks` | cumulative |  | When a broker goes down, ISR for some of partitions will shrink. When that broker is up again, ISR will be expanded once the replicas are fully caught up. Other than that, the expected value for both ISR shrink rate and expansion rate is 0. |
 | `kafka-leader-election-rate` | cumulative |  | Number of leader elections |
 | `kafka-max-lag` | gauge |  | Maximum lag in messages between the follower and leader replicas |
 | `kafka-offline-partitions-count` | gauge |  | Number of partitions that don’t have an active leader and are hence not writable or readable |
 | `kafka-unclean-elections` | cumulative |  | Number of unclean leader elections. This happens when a leader goes down and an out-of-sync replica is chosen to be the leader |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
 
 
 To specify custom metrics you want to monitor, add a `metricsToInclude` filter

--- a/docs/monitors/collectd-kafka_consumer.md
+++ b/docs/monitors/collectd-kafka_consumer.md
@@ -86,11 +86,19 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Included | Description |
 | ---  | ---  | ---    | ---         |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
 | `kafka.consumer.bytes-consumed-rate` | gauge |  | Average number of bytes consumed per second. This metric has either client-id dimension or, both client-id and topic dimensions. The former is an aggregate across all topics of the latter. |
 | `kafka.consumer.fetch-rate` | gauge |  | Number of records consumed per second. |
 | `kafka.consumer.fetch-size-avg` | gauge |  | Average number of bytes fetched per request. This metric has either client-id dimension or, both client-id and topic dimensions. The former is an aggregate across all topics of the latter. |
 | `kafka.consumer.records-consumed-rate` | gauge |  | Average number of records consumed per second. This metric has either client-id dimension or, both client-id and topic dimensions. The former is an aggregate across all topics of the latter. |
 | `kafka.consumer.records-lag-max` | gauge |  | Maximum lag in of records for any partition in this window. An increasing value over time is your best indication that the consumer group is not keeping up with the producers. |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
 
 
 

--- a/docs/monitors/collectd-kafka_producer.md
+++ b/docs/monitors/collectd-kafka_producer.md
@@ -78,6 +78,13 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Included | Description |
 | ---  | ---  | ---    | ---         |
+| `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
+| `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
+| `invocations` | cumulative | ✔ | Total number of garbage collection events |
+| `jmx_memory.committed` | gauge | ✔ | Amount of memory guaranteed to be available in bytes |
+| `jmx_memory.init` | gauge | ✔ | Amount of initial memory at startup in bytes |
+| `jmx_memory.max` | gauge | ✔ | Maximum amount of memory that can be used in bytes |
+| `jmx_memory.used` | gauge | ✔ | Current memory usage in bytes |
 | `kafka.producer.byte-rate` | gauge |  | Average number of bytes sent per second for a topic. This metric has client-id and topic dimensions. |
 | `kafka.producer.compression-rate` | gauge |  | Average compression rate of record batches for a topic. This metric has client-id and topic dimensions. |
 | `kafka.producer.io-wait-time-ns-avg` | gauge |  | Average length of time the I/O thread spent waiting for a socket ready for reads or writes in nanoseconds. This metric has client-id dimension. |
@@ -88,6 +95,7 @@ The following table lists the metrics available for this monitor. Metrics that a
 | `kafka.producer.request-latency-avg` | gauge |  | Average request latency in ms. Time it takes on average for the producer to get responses from the broker. This metric has client-id dimension. |
 | `kafka.producer.request-rate` | gauge |  | Average number of requests sent per second. This metric has client-id dimension. |
 | `kafka.producer.response-rate` | gauge |  | Average number of responses received per second. This metric has client-id dimension. |
+| `total_time_in_ms.collection_time` | cumulative | ✔ | Amount of time spent garbage collecting in milliseconds |
 
 
 

--- a/internal/monitors/collectd/activemq/metadata.yaml
+++ b/internal/monitors/collectd/activemq/metadata.yaml
@@ -4,6 +4,41 @@ monitors:
     Monitors Apache ActiveMQ via the collectd
     GenericJMX plugin.
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
     counter.amq.TotalConnectionsCount:
       description: Total connections count per broker
       included: true

--- a/internal/monitors/collectd/cassandra/metadata.yaml
+++ b/internal/monitors/collectd/cassandra/metadata.yaml
@@ -4,6 +4,41 @@ monitors:
     Monitors Cassandra using the GenericJMX collectd
     plugin.
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
     counter.cassandra.ClientRequest.RangeSlice.Latency.Count:
       description: Count of range slice operations since server start
       included: true

--- a/internal/monitors/collectd/docker/metadata.yaml
+++ b/internal/monitors/collectd/docker/metadata.yaml
@@ -8,5 +8,58 @@ monitors:
 
     See https://github.com/signalfx/docker-collectd-plugin.
   metrics:
+    # Needs to be brought in line with https://github.com/signalfx/integrations/tree/master/collectd-docker/docs
+    blkio.io_service_bytes_recursive.read:
+      description: ''
+      included: true
+      type: cumulative
+    blkio.io_service_bytes_recursive.write:
+      description:
+      included: true
+      type: cumulative
+    cpu.idle:
+      description:
+      included: true
+      type: gauge
+    cpu.usage.system:
+      description:
+      included: true
+      type: gauge
+    cpu.usage.total:
+      description:
+      included: true
+      type: gauge
+    memory.buffered:
+      description:
+      included: true
+      type: gauge
+    memory.cached:
+      description:
+      included: true
+      type: gauge
+    memory.free:
+      description:
+      included: true
+      type: gauge
+    memory.usage.limit:
+      description:
+      included: true
+      type: gauge
+    memory.usage.total:
+      description:
+      included: true
+      type: gauge
+    memory.used:
+      description:
+      included: true
+      type: gauge
+    network.usage.rx_bytes:
+      description:
+      included: true
+      type: cumulative
+    network.usage.tx_bytes:
+      description:
+      included: true
+      type: cumulative
   monitorType: collectd/docker
   properties:

--- a/internal/monitors/collectd/genericjmx/metadata.yaml
+++ b/internal/monitors/collectd/genericjmx/metadata.yaml
@@ -4,7 +4,7 @@ monitors:
     Monitors Java services that expose metrics on
     JMX using collectd's GenericJMX plugin.
 
-    See the following for more information 
+    See the following for more information
     - https://github.com/signalfx/integrations/tree/master/collectd-genericjmx
     - https://collectd.org/documentation/manpages/collectd-java.5.shtml
     - https://collectd.org/wiki/index.php/Plugin:GenericJMX
@@ -86,5 +86,37 @@ monitors:
 
      - https://realjenius.com/2012/11/21/java7-jmx-tunneling-freedom/
   metrics:
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
   monitorType: collectd/genericjmx
   properties:

--- a/internal/monitors/collectd/hadoop/metadata.yaml
+++ b/internal/monitors/collectd/hadoop/metadata.yaml
@@ -27,5 +27,137 @@ monitors:
     you may also configure the [collectd/hadoopjmx](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoopjmx)
     monitor to collect additional metrics about the hadoop cluster.
   metrics:
+    gauge.hadoop.cluster.metrics.active_nodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.allocated_mb:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.allocated_virtual_cores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.apps_completed:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.apps_failed:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.apps_running:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.apps_submitted:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.available_mb:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.available_virtual_cores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.decommissioned_nodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.lost_nodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.rebooted_nodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.reserved_mb:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.reserved_virtual_cores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.total_mb:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.total_virtual_cores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.cluster.metrics.unhealthy_nodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.elapsedTime:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.failedMapAttempts:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.failedReduceAttempts:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.mapsTotal:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.successfulMapAttempts:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.mapreduce.job.successfulReduceAttempts:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.allocatedMB:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.allocatedVCores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.clusterUsagePercentage:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.memorySeconds:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.priority:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.progress:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.queueUsagePercentage:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.runningContainers:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.apps.vcoreSeconds:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop.resource.manager.scheduler.leaf.queue.usedCapacity:
+      description:
+      included: true
+      type: gauge
   monitorType: collectd/hadoop
   properties:

--- a/internal/monitors/collectd/hadoopjmx/metadata.yaml
+++ b/internal/monitors/collectd/hadoopjmx/metadata.yaml
@@ -1,29 +1,209 @@
 monitors:
 - dimensions:
-  doc: "Collects metrics about a Hadoop cluster using\nusing collectd's GenericJMX\
-    \ plugin.\n\nAlso see\nhttps://github.com/signalfx/integrations/tree/master/collectd-hadoop.\n\
-    \n>To enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and\
-    \ yarn-env.sh respectively\n\n**hadoop-env.sh:**\n```\nexport HADOOP_NAMENODE_OPTS=\"\
-    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\
-    \ -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS\"\nexport HADOOP_DATANODE_OPTS=\"\
-    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\
-    \ -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS\"\n```\n\n**yarn-env.sh:**\n\
-    ```\nexport YARN_NODEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\
-    \ -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS\"\nexport YARN_RESOURCEMANAGER_OPTS=\"\
-    -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false\
-    \ -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS\"\n```\n\
-    \nThis monitor has a set of built in MBeans configured for:\n- [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)\n\
-    - [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)\n\
-    - [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)\n\
-    - [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)\n\
-    \nSample YAML configuration:\n\n\tName Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n\
-    \  host: 127.0.0.1\n  port: 5677\n  nodeType: nameNode\n```\n\n\tResource Manager\n\
-    ```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5680\n\
-    \  nodeType: resourceManager\n```\n\n\tNode Manager\n```yaml\nmonitors:\n- type:\
-    \ collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 8002\n  nodeType: nodeManager\n\
-    ```\n\n\tData Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n\
-    \  port: 5679\n  nodeType: dataNode\n```\n\nYou may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)\n\
-    monitor to collect additional metrics about the hadoop cluster from the REST API\n"
+  doc: |
+    Collects metrics about a Hadoop cluster using using collectd's GenericJMX plugin.
+
+    Also see https://github.com/signalfx/integrations/tree/master/collectd-hadoop.
+
+    To enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively
+
+    **hadoop-env.sh:**
+    ```sh
+    export HADOOP_NAMENODE_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS"
+    export HADOOP_DATANODE_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS"
+    ```
+
+    **yarn-env.sh:**
+    ```sh
+    export YARN_NODEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS"
+    export YARN_RESOURCEMANAGER_OPTS="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS"
+    ```
+
+    This monitor has a set of built in MBeans configured for:
+      - [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)
+      - [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)
+      - [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)
+      - [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)
+
+    Sample YAML configuration:
+
+    Name Node
+    ```yaml
+    monitors:
+    - type: collectd/hadoopjmx
+      host: 127.0.0.1
+      port: 5677
+      nodeType: nameNode
+    ```
+
+    Resource Manager
+    ```yaml
+    monitors:
+    - type: collectd/hadoopjmx
+      host: 127.0.0.1
+      port: 5680
+      nodeType: resourceManager
+    ```
+
+    Node Manager
+    ```yaml
+    monitors:
+    - type: collectd/hadoopjmx
+      host: 127.0.0.1
+      port: 8002
+      nodeType: nodeManager
+    ```
+
+    Data Node
+    ```yaml
+    monitors:
+    - type: collectd/hadoopjmx
+      host: 127.0.0.1
+      port: 5679
+      nodeType: dataNode
+    ```
+
+    You may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)
+    monitor to collect additional metrics about the hadoop cluster from the REST API
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
+    counter.hadoop-namenode-gc-count:
+      description:
+      included: true
+      type: cumulative
+    counter.hadoop-namenode-gc-time:
+      description:
+      included: true
+      type: cumulative
+    counter.hadoop-namenode-rpc-total-calls:
+      description:
+      included: true
+      type: cumulative
+    counter.hadoop-namenode-total-load:
+      description:
+      included: true
+      type: cumulative
+    counter.hadoop-namenode-volume-failures:
+      description:
+      included: true
+      type: cumulative
+    gauge.hadoop-datanode-fs-capacity:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-fs-dfs-remaining:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-fs-dfs-used:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-jvm-heap-used:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-rpc-call-queue-length:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-rpc-open-connections:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-rpc-processing-avg:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-datanode-rpc-queue-time-avg:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-capacity-total:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-capacity-used:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-current-heap-used:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-dead-datanodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-dfs-free:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-live-datanodes:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-max-heap:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-percent-remaining:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-rpc-avg-process-time:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-rpc-avg-queue:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-namenode-under-replicated-blocks:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-resourceManager-allocated-vcores:
+      description:
+      included: true
+      type: gauge
+    gauge.hadoop-resourceManager-available-vcores:
+      description:
+      included: true
+      type: gauge
   monitorType: collectd/hadoopjmx
   properties:

--- a/internal/monitors/collectd/kafka/metadata.yaml
+++ b/internal/monitors/collectd/kafka/metadata.yaml
@@ -19,6 +19,41 @@ monitors:
 
     See https://github.com/signalfx/integrations/tree/master/collectd-kafka.
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
     counter.kafka-all-bytes-in:
       description: Number of bytes received per second across all topics
       included: false

--- a/internal/monitors/collectd/kafkaconsumer/metadata.yaml
+++ b/internal/monitors/collectd/kafkaconsumer/metadata.yaml
@@ -29,6 +29,41 @@ monitors:
     of metrics collected by default
   sendAll: true
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
     kafka.consumer.bytes-consumed-rate:
       description: Average number of bytes consumed per second. This metric has either
         client-id dimension or, both client-id and topic dimensions. The former is

--- a/internal/monitors/collectd/kafkaproducer/metadata.yaml
+++ b/internal/monitors/collectd/kafkaproducer/metadata.yaml
@@ -21,6 +21,41 @@ monitors:
     Note that this monitor requires Kafka v0.9.0.0 or above and collects metrics from the new producer API.
   sendAll: true
   metrics:
+    # Taken from genericjmx monitor. If you want to change them update genericjmx and update
+    # all other monitors that use genericjmx with this same notice.
+    gauge.jvm.threads.count:
+      description: Number of JVM threads
+      included: true
+      type: gauge
+    gauge.loaded_classes:
+      description: Number of classes loaded in the JVM
+      included: true
+      type: gauge
+    invocations:
+      description: Total number of garbage collection events
+      included: true
+      type: cumulative
+    jmx_memory.committed:
+      description: Amount of memory guaranteed to be available in bytes
+      included: true
+      type: gauge
+    jmx_memory.max:
+      description: Maximum amount of memory that can be used in bytes
+      included: true
+      type: gauge
+    jmx_memory.used:
+      description: Current memory usage in bytes
+      included: true
+      type: gauge
+    total_time_in_ms.collection_time:
+      description: Amount of time spent garbage collecting in milliseconds
+      included: true
+      type: cumulative
+    jmx_memory.init:
+      description: Amount of initial memory at startup in bytes
+      included: true
+      type: gauge
+
     kafka.producer.byte-rate:
       description: Average number of bytes sent per second for a topic. This metric
         has client-id and topic dimensions.

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -1282,6 +1282,54 @@
           "description": "The total time (ms) that messages have spent blocked by Flow Control",
           "group": null,
           "included": false
+        },
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
         }
       },
       "properties": null,
@@ -1790,6 +1838,54 @@
         "gauge.cassandra.Storage.TotalHintsInProgress.Count": {
           "type": "gauge",
           "description": "Total pending hints",
+          "group": null,
+          "included": true
+        },
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
           "group": null,
           "included": true
         }
@@ -3314,7 +3410,86 @@
       "dimensions": null,
       "doc": "Pulls container stats from the Docker Engine.  We\nstrongly recommend using the\n[docker-container-stats](./docker-container-stats.md) monitor instead, as it\nwill scale to large number of containers much better.\n\nSee https://github.com/signalfx/docker-collectd-plugin.\n",
       "groups": null,
-      "metrics": null,
+      "metrics": {
+        "blkio.io_service_bytes_recursive.read": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "blkio.io_service_bytes_recursive.write": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "cpu.idle": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "cpu.usage.system": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "cpu.usage.total": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.buffered": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.cached": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.free": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.usage.limit": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.usage.total": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "memory.used": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "network.usage.rx_bytes": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "network.usage.tx_bytes": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        }
+      },
       "properties": null,
       "metricsExhaustive": false,
       "config": {
@@ -4054,9 +4229,58 @@
       "monitorType": "collectd/genericjmx",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Monitors Java services that expose metrics on\nJMX using collectd's GenericJMX plugin.\n\nSee the following for more information \n- https://github.com/signalfx/integrations/tree/master/collectd-genericjmx\n- https://collectd.org/documentation/manpages/collectd-java.5.shtml\n- https://collectd.org/wiki/index.php/Plugin:GenericJMX\n\nExample (gets the thread count from a standard JMX MBean available on all\nJava JMX-enabled apps):\n\n```yaml\n\nmonitors:\n - type: collectd/genericjmx\n   host: my-java-app\n   port: 7099\n   mBeanDefinitions:\n     threading:\n       objectName: java.lang:type=Threading\n       values:\n       - type: gauge\n         table: false\n         instancePrefix: jvm.threads.count\n         attribute: ThreadCount\n```\n## Troubleshooting\n\nExposing JMX in your Java application can be a tricky process.  Oracle has a\n[helpful guide for Java\n8](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html)\nthat explains how to expose JMX metrics automatically by setting Java\nproperties on your application.  Here are a set of Java properties that are\nknown to work with Java 7+:\n\n```\njava \\\n  -Dcom.sun.management.jmxremote.port=5000 \\\n  -Dcom.sun.management.jmxremote.authenticate=false \\\n  -Dcom.sun.management.jmxremote.ssl=false \\\n  -Dcom.sun.management.jmxremote.rmi.port=5000 \\\n  ...\n```\n\nThis should work as long as the agent is allowed to access port 5000 on the\nJava app's host (i.e. there is no firewall blocking it).  Note that this\ndoes not enable authentication or encryption, but these can be added if\ndesired.\n\nAssuming you have the `host` config set to `172.17.0.3` and the port set to\n`5000` (this is a totally arbitrary port and your JMX app will probably be\nsomething different), here are some errors you might receive and their\nmeanings:\n\n### Connection Refused\n```\nCreating MBean server connection failed: java.io.IOException: Failed to retrieve RMIServer stub: javax.naming.ServiceUnavailableException [Root exception is java.rmi.ConnectException: Connection refused to host: 172.17.0.3; nested exception is:\n     java.net.ConnectException: Connection refused (Connection refused)]\n```\n\nThis error indicates that the JMX connect port is not open on the specified\nhost.  Confirm (via netstat/ss or some other tool) that this port\nis indeed open on the configured host, and is listening on an appropriate\naddress (i.e. if the agent is running on a remote server then JMX should not\nbe listening on localhost only).\n\n### RMI Connection Issues\n\n```\nCreating MBean server connection failed: java.rmi.ConnectException: Connection refused to host: 172.17.0.3; nested exception is:\n     java.net.ConnectException: Connection timed out (Connection timed out)\n```\n\nThis indicates that the JMX connect port was reached successfully, but the\nRMI port that it was directed to is being blocked, probably by a firewall.\nThe easiest thing to do here is to make sure the\n`com.sun.management.jmxremote.rmi.port` property in your Java app is set to\nthe same port as the JMX connect port.  There may be other variations of\nthis that say `Connection reset` or `Connection refused` but they all\ngeneraly indicate a similar cause.\n\n## Useful links\n\n - https://realjenius.com/2012/11/21/java7-jmx-tunneling-freedom/\n",
+      "doc": "Monitors Java services that expose metrics on\nJMX using collectd's GenericJMX plugin.\n\nSee the following for more information\n- https://github.com/signalfx/integrations/tree/master/collectd-genericjmx\n- https://collectd.org/documentation/manpages/collectd-java.5.shtml\n- https://collectd.org/wiki/index.php/Plugin:GenericJMX\n\nExample (gets the thread count from a standard JMX MBean available on all\nJava JMX-enabled apps):\n\n```yaml\n\nmonitors:\n - type: collectd/genericjmx\n   host: my-java-app\n   port: 7099\n   mBeanDefinitions:\n     threading:\n       objectName: java.lang:type=Threading\n       values:\n       - type: gauge\n         table: false\n         instancePrefix: jvm.threads.count\n         attribute: ThreadCount\n```\n## Troubleshooting\n\nExposing JMX in your Java application can be a tricky process.  Oracle has a\n[helpful guide for Java\n8](https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html)\nthat explains how to expose JMX metrics automatically by setting Java\nproperties on your application.  Here are a set of Java properties that are\nknown to work with Java 7+:\n\n```\njava \\\n  -Dcom.sun.management.jmxremote.port=5000 \\\n  -Dcom.sun.management.jmxremote.authenticate=false \\\n  -Dcom.sun.management.jmxremote.ssl=false \\\n  -Dcom.sun.management.jmxremote.rmi.port=5000 \\\n  ...\n```\n\nThis should work as long as the agent is allowed to access port 5000 on the\nJava app's host (i.e. there is no firewall blocking it).  Note that this\ndoes not enable authentication or encryption, but these can be added if\ndesired.\n\nAssuming you have the `host` config set to `172.17.0.3` and the port set to\n`5000` (this is a totally arbitrary port and your JMX app will probably be\nsomething different), here are some errors you might receive and their\nmeanings:\n\n### Connection Refused\n```\nCreating MBean server connection failed: java.io.IOException: Failed to retrieve RMIServer stub: javax.naming.ServiceUnavailableException [Root exception is java.rmi.ConnectException: Connection refused to host: 172.17.0.3; nested exception is:\n     java.net.ConnectException: Connection refused (Connection refused)]\n```\n\nThis error indicates that the JMX connect port is not open on the specified\nhost.  Confirm (via netstat/ss or some other tool) that this port\nis indeed open on the configured host, and is listening on an appropriate\naddress (i.e. if the agent is running on a remote server then JMX should not\nbe listening on localhost only).\n\n### RMI Connection Issues\n\n```\nCreating MBean server connection failed: java.rmi.ConnectException: Connection refused to host: 172.17.0.3; nested exception is:\n     java.net.ConnectException: Connection timed out (Connection timed out)\n```\n\nThis indicates that the JMX connect port was reached successfully, but the\nRMI port that it was directed to is being blocked, probably by a firewall.\nThe easiest thing to do here is to make sure the\n`com.sun.management.jmxremote.rmi.port` property in your Java app is set to\nthe same port as the JMX connect port.  There may be other variations of\nthis that say `Connection reset` or `Connection refused` but they all\ngeneraly indicate a similar cause.\n\n## Useful links\n\n - https://realjenius.com/2012/11/21/java7-jmx-tunneling-freedom/\n",
       "groups": null,
-      "metrics": null,
+      "metrics": {
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
+        }
+      },
       "properties": null,
       "metricsExhaustive": false,
       "config": {
@@ -4265,7 +4489,206 @@
       "dimensions": null,
       "doc": "Collects metrics about a Hadoop cluster using the\n[collectd Hadoop Python plugin](https://github.com/signalfx/collectd-hadoop).\nAlso see\nhttps://github.com/signalfx/integrations/tree/master/collectd-hadoop.\n\nThe `collectd/hadoop` monitor will collect metrics from the Resource Manager\nREST API for the following:\n- Cluster Metrics\n- Cluster Scheduler\n- Cluster Applications\n- Cluster Nodes\n- MapReduce Jobs\n\nSample YAML configuration:\n\n```yaml\nmonitors:\n- type: collectd/hadoop\n  host: 127.0.0.1\n  port: 8088\n```\n\nIf a remote JMX port is exposed in the hadoop cluster, then\nyou may also configure the [collectd/hadoopjmx](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoopjmx)\nmonitor to collect additional metrics about the hadoop cluster.\n",
       "groups": null,
-      "metrics": null,
+      "metrics": {
+        "gauge.hadoop.cluster.metrics.active_nodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.allocated_mb": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.allocated_virtual_cores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.apps_completed": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.apps_failed": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.apps_running": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.apps_submitted": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.available_mb": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.available_virtual_cores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.decommissioned_nodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.lost_nodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.rebooted_nodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.reserved_mb": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.reserved_virtual_cores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.total_mb": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.total_virtual_cores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.cluster.metrics.unhealthy_nodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.elapsedTime": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.failedMapAttempts": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.failedReduceAttempts": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.mapsTotal": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.successfulMapAttempts": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.mapreduce.job.successfulReduceAttempts": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.allocatedMB": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.allocatedVCores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.clusterUsagePercentage": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.memorySeconds": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.priority": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.progress": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.queueUsagePercentage": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.runningContainers": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.apps.vcoreSeconds": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop.resource.manager.scheduler.leaf.queue.usedCapacity": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        }
+      },
       "properties": null,
       "metricsExhaustive": false,
       "config": {
@@ -4306,9 +4729,214 @@
       "monitorType": "collectd/hadoopjmx",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Collects metrics about a Hadoop cluster using\nusing collectd's GenericJMX plugin.\n\nAlso see\nhttps://github.com/signalfx/integrations/tree/master/collectd-hadoop.\n\n\u003eTo enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively\n\n**hadoop-env.sh:**\n```\nexport HADOOP_NAMENODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS\"\nexport HADOOP_DATANODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS\"\n```\n\n**yarn-env.sh:**\n```\nexport YARN_NODEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS\"\nexport YARN_RESOURCEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS\"\n```\n\nThis monitor has a set of built in MBeans configured for:\n- [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)\n- [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)\n- [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)\n- [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)\n\nSample YAML configuration:\n\n\tName Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5677\n  nodeType: nameNode\n```\n\n\tResource Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5680\n  nodeType: resourceManager\n```\n\n\tNode Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 8002\n  nodeType: nodeManager\n```\n\n\tData Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5679\n  nodeType: dataNode\n```\n\nYou may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)\nmonitor to collect additional metrics about the hadoop cluster from the REST API\n",
+      "doc": "Collects metrics about a Hadoop cluster using using collectd's GenericJMX plugin.\n\nAlso see https://github.com/signalfx/integrations/tree/master/collectd-hadoop.\n\nTo enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively\n\n**hadoop-env.sh:**\n```sh\nexport HADOOP_NAMENODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS\"\nexport HADOOP_DATANODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS\"\n```\n\n**yarn-env.sh:**\n```sh\nexport YARN_NODEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS\"\nexport YARN_RESOURCEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS\"\n```\n\nThis monitor has a set of built in MBeans configured for:\n  - [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)\n  - [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)\n  - [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)\n  - [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)\n\nSample YAML configuration:\n\nName Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5677\n  nodeType: nameNode\n```\n\nResource Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5680\n  nodeType: resourceManager\n```\n\nNode Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 8002\n  nodeType: nodeManager\n```\n\nData Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5679\n  nodeType: dataNode\n```\n\nYou may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)\nmonitor to collect additional metrics about the hadoop cluster from the REST API\n",
       "groups": null,
-      "metrics": null,
+      "metrics": {
+        "counter.hadoop-namenode-gc-count": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "counter.hadoop-namenode-gc-time": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "counter.hadoop-namenode-rpc-total-calls": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "counter.hadoop-namenode-total-load": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "counter.hadoop-namenode-volume-failures": {
+          "type": "cumulative",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-fs-capacity": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-fs-dfs-remaining": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-fs-dfs-used": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-jvm-heap-used": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-rpc-call-queue-length": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-rpc-open-connections": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-rpc-processing-avg": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-datanode-rpc-queue-time-avg": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-capacity-total": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-capacity-used": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-current-heap-used": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-dead-datanodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-dfs-free": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-live-datanodes": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-max-heap": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-percent-remaining": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-rpc-avg-process-time": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-rpc-avg-queue": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-namenode-under-replicated-blocks": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-resourceManager-allocated-vcores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.hadoop-resourceManager-available-vcores": {
+          "type": "gauge",
+          "description": "",
+          "group": null,
+          "included": true
+        },
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
+        }
+      },
       "properties": null,
       "metricsExhaustive": false,
       "config": {
@@ -5396,6 +6024,12 @@
           "group": null,
           "included": false
         },
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
         "gauge.kafka-active-controllers": {
           "type": "gauge",
           "description": "Specifies if the broker an active controller",
@@ -5450,6 +6084,42 @@
           "group": null,
           "included": true
         },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
         "kafka-isr-expands": {
           "type": "cumulative",
           "description": "When a broker is brought up after a failure, it starts catching up by reading from the leader. Once it is caught up, it gets added back to the ISR.",
@@ -5485,6 +6155,12 @@
           "description": "Number of unclean leader elections. This happens when a leader goes down and an out-of-sync replica is chosen to be the leader",
           "group": null,
           "included": false
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
         }
       },
       "properties": null,
@@ -5704,6 +6380,48 @@
       "doc": "Monitors a Java based Kafka consumer using GenericJMX.\n\nSee the [integration documentation](https://github.com/signalfx/integrations/tree/master/collectd-kafka)\nfor more information.\n\nThis monitor has a set of [built in MBeans\nconfigured](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/kafkaconsumer/mbeans.go)\nfor which it pulls metrics from the Kafka consumer's JMX endpoint.\n\nSample YAML configuration:\n```yaml\nmonitors:\n  - type: collectd/kafka_consumer\n    host: localhost\n    port: 9099\n    mBeansToOmit:\n      - fetch-size-avg-per-topic\n```\n\nNote that this monitor requires Kafka v0.9.0.0 or above and collects metrics from the new consumer API.\nAlso, per-topic metrics that are collected by default are not available through the new consumer API in\nv0.9.0.0 which can cause the logs to flood with warnings related to the MBean not being found.\nUse the `mBeansToOmit` config option in such cases. The above example configuration will not attempt to\ncollect the MBean referenced by `fetch-size-avg-per-topic`. Here is a\n[list](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/kafkaconsumer/mbeans.go)\nof metrics collected by default\n",
       "groups": null,
       "metrics": {
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
         "kafka.consumer.bytes-consumed-rate": {
           "type": "gauge",
           "description": "Average number of bytes consumed per second. This metric has either client-id dimension or, both client-id and topic dimensions. The former is an aggregate across all topics of the latter.",
@@ -5733,6 +6451,12 @@
           "description": "Maximum lag in of records for any partition in this window. An increasing value over time is your best indication that the consumer group is not keeping up with the producers.",
           "group": null,
           "included": false
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
         }
       },
       "properties": null,
@@ -5944,6 +6668,48 @@
       "doc": "Monitors a Java based Kafka producer using GenericJMX.\n\nSee the [integration documentation](https://github.com/signalfx/integrations/tree/master/collectd-kafka)\nfor more information.\n\nThis monitor has a set of [built in MBeans\nconfigured](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/kafkaproducer/mbeans.go)\nfor which it pulls metrics from the Kafka producer's JMX endpoint.\n\nSample YAML configuration:\n```yaml\nmonitors:\n  - type: collectd/kafka_producer\n    host: localhost\n    port: 8099\n```\n\nNote that this monitor requires Kafka v0.9.0.0 or above and collects metrics from the new producer API.\n",
       "groups": null,
       "metrics": {
+        "gauge.jvm.threads.count": {
+          "type": "gauge",
+          "description": "Number of JVM threads",
+          "group": null,
+          "included": true
+        },
+        "gauge.loaded_classes": {
+          "type": "gauge",
+          "description": "Number of classes loaded in the JVM",
+          "group": null,
+          "included": true
+        },
+        "invocations": {
+          "type": "cumulative",
+          "description": "Total number of garbage collection events",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.committed": {
+          "type": "gauge",
+          "description": "Amount of memory guaranteed to be available in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.init": {
+          "type": "gauge",
+          "description": "Amount of initial memory at startup in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.max": {
+          "type": "gauge",
+          "description": "Maximum amount of memory that can be used in bytes",
+          "group": null,
+          "included": true
+        },
+        "jmx_memory.used": {
+          "type": "gauge",
+          "description": "Current memory usage in bytes",
+          "group": null,
+          "included": true
+        },
         "kafka.producer.byte-rate": {
           "type": "gauge",
           "description": "Average number of bytes sent per second for a topic. This metric has client-id and topic dimensions.",
@@ -6003,6 +6769,12 @@
           "description": "Average number of responses received per second. This metric has client-id dimension.",
           "group": null,
           "included": false
+        },
+        "total_time_in_ms.collection_time": {
+          "type": "cumulative",
+          "description": "Amount of time spent garbage collecting in milliseconds",
+          "group": null,
+          "included": true
         }
       },
       "properties": null,


### PR DESCRIPTION
They still need descriptions but if that's desired we can make a story. But this is required for removing the whitelist.