### PR TITLE
update k8s deployment files

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -135,7 +135,6 @@ gatherDockerMetrics: true
 # cAdvisor metrics that cause a large increase in DPM for little value for most
 # customers.
 metricsToExclude:
- - {"#from": "/lib/whitelist.json", flatten: true}
 
 
 # The path to the 'etc' directory of the underlying K8s node.  This allows the


### PR DESCRIPTION
The `update-deployments-version` was confused because of the branching for the 4.6.3 release. that was not off master. `git describe` was still showing version 4.6.2 because it wasn't a real merge. Doing a real merge of the v4.6.3 tag fixes things.