### PR TITLE
Update metadata and tests for hadoopjmx, activemq, and cassandra

### DIFF
--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -27,6 +27,9 @@ syncs:
     - Path signalfx-agent
     - Path monitor-code-gen
     - Path scripts/windows/vagrant/boxcutter
+    - Name __pycache__
+    - Name *.exe
+    - Name *.tar.gz
     - Name .idea
     - Name .DS_Store
 

--- a/docs/monitors/collectd-hadoopjmx.md
+++ b/docs/monitors/collectd-hadoopjmx.md
@@ -125,32 +125,59 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Included | Description |
 | ---  | ---  | ---    | ---         |
+| `counter.hadoop-datanode-blocks-read` | cumulative |  |  |
+| `counter.hadoop-datanode-blocks-written` | cumulative |  |  |
+| `counter.hadoop-datanode-bytes-read` | cumulative |  |  |
+| `counter.hadoop-datanode-bytes-written` | cumulative |  |  |
+| `counter.hadoop-namenode-files-total` | cumulative |  |  |
 | `counter.hadoop-namenode-gc-count` | cumulative | ✔ |  |
 | `counter.hadoop-namenode-gc-time` | cumulative | ✔ |  |
 | `counter.hadoop-namenode-rpc-total-calls` | cumulative | ✔ |  |
 | `counter.hadoop-namenode-total-load` | cumulative | ✔ |  |
 | `counter.hadoop-namenode-volume-failures` | cumulative | ✔ |  |
+| `counter.hadoop-nodeManager-containers-failed` | cumulative |  |  |
+| `counter.hadoop-nodeManager-containers-launched` | cumulative |  |  |
 | `gauge.hadoop-datanode-fs-capacity` | gauge | ✔ |  |
 | `gauge.hadoop-datanode-fs-dfs-remaining` | gauge | ✔ |  |
 | `gauge.hadoop-datanode-fs-dfs-used` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-info-xceiver` | gauge |  |  |
 | `gauge.hadoop-datanode-jvm-heap-used` | gauge | ✔ |  |
+| `gauge.hadoop-datanode-jvm-non-heap-used` | gauge |  |  |
 | `gauge.hadoop-datanode-rpc-call-queue-length` | gauge | ✔ |  |
 | `gauge.hadoop-datanode-rpc-open-connections` | gauge | ✔ |  |
 | `gauge.hadoop-datanode-rpc-processing-avg` | gauge | ✔ |  |
 | `gauge.hadoop-datanode-rpc-queue-time-avg` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-blocks-with-corrupt-replicas` | gauge |  |  |
+| `gauge.hadoop-namenode-capacity-remaining` | gauge |  |  |
 | `gauge.hadoop-namenode-capacity-total` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-capacity-used` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-corrupt-blocks` | gauge |  |  |
 | `gauge.hadoop-namenode-current-heap-used` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-dead-datanodes` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-dfs-free` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-live-datanodes` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-max-heap` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-missing-blocks` | gauge |  |  |
+| `gauge.hadoop-namenode-percent-dfs-used` | gauge |  |  |
 | `gauge.hadoop-namenode-percent-remaining` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-rpc-avg-process-time` | gauge | ✔ |  |
 | `gauge.hadoop-namenode-rpc-avg-queue` | gauge | ✔ |  |
+| `gauge.hadoop-namenode-stale-datanodes` | gauge |  |  |
 | `gauge.hadoop-namenode-under-replicated-blocks` | gauge | ✔ |  |
+| `gauge.hadoop-nodeManager-allocated-memory` | gauge |  |  |
+| `gauge.hadoop-nodeManager-allocated-vcores` | gauge |  |  |
+| `gauge.hadoop-nodeManager-available-memory` | gauge |  |  |
+| `gauge.hadoop-nodeManager-available-vcores` | gauge |  |  |
+| `gauge.hadoop-resourceManager-active-apps` | gauge |  |  |
+| `gauge.hadoop-resourceManager-active-nms` | gauge |  |  |
+| `gauge.hadoop-resourceManager-active-users` | gauge |  |  |
+| `gauge.hadoop-resourceManager-allocated-containers` | gauge |  |  |
+| `gauge.hadoop-resourceManager-allocated-memory` | gauge |  |  |
 | `gauge.hadoop-resourceManager-allocated-vcores` | gauge | ✔ |  |
+| `gauge.hadoop-resourceManager-available-memory` | gauge |  |  |
 | `gauge.hadoop-resourceManager-available-vcores` | gauge | ✔ |  |
+| `gauge.hadoop-resourceManager-heap-max` | gauge |  |  |
+| `gauge.hadoop-resourceManager-heap-used` | gauge |  |  |
 | `gauge.jvm.threads.count` | gauge | ✔ | Number of JVM threads |
 | `gauge.loaded_classes` | gauge | ✔ | Number of classes loaded in the JVM |
 | `invocations` | cumulative | ✔ | Total number of garbage collection events |
@@ -175,6 +202,33 @@ required for gathering additional metrics.
 
 metricsToInclude:
   - metricNames:
+    - counter.hadoop-datanode-blocks-read
+    - counter.hadoop-datanode-blocks-written
+    - counter.hadoop-datanode-bytes-read
+    - counter.hadoop-datanode-bytes-written
+    - counter.hadoop-namenode-files-total
+    - counter.hadoop-nodeManager-containers-failed
+    - counter.hadoop-nodeManager-containers-launched
+    - gauge.hadoop-datanode-info-xceiver
+    - gauge.hadoop-datanode-jvm-non-heap-used
+    - gauge.hadoop-namenode-blocks-with-corrupt-replicas
+    - gauge.hadoop-namenode-capacity-remaining
+    - gauge.hadoop-namenode-corrupt-blocks
+    - gauge.hadoop-namenode-missing-blocks
+    - gauge.hadoop-namenode-percent-dfs-used
+    - gauge.hadoop-namenode-stale-datanodes
+    - gauge.hadoop-nodeManager-allocated-memory
+    - gauge.hadoop-nodeManager-allocated-vcores
+    - gauge.hadoop-nodeManager-available-memory
+    - gauge.hadoop-nodeManager-available-vcores
+    - gauge.hadoop-resourceManager-active-apps
+    - gauge.hadoop-resourceManager-active-nms
+    - gauge.hadoop-resourceManager-active-users
+    - gauge.hadoop-resourceManager-allocated-containers
+    - gauge.hadoop-resourceManager-allocated-memory
+    - gauge.hadoop-resourceManager-available-memory
+    - gauge.hadoop-resourceManager-heap-max
+    - gauge.hadoop-resourceManager-heap-used
     monitorType: collectd/hadoopjmx
 ```
 

--- a/internal/monitors/collectd/activemq/metadata.yaml
+++ b/internal/monitors/collectd/activemq/metadata.yaml
@@ -6,38 +6,48 @@ monitors:
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
     counter.amq.TotalConnectionsCount:
       description: Total connections count per broker

--- a/internal/monitors/collectd/cassandra/metadata.yaml
+++ b/internal/monitors/collectd/cassandra/metadata.yaml
@@ -6,38 +6,48 @@ monitors:
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
     counter.cassandra.ClientRequest.RangeSlice.Latency.Count:
       description: Count of range slice operations since server start

--- a/internal/monitors/collectd/genericjmx/mbeans.go
+++ b/internal/monitors/collectd/genericjmx/mbeans.go
@@ -33,6 +33,14 @@ func (m MBeanMap) MBeanNames() []string {
 var DefaultMBeans MBeanMap
 
 const defaultMBeanYAML = `
+classes:
+  objectName: java.lang:type=ClassLoading
+  values:
+  - type: gauge
+    instancePrefix: loaded_classes
+    table: false
+    attribute: LoadedClassCount
+
 garbage_collector:
   objectName: "java.lang:type=GarbageCollector,*"
   instancePrefix: "gc-"

--- a/internal/monitors/collectd/genericjmx/metadata.yaml
+++ b/internal/monitors/collectd/genericjmx/metadata.yaml
@@ -88,34 +88,42 @@ monitors:
   metrics:
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
   monitorType: collectd/genericjmx

--- a/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go
+++ b/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go
@@ -76,7 +76,7 @@ hadoop-datanode-FsVolume:
     attribute: "FileIoErrorRateAvgTime"
 
 hadoop-datanode-activity:
-  objectName: "Hadoop:name=DataNodeActivity,service=DataNode"
+  objectName: "Hadoop:name=DataNodeActivity-*,service=DataNode"
   values:
   - instancePrefix: "hadoop-datanode-bytes-written"
     type: "counter"
@@ -98,7 +98,7 @@ hadoop-datanode-activity:
 hadoop-datanode-fs-data-set-state:
   objectName: "Hadoop:name=FSDatasetState,service=DataNode"
   values:
-  - instancePrefix: "hadoop-datanode-bytes-written"
+  - instancePrefix: "hadoop-datanode-fs-capacity"
     type: "gauge"
     table: false
     attribute: "Capacity"

--- a/internal/monitors/collectd/hadoopjmx/metadata.yaml
+++ b/internal/monitors/collectd/hadoopjmx/metadata.yaml
@@ -65,145 +65,328 @@ monitors:
 
     You may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)
     monitor to collect additional metrics about the hadoop cluster from the REST API
+  groups:
+    name-node:
+      description: Metrics for NameNodes containing HDFS metadata
+    data-node:
+      description: Metrics for DataNodes containing HDFS files
+    resource-manager:
+      description: Metrics for Hadoop resource management
+    node-manager:
+      description: Metrics for Node Manager
+    jvm:
+      description: JVM metrics
+
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
+    counter.hadoop-namenode-files-total:
+      description:
+      group: name-node
+      included: false
+      type: cumulative
     counter.hadoop-namenode-gc-count:
       description:
+      group: name-node
       included: true
       type: cumulative
     counter.hadoop-namenode-gc-time:
       description:
+      group: name-node
       included: true
       type: cumulative
     counter.hadoop-namenode-rpc-total-calls:
       description:
+      group: name-node
       included: true
       type: cumulative
     counter.hadoop-namenode-total-load:
       description:
+      group: name-node
       included: true
       type: cumulative
     counter.hadoop-namenode-volume-failures:
       description:
+      group: name-node
       included: true
+      type: cumulative
+    counter.hadoop-nodeManager-containers-failed:
+      description:
+      group: node-manager
+      included: false
+      type: cumulative
+    counter.hadoop-nodeManager-containers-launched:
+      description:
+      group: node-manager
+      included: false
+      type: cumulative
+    counter.hadoop-datanode-bytes-written:
+      description:
+      group: data-node
+      included: false
+      type: cumulative
+    counter.hadoop-datanode-blocks-written:
+      description:
+      group: data-node
+      included: false
+      type: cumulative
+    counter.hadoop-datanode-blocks-read:
+      description:
+      group: data-node
+      included: false
+      type: cumulative
+    counter.hadoop-datanode-bytes-read:
+      description:
+      group: data-node
+      included: false
       type: cumulative
     gauge.hadoop-datanode-fs-capacity:
       description:
+      group: data-node
       included: true
       type: gauge
     gauge.hadoop-datanode-fs-dfs-remaining:
       description:
+      group: data-node
       included: true
       type: gauge
     gauge.hadoop-datanode-fs-dfs-used:
       description:
+      group: data-node
       included: true
+      type: gauge
+    gauge.hadoop-datanode-info-xceiver:
+      description:
+      group: data-node
+      included: false
       type: gauge
     gauge.hadoop-datanode-jvm-heap-used:
       description:
+      group: data-node
       included: true
+      type: gauge
+    gauge.hadoop-datanode-jvm-non-heap-used:
+      description:
+      group: data-node
+      included: false
       type: gauge
     gauge.hadoop-datanode-rpc-call-queue-length:
       description:
+      group: data-node
       included: true
       type: gauge
     gauge.hadoop-datanode-rpc-open-connections:
       description:
+      group: data-node
       included: true
       type: gauge
     gauge.hadoop-datanode-rpc-processing-avg:
       description:
+      group: data-node
       included: true
       type: gauge
     gauge.hadoop-datanode-rpc-queue-time-avg:
       description:
+      group: data-node
       included: true
+      type: gauge
+    gauge.hadoop-namenode-blocks-with-corrupt-replicas:
+      description:
+      group: name-node
+      included: false
+      type: gauge
+    gauge.hadoop-namenode-capacity-remaining:
+      description:
+      group: name-node
+      included: false
       type: gauge
     gauge.hadoop-namenode-capacity-total:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-capacity-used:
       description:
+      group: name-node
       included: true
+      type: gauge
+    gauge.hadoop-namenode-corrupt-blocks:
+      description:
+      group: name-node
+      included: false
       type: gauge
     gauge.hadoop-namenode-current-heap-used:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-dead-datanodes:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-dfs-free:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-live-datanodes:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-max-heap:
       description:
+      group: name-node
       included: true
+      type: gauge
+    gauge.hadoop-namenode-missing-blocks:
+      description:
+      group: name-node
+      included: false
+      type: gauge
+    gauge.hadoop-namenode-percent-dfs-used:
+      description:
+      group: name-node
+      included: false
       type: gauge
     gauge.hadoop-namenode-percent-remaining:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-rpc-avg-process-time:
       description:
+      group: name-node
       included: true
       type: gauge
     gauge.hadoop-namenode-rpc-avg-queue:
       description:
+      group: name-node
       included: true
+      type: gauge
+    gauge.hadoop-namenode-stale-datanodes:
+      description:
+      group: name-node
+      included: false
       type: gauge
     gauge.hadoop-namenode-under-replicated-blocks:
       description:
+      group: name-node
       included: true
+      type: gauge
+    gauge.hadoop-nodeManager-allocated-memory:
+      description:
+      group: node-manager
+      included: false
+      type: gauge
+    gauge.hadoop-nodeManager-allocated-vcores:
+      description:
+      group: node-manager
+      included: false
+      type: gauge
+    gauge.hadoop-nodeManager-available-memory:
+      description:
+      group: node-manager
+      included: false
+      type: gauge
+    gauge.hadoop-nodeManager-available-vcores:
+      description:
+      group: node-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-active-apps:
+      description:
+      group: resource-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-active-nms:
+      description:
+      group: resource-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-active-users:
+      description:
+      group: resource-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-allocated-containers:
+      description:
+      group: resource-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-allocated-memory:
+      description:
+      group: resource-manager
+      included: false
       type: gauge
     gauge.hadoop-resourceManager-allocated-vcores:
       description:
+      group: resource-manager
       included: true
+      type: gauge
+    gauge.hadoop-resourceManager-available-memory:
+      description:
+      group: resource-manager
+      included: false
       type: gauge
     gauge.hadoop-resourceManager-available-vcores:
       description:
+      group: resource-manager
       included: true
+      type: gauge
+    gauge.hadoop-resourceManager-heap-max:
+      description:
+      group: resource-manager
+      included: false
+      type: gauge
+    gauge.hadoop-resourceManager-heap-used:
+      description:
+      group: resource-manager
+      included: false
       type: gauge
   monitorType: collectd/hadoopjmx
   properties:

--- a/internal/monitors/collectd/kafka/metadata.yaml
+++ b/internal/monitors/collectd/kafka/metadata.yaml
@@ -21,38 +21,48 @@ monitors:
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
     counter.kafka-all-bytes-in:
       description: Number of bytes received per second across all topics

--- a/internal/monitors/collectd/kafkaconsumer/metadata.yaml
+++ b/internal/monitors/collectd/kafkaconsumer/metadata.yaml
@@ -30,38 +30,48 @@ monitors:
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
     kafka.consumer.bytes-consumed-rate:
       description: Average number of bytes consumed per second. This metric has either

--- a/internal/monitors/collectd/kafkaproducer/metadata.yaml
+++ b/internal/monitors/collectd/kafkaproducer/metadata.yaml
@@ -22,38 +22,48 @@ monitors:
   metrics:
     # Taken from genericjmx monitor. If you want to change them update genericjmx and update
     # all other monitors that use genericjmx with this same notice.
+    ### BEGIN JVM METRICS ###
     gauge.jvm.threads.count:
       description: Number of JVM threads
+      group: jvm
       included: true
       type: gauge
     gauge.loaded_classes:
       description: Number of classes loaded in the JVM
+      group: jvm
       included: true
       type: gauge
     invocations:
       description: Total number of garbage collection events
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.committed:
       description: Amount of memory guaranteed to be available in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.max:
       description: Maximum amount of memory that can be used in bytes
+      group: jvm
       included: true
       type: gauge
     jmx_memory.used:
       description: Current memory usage in bytes
+      group: jvm
       included: true
       type: gauge
     total_time_in_ms.collection_time:
       description: Amount of time spent garbage collecting in milliseconds
+      group: jvm
       included: true
       type: cumulative
     jmx_memory.init:
       description: Amount of initial memory at startup in bytes
+      group: jvm
       included: true
       type: gauge
+    ### END JVM METRICS ###
 
     kafka.producer.byte-rate:
       description: Average number of bytes sent per second for a topic. This metric

--- a/scripts/audit-monitor.py
+++ b/scripts/audit-monitor.py
@@ -1,41 +1,61 @@
-import argparse
+#!/usr/bin/env python3
 import sys
-import time
 
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
+
+import argparse
+import time
 from tests.helpers.agent import Agent
 
 
 def main(opts):
+
     config = Path(opts.config).read_text()
 
-    with Agent.run(config, debug=False, quiet=True) as agent:
+    with Agent.run(config, debug=False) as agent:
         time.sleep(opts.period)
         if opts.enable_metrics:
             print("Metrics:")
-            print('\n'.join(set(agent.fake_services.datapoints_by_metric)))
+            print("\n".join(sorted(set(agent.fake_services.datapoints_by_metric))))
         if opts.enable_dimensions:
             if opts.enable_metrics:
                 print()
             print("Dimensions:")
-            print('\n'.join(set(agent.fake_services.datapoints_by_dim)))
+            print("\n".join(sorted(set(agent.fake_services.datapoints_by_dim))))
 
 
-if __name__ == '__main__':
-    args = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter, description="""
+if __name__ == "__main__":
+    args = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="""
 Runs agent and prints out metrics and dimensions emitted. Config file example:
 
     monitors:
       - type: collectd/df
         hostFSPath: /
-""")
+""",
+    )
     args.add_argument("--config", "-c", type=str, metavar="PATH", required=True, help="Agent monitors configuration")
-    args.add_argument("-p", "--period", type=int, metavar="SECONDS", default=10,
-                      help="Collection period (default: %(default)s)")
-    args.add_argument("--without-metrics", "-wm", action="store_false", default=True, dest="enable_metrics",
-                      help="Disable metric output")
-    args.add_argument("--without-dimensions", "-wd", action="store_false", default=True, dest="enable_dimensions",
-                      help="Disable dimension output")
+    args.add_argument(
+        "-p", "--period", type=int, metavar="SECONDS", default=10, help="Collection period (default: %(default)s)"
+    )
+    args.add_argument(
+        "--without-metrics",
+        "-wm",
+        action="store_false",
+        default=True,
+        dest="enable_metrics",
+        help="Disable metric output",
+    )
+    args.add_argument(
+        "--without-dimensions",
+        "-wd",
+        action="store_false",
+        default=True,
+        dest="enable_dimensions",
+        help="Disable dimension output",
+    )
     opts = args.parse_args()
     main(opts)

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -1302,49 +1302,49 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -1860,49 +1860,49 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -4251,49 +4251,49 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -4746,210 +4746,388 @@
       "sendAll": false,
       "dimensions": null,
       "doc": "Collects metrics about a Hadoop cluster using using collectd's GenericJMX plugin.\n\nAlso see https://github.com/signalfx/integrations/tree/master/collectd-hadoop.\n\nTo enable JMX in Hadoop, add the following JVM options to hadoop-env.sh and yarn-env.sh respectively\n\n**hadoop-env.sh:**\n```sh\nexport HADOOP_NAMENODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5677 $HADOOP_NAMENODE_OPTS\"\nexport HADOOP_DATANODE_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5679 $HADOOP_DATANODE_OPTS\"\n```\n\n**yarn-env.sh:**\n```sh\nexport YARN_NODEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=8002 $YARN_NODEMANAGER_OPTS\"\nexport YARN_RESOURCEMANAGER_OPTS=\"-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=5680 $YARN_RESOURCEMANAGER_OPTS\"\n```\n\nThis monitor has a set of built in MBeans configured for:\n  - [Name Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nameNodeMBeans.go)\n  - [Resource Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/resourceManagerMBeans.go)\n  - [Node Manager](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/nodeManagerMBeans.go)\n  - [Data Nodes](https://github.com/signalfx/signalfx-agent/tree/master/internal/monitors/collectd/hadoopjmx/dataNodeMBeans.go)\n\nSample YAML configuration:\n\nName Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5677\n  nodeType: nameNode\n```\n\nResource Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5680\n  nodeType: resourceManager\n```\n\nNode Manager\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 8002\n  nodeType: nodeManager\n```\n\nData Node\n```yaml\nmonitors:\n- type: collectd/hadoopjmx\n  host: 127.0.0.1\n  port: 5679\n  nodeType: dataNode\n```\n\nYou may also configure the [collectd/hadoop](https://github.com/signalfx/signalfx-agent/tree/master/docs/monitors/collectd/hadoop)\nmonitor to collect additional metrics about the hadoop cluster from the REST API\n",
-      "groups": null,
+      "groups": {
+        "data-node": {
+          "description": "Metrics for DataNodes containing HDFS files"
+        },
+        "jvm": {
+          "description": "JVM metrics"
+        },
+        "name-node": {
+          "description": "Metrics for NameNodes containing HDFS metadata"
+        },
+        "node-manager": {
+          "description": "Metrics for Node Manager"
+        },
+        "resource-manager": {
+          "description": "Metrics for Hadoop resource management"
+        }
+      },
       "metrics": {
+        "counter.hadoop-datanode-blocks-read": {
+          "type": "cumulative",
+          "description": "",
+          "group": "data-node",
+          "included": false
+        },
+        "counter.hadoop-datanode-blocks-written": {
+          "type": "cumulative",
+          "description": "",
+          "group": "data-node",
+          "included": false
+        },
+        "counter.hadoop-datanode-bytes-read": {
+          "type": "cumulative",
+          "description": "",
+          "group": "data-node",
+          "included": false
+        },
+        "counter.hadoop-datanode-bytes-written": {
+          "type": "cumulative",
+          "description": "",
+          "group": "data-node",
+          "included": false
+        },
+        "counter.hadoop-namenode-files-total": {
+          "type": "cumulative",
+          "description": "",
+          "group": "name-node",
+          "included": false
+        },
         "counter.hadoop-namenode-gc-count": {
           "type": "cumulative",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "counter.hadoop-namenode-gc-time": {
           "type": "cumulative",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "counter.hadoop-namenode-rpc-total-calls": {
           "type": "cumulative",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "counter.hadoop-namenode-total-load": {
           "type": "cumulative",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "counter.hadoop-namenode-volume-failures": {
           "type": "cumulative",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
+        },
+        "counter.hadoop-nodeManager-containers-failed": {
+          "type": "cumulative",
+          "description": "",
+          "group": "node-manager",
+          "included": false
+        },
+        "counter.hadoop-nodeManager-containers-launched": {
+          "type": "cumulative",
+          "description": "",
+          "group": "node-manager",
+          "included": false
         },
         "gauge.hadoop-datanode-fs-capacity": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
         },
         "gauge.hadoop-datanode-fs-dfs-remaining": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
         },
         "gauge.hadoop-datanode-fs-dfs-used": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
+        },
+        "gauge.hadoop-datanode-info-xceiver": {
+          "type": "gauge",
+          "description": "",
+          "group": "data-node",
+          "included": false
         },
         "gauge.hadoop-datanode-jvm-heap-used": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
+        },
+        "gauge.hadoop-datanode-jvm-non-heap-used": {
+          "type": "gauge",
+          "description": "",
+          "group": "data-node",
+          "included": false
         },
         "gauge.hadoop-datanode-rpc-call-queue-length": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
         },
         "gauge.hadoop-datanode-rpc-open-connections": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
         },
         "gauge.hadoop-datanode-rpc-processing-avg": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
         },
         "gauge.hadoop-datanode-rpc-queue-time-avg": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "data-node",
           "included": true
+        },
+        "gauge.hadoop-namenode-blocks-with-corrupt-replicas": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
+        },
+        "gauge.hadoop-namenode-capacity-remaining": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
         },
         "gauge.hadoop-namenode-capacity-total": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-capacity-used": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
+        },
+        "gauge.hadoop-namenode-corrupt-blocks": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
         },
         "gauge.hadoop-namenode-current-heap-used": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-dead-datanodes": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-dfs-free": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-live-datanodes": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-max-heap": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
+        },
+        "gauge.hadoop-namenode-missing-blocks": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
+        },
+        "gauge.hadoop-namenode-percent-dfs-used": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
         },
         "gauge.hadoop-namenode-percent-remaining": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-rpc-avg-process-time": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
         },
         "gauge.hadoop-namenode-rpc-avg-queue": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
+        },
+        "gauge.hadoop-namenode-stale-datanodes": {
+          "type": "gauge",
+          "description": "",
+          "group": "name-node",
+          "included": false
         },
         "gauge.hadoop-namenode-under-replicated-blocks": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "name-node",
           "included": true
+        },
+        "gauge.hadoop-nodeManager-allocated-memory": {
+          "type": "gauge",
+          "description": "",
+          "group": "node-manager",
+          "included": false
+        },
+        "gauge.hadoop-nodeManager-allocated-vcores": {
+          "type": "gauge",
+          "description": "",
+          "group": "node-manager",
+          "included": false
+        },
+        "gauge.hadoop-nodeManager-available-memory": {
+          "type": "gauge",
+          "description": "",
+          "group": "node-manager",
+          "included": false
+        },
+        "gauge.hadoop-nodeManager-available-vcores": {
+          "type": "gauge",
+          "description": "",
+          "group": "node-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-active-apps": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-active-nms": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-active-users": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-allocated-containers": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-allocated-memory": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
         },
         "gauge.hadoop-resourceManager-allocated-vcores": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "resource-manager",
           "included": true
+        },
+        "gauge.hadoop-resourceManager-available-memory": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
         },
         "gauge.hadoop-resourceManager-available-vcores": {
           "type": "gauge",
           "description": "",
-          "group": null,
+          "group": "resource-manager",
           "included": true
+        },
+        "gauge.hadoop-resourceManager-heap-max": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
+        },
+        "gauge.hadoop-resourceManager-heap-used": {
+          "type": "gauge",
+          "description": "",
+          "group": "resource-manager",
+          "included": false
         },
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -6043,7 +6221,7 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.kafka-active-controllers": {
@@ -6103,37 +6281,37 @@
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "kafka-isr-expands": {
@@ -6175,7 +6353,7 @@
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -6399,43 +6577,43 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "kafka.consumer.bytes-consumed-rate": {
@@ -6471,7 +6649,7 @@
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },
@@ -6687,43 +6865,43 @@
         "gauge.jvm.threads.count": {
           "type": "gauge",
           "description": "Number of JVM threads",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "gauge.loaded_classes": {
           "type": "gauge",
           "description": "Number of classes loaded in the JVM",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "invocations": {
           "type": "cumulative",
           "description": "Total number of garbage collection events",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.committed": {
           "type": "gauge",
           "description": "Amount of memory guaranteed to be available in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.init": {
           "type": "gauge",
           "description": "Amount of initial memory at startup in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.max": {
           "type": "gauge",
           "description": "Maximum amount of memory that can be used in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "jmx_memory.used": {
           "type": "gauge",
           "description": "Current memory usage in bytes",
-          "group": null,
+          "group": "jvm",
           "included": true
         },
         "kafka.producer.byte-rate": {
@@ -6789,7 +6967,7 @@
         "total_time_in_ms.collection_time": {
           "type": "cumulative",
           "description": "Amount of time spent garbage collecting in milliseconds",
-          "group": null,
+          "group": "jvm",
           "included": true
         }
       },

--- a/tests/helpers/metadata.py
+++ b/tests/helpers/metadata.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import yaml
 
 from tests.paths import REPO_ROOT_DIR
@@ -6,11 +8,12 @@ from tests.paths import REPO_ROOT_DIR
 class Metadata:
     """Metadata information like metrics and dimensions for a monitor"""
 
-    def __init__(self, monitor_type, included_metrics, nonincluded_metrics, dims):
+    def __init__(self, monitor_type, included_metrics, nonincluded_metrics, metric_by_group, dims):
         self.monitor_type = monitor_type
         self.included_metrics = included_metrics
         self.nonincluded_mertics = nonincluded_metrics
         self.all_metrics = self.included_metrics | self.nonincluded_mertics
+        self.metrics_by_group = metric_by_group
         self.dims = dims
 
     @classmethod
@@ -21,10 +24,17 @@ class Metadata:
             doc = yaml.safe_load(fd)
             monitor = _find_monitor(doc["monitors"], mon_type)
 
+            metrics_by_group = defaultdict(set)
+            for metric, info in (monitor.get("metrics") or {}).items():
+                group = info.get("group")
+                if group:
+                    metrics_by_group[group].add(metric)
+
             return cls(
                 monitor_type=monitor["monitorType"],
                 included_metrics=frozenset(_get_monitor_metrics(monitor, included=True)),
                 nonincluded_metrics=frozenset(_get_monitor_metrics(monitor, included=False)),
+                metric_by_group=metrics_by_group,
                 dims=frozenset(_get_monitor_dims(doc)),
             )
 
@@ -43,7 +53,7 @@ def _find_monitor(monitors, mon_type):
     raise ValueError(f"mon_type {mon_type} was not found")
 
 
-def _get_monitor_metrics(monitor, included=True):
+def _get_monitor_metrics(monitor, included):
     for metric, info in (monitor.get("metrics") or {}).items():
         if info["included"] == included:
             yield metric

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -12,6 +12,7 @@ from typing import Dict, List
 import docker
 import netifaces as ni
 import yaml
+
 from tests.helpers.assertions import regex_search_matches_output
 from tests.paths import SELFDESCRIBE_JSON, TEST_SERVICES_DIR
 

--- a/tests/monitors/activemq/activemq_test.py
+++ b/tests/monitors/activemq/activemq_test.py
@@ -3,33 +3,50 @@ Tests for the collectd/activemq monitor
 """
 from functools import partial as p
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
-from tests.helpers.agent import Agent
-from tests.helpers.assertions import any_metric_found, tcp_socket_open
-from tests.helpers.util import container_ip, get_monitor_metrics_from_selfdescribe, run_service, wait_for
+
+from tests.helpers.assertions import tcp_socket_open
+from tests.helpers.metadata import Metadata
+from tests.helpers.util import container_ip, run_service, wait_for
+from tests.helpers.verify import verify_included_metrics, verify_all_metrics
 
 pytestmark = [pytest.mark.collectd, pytest.mark.activemq, pytest.mark.monitor_with_endpoints]
 
+METADATA = Metadata.from_package("collectd/activemq")
 SCRIPT_DIR = Path(__file__).parent.resolve()
 
 
-def test_activemq():
+def test_activemq_included():
     with run_service("activemq") as activemq_container:
         host = container_ip(activemq_container)
-        config = dedent(
-            f"""
-            monitors:
-              - type: collectd/activemq
-                host: {host}
-                port: 1099
-                serviceURL: service:jmx:rmi:///jndi/rmi://{host}:1099/jmxrmi
-                username: testuser
-                password: testing123
+        config = f"""
+        monitors:
+          - type: collectd/activemq
+            host: {host}
+            port: 1099
+            serviceURL: service:jmx:rmi:///jndi/rmi://{host}:1099/jmxrmi
+            username: testuser
+            password: testing123
         """
-        )
+
         assert wait_for(p(tcp_socket_open, host, 1099), 60), "service didn't start"
-        with Agent.run(config) as agent:
-            metrics = get_monitor_metrics_from_selfdescribe("collectd/activemq")
-            assert wait_for(p(any_metric_found, agent.fake_services, metrics)), "Didn't get activemq datapoints"
+        verify_included_metrics(config, METADATA)
+
+
+def test_activemq_all():
+    with run_service("activemq") as activemq_container:
+        host = container_ip(activemq_container)
+        config = f"""
+        monitors:
+          - type: collectd/activemq
+            host: {host}
+            port: 1099
+            serviceURL: service:jmx:rmi:///jndi/rmi://{host}:1099/jmxrmi
+            username: testuser
+            password: testing123
+            extraMetrics: ["*"]
+        """
+
+        assert wait_for(p(tcp_socket_open, host, 1099), 60), "service didn't start"
+        verify_all_metrics(config, METADATA)

--- a/tests/monitors/hadoopjmx/hadoopjmx_test.py
+++ b/tests/monitors/hadoopjmx/hadoopjmx_test.py
@@ -1,39 +1,45 @@
-import string
 from functools import partial as p
 
 import pytest
 
 from tests.helpers.agent import Agent
-from tests.helpers.assertions import has_datapoint_with_dim, tcp_socket_open
+from tests.helpers.assertions import tcp_socket_open, has_datapoint_with_dim
+from tests.helpers.metadata import Metadata
 from tests.helpers.util import container_ip, run_container, wait_for
+from tests.helpers.verify import verify
 from tests.monitors.hadoop.hadoop_test import start_hadoop
 
 pytestmark = [pytest.mark.collectd, pytest.mark.hadoopjmx, pytest.mark.monitor_with_endpoints]
 
+METADATA = Metadata.from_package("collectd/hadoopjmx")
+LATEST_VERSION = "3.0.3"
+VERSIONS = ["2.9.1", LATEST_VERSION]
 NODETYPE_PORT = {"nameNode": 5677, "dataNode": 5677, "resourceManager": 5680, "nodeManager": 8002}
+NODETYPE_GROUP = {
+    "nameNode": "name-node",
+    "dataNode": "data-node",
+    "resourceManager": "resource-manager",
+    "nodeManager": "node-manager",
+}
 YARN_VAR = {"resourceManager": "YARN_RESOURCEMANAGER_OPTS", "nodeManager": "YARN_NODEMANAGER_OPTS"}
 YARN_OPTS = (
     '%s="-Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false '
     '-Dcom.sun.management.jmxremote.port=%d $%s"'
 )
 YARN_ENV_PATH = "/usr/local/hadoop/etc/hadoop/yarn-env.sh"
-HADOOPJMX_CONFIG = string.Template(
-    """
+HADOOPJMX_CONFIG = """
 monitors:
   - type: collectd/hadoopjmx
-    host: $host
-    port: $port
-    nodeType: $nodeType
+    host: {host}
+    port: {port}
+    nodeType: {nodeType}
     customDimensions:
-      nodeType: $nodeType
+      nodeType: {nodeType}
+    extraMetrics: {extraMetrics}
 """
-)
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=5)
-@pytest.mark.parametrize("version", ["2.9.1", "3.0.3"])
-@pytest.mark.parametrize("node_type", NODETYPE_PORT.keys())
-def test_hadoopjmx(version, node_type):
+def run(version, node_type, metrics, extra_metrics=""):
     """
     Any new versions of hadoop should be manually built, tagged, and pushed to quay.io, i.e.
     docker build \
@@ -42,28 +48,55 @@ def test_hadoopjmx(version, node_type):
         <repo_root>/test-services/hadoop
     docker push quay.io/signalfx/hadoop-test:<version>
     """
-    with run_container("quay.io/signalfx/hadoop-test:%s" % version, hostname="hadoop-master") as hadoop_master:
-        with run_container("quay.io/signalfx/hadoop-test:%s" % version, hostname="hadoop-worker1") as hadoop_worker1:
-            if node_type in ["nameNode", "resourceManager"]:
-                container = hadoop_master
-            else:
-                container = hadoop_worker1
-            host = container_ip(container)
-            port = NODETYPE_PORT[node_type]
-            if node_type in ["resourceManager", "nodeManager"]:
-                yarn_var = YARN_VAR[node_type]
-                yarn_opts = YARN_OPTS % (yarn_var, port, yarn_var)
-                cmd = ["/bin/bash", "-c", "echo 'export %s' >> %s" % (yarn_opts, YARN_ENV_PATH)]
-                container.exec_run(cmd)
+    with run_container(
+        f"quay.io/signalfx/hadoop-test:{version}", hostname="hadoop-master"
+    ) as hadoop_master, run_container(
+        f"quay.io/signalfx/hadoop-test:{version}", hostname="hadoop-worker1"
+    ) as hadoop_worker1:
+        if node_type in ["nameNode", "resourceManager"]:
+            container = hadoop_master
+        else:
+            container = hadoop_worker1
+        host = container_ip(container)
+        port = NODETYPE_PORT[node_type]
+        if node_type in ["resourceManager", "nodeManager"]:
+            yarn_var = YARN_VAR[node_type]
+            yarn_opts = YARN_OPTS % (yarn_var, port, yarn_var)
+            cmd = ["/bin/bash", "-c", f"echo 'export {yarn_opts}' >> {YARN_ENV_PATH}"]
+            container.exec_run(cmd)
 
-            start_hadoop(hadoop_master, hadoop_worker1)
+        start_hadoop(hadoop_master, hadoop_worker1)
 
-            # wait for jmx to be available
-            assert wait_for(p(tcp_socket_open, host, port), 60), "jmx service not listening on port %d" % port
+        # wait for jmx to be available
+        assert wait_for(p(tcp_socket_open, host, port)), f"JMX service not listening on port {port}"
 
-            # start the agent with hadoopjmx config
-            config = HADOOPJMX_CONFIG.substitute(host=host, port=port, nodeType=node_type)
-            with Agent.run(config) as agent:
-                assert wait_for(p(has_datapoint_with_dim, agent.fake_services, "nodeType", node_type)), (
-                    "Didn't get hadoopjmx datapoints for nodeType %s" % node_type
-                )
+        # start the agent with hadoopjmx config
+        config = HADOOPJMX_CONFIG.format(host=host, port=port, nodeType=node_type, extraMetrics=extra_metrics)
+        with Agent.run(config) as agent:
+            verify(agent, metrics)
+            # Check for expected dimension.
+            assert has_datapoint_with_dim(
+                agent.fake_services, "nodeType", node_type
+            ), f"Didn't get hadoopjmx datapoints for nodeType {node_type}"
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+@pytest.mark.parametrize("version", VERSIONS)
+@pytest.mark.parametrize("node_type", NODETYPE_PORT.keys())
+def test_hadoopjmx_included(version, node_type):
+    included = (
+        METADATA.metrics_by_group[NODETYPE_GROUP[node_type]] | METADATA.metrics_by_group["jvm"]
+    ) & METADATA.included_metrics
+    run(version, node_type, included)
+
+
+@pytest.mark.flaky(reruns=2, reruns_delay=5)
+@pytest.mark.parametrize("node_type", NODETYPE_PORT.keys())
+def test_hadoopjmx_all(node_type):
+    # Just test latest for all metrics.
+    run(
+        LATEST_VERSION,
+        node_type,
+        METADATA.metrics_by_group[NODETYPE_GROUP[node_type]] | METADATA.metrics_by_group["jvm"],
+        extra_metrics="['*']",
+    )


### PR DESCRIPTION
* Assign all jvm metrics to jvm group
* Collect `gauge.loaded_classes` that was missing for some reason
* Add missing hadoopjmx metrics
* Add a group => metrics map to testing metadata