### PR TITLE
Fix spark metric collection

### DIFF
--- a/docs/monitors/collectd-spark.md
+++ b/docs/monitors/collectd-spark.md
@@ -57,9 +57,9 @@ The following table lists the metrics available for this monitor. Metrics that a
 
 | Name | Type | Included | Description |
 | ---  | ---  | ---    | ---         |
-| `counter.HiveExternalCatalog.counter.HiveClientCalls` | counter |  | Total number of client calls sent to Hive for query processing |
 | `counter.HiveExternalCatalog.fileCacheHits` | counter |  | Total number of file level cache hits occurred |
 | `counter.HiveExternalCatalog.filesDiscovered` | counter |  | Total number of files discovered |
+| `counter.HiveExternalCatalog.hiveClientCalls` | counter |  | Total number of client calls sent to Hive for query processing |
 | `counter.HiveExternalCatalog.parallelListingJobCount` | counter |  | Total number of Hive-specific jobs running in parallel |
 | `counter.HiveExternalCatalog.partitionsFetched` | counter |  | Total number of partitions fetched |
 | `counter.spark.driver.completed_tasks` | counter |  | Total number of completed tasks in driver mapped to a particular application |
@@ -163,9 +163,9 @@ required for gathering additional metrics.
 
 metricsToInclude:
   - metricNames:
-    - counter.HiveExternalCatalog.counter.HiveClientCalls
     - counter.HiveExternalCatalog.fileCacheHits
     - counter.HiveExternalCatalog.filesDiscovered
+    - counter.HiveExternalCatalog.hiveClientCalls
     - counter.HiveExternalCatalog.parallelListingJobCount
     - counter.HiveExternalCatalog.partitionsFetched
     - counter.spark.driver.completed_tasks

--- a/internal/monitors/collectd/spark/metadata.yaml
+++ b/internal/monitors/collectd/spark/metadata.yaml
@@ -27,7 +27,7 @@ monitors:
         collectApplicationMetrics: true
     ```
   metrics:
-    counter.HiveExternalCatalog.counter.HiveClientCalls:
+    counter.HiveExternalCatalog.hiveClientCalls:
       description: Total number of client calls sent to Hive for query processing
       included: false
       type: counter

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -11990,12 +11990,6 @@
       "doc": "Collects metrics about a Spark cluster using the\n[collectd Spark Python plugin](https://github.com/signalfx/collectd-spark).\nAlso see\nhttps://github.com/signalfx/integrations/tree/master/collectd-spark.\n\nYou have to specify distinct monitor configurations and discovery rules for\nmaster and worker processes.  For the master configuration, set `isMaster`\nto true.\n\nWe only support HTTP endpoints for now.\n\nWhen running Spark on Apache Hadoop / Yarn, this integration is only capable\nof reporting application metrics from the master node.  Please use the\ncollectd/hadoop monitor to report on the health of the cluster.\n\nAn example configuration for monitoring applications on Yarn\n```yaml\nmonitors:\n  - type: collectd/spark\n    host: 000.000.000.000\n    port: 8088\n    clusterType: Yarn\n    isMaster: true\n    collectApplicationMetrics: true\n```\n",
       "groups": null,
       "metrics": {
-        "counter.HiveExternalCatalog.counter.HiveClientCalls": {
-          "type": "counter",
-          "description": "Total number of client calls sent to Hive for query processing",
-          "group": null,
-          "included": false
-        },
         "counter.HiveExternalCatalog.fileCacheHits": {
           "type": "counter",
           "description": "Total number of file level cache hits occurred",
@@ -12005,6 +11999,12 @@
         "counter.HiveExternalCatalog.filesDiscovered": {
           "type": "counter",
           "description": "Total number of files discovered",
+          "group": null,
+          "included": false
+        },
+        "counter.HiveExternalCatalog.hiveClientCalls": {
+          "type": "counter",
+          "description": "Total number of client calls sent to Hive for query processing",
           "group": null,
           "included": false
         },

--- a/test-services/spark/Dockerfile
+++ b/test-services/spark/Dockerfile
@@ -1,0 +1,12 @@
+FROM gettyimages/spark:2.4.1-hadoop-3.0
+
+RUN apt-get update && \
+    apt-get install -y netcat procps
+
+EXPOSE 8080
+
+WORKDIR $SPARK_HOME
+COPY metrics.properties $SPARK_HOME/conf/metrics.properties
+COPY spark-defaults.conf $SPARK_HOME/conf/spark-defaults.conf
+
+CMD ["./bin/spark-class", "org.apache.spark.deploy.master.Master"]

--- a/test-services/spark/metrics.properties
+++ b/test-services/spark/metrics.properties
@@ -1,0 +1,14 @@
+*.sink.jmx.class=org.apache.spark.metrics.sink.JmxSink
+
+*.sink.servlet.class=org.apache.spark.metrics.sink.MetricsServlet
+*.sink.servlet.period=1
+*.sink.servlet.unit=seconds
+*.sink.servlet.path=/metrics/json/
+master.sink.servlet.path=/metrics/master/json/
+applications.sink.servlet.path=/metrics/applications/json/
+
+master.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+worker.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+driver.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+executor.source.jvm.class=org.apache.spark.metrics.source.JvmSource
+application.source.jvm.class=org.apache.spark.metrics.source.JvmSource

--- a/test-services/spark/spark-defaults.conf
+++ b/test-services/spark/spark-defaults.conf
@@ -1,0 +1,12 @@
+# Default system properties included when running spark-submit.
+# This is useful for setting default environmental settings.
+
+spark.driver.port 7001
+spark.fileserver.port 7002
+spark.broadcast.port 7003
+spark.replClassServer.port 7004
+spark.blockManager.port 7005
+spark.executor.port 7006
+
+spark.broadcast.factory=org.apache.spark.broadcast.HttpBroadcastFactory
+spark.port.maxRetries 4

--- a/tests/monitors/spark/spark_test.py
+++ b/tests/monitors/spark/spark_test.py
@@ -1,0 +1,100 @@
+"""
+Tests for the collectd/spark monitor
+"""
+from functools import partial as p
+
+import pytest
+
+from tests.helpers.agent import Agent
+from tests.helpers.assertions import has_datapoint_with_dim, tcp_socket_open
+from tests.helpers.metadata import Metadata
+from tests.helpers.util import container_ip, run_service, wait_for
+from tests.helpers.verify import verify
+
+pytestmark = [pytest.mark.collectd, pytest.mark.spark, pytest.mark.monitor_with_endpoints]
+
+METADATA = Metadata.from_package("collectd/spark")
+
+# TODO: figure out how to get these metrics
+EXCLUDED = {
+    "gauge.jvm.MarkSweepCompact.count",
+    "gauge.jvm.MarkSweepCompact.time",
+    "gauge.jvm.pools.Eden-Space.committed",
+    "gauge.jvm.pools.Eden-Space.used",
+    "gauge.jvm.pools.Survivor-Space.committed",
+    "gauge.jvm.pools.Survivor-Space.used",
+    "gauge.jvm.pools.Tenured-Gen.committed",
+    "gauge.jvm.pools.Tenured-Gen.used",
+}
+
+SPARK_APP = "examples/src/main/python/streaming/network_wordcount.py localhost 9999"
+
+
+def run(config, metrics):
+    with run_service("spark", command="bin/spark-class org.apache.spark.deploy.master.Master") as spark_master:
+        master_ip = container_ip(spark_master)
+        assert wait_for(p(tcp_socket_open, master_ip, 7077), 60), "master service didn't start"
+        assert wait_for(p(tcp_socket_open, master_ip, 8080), 60), "master webui service didn't start"
+        assert spark_master.exec_run("./sbin/start-history-server.sh").exit_code == 0, "history service didn't start"
+
+        with run_service(
+            "spark", command=f"bin/spark-class org.apache.spark.deploy.worker.Worker spark://{master_ip}:7077"
+        ) as spark_worker:
+            worker_ip = container_ip(spark_worker)
+            assert wait_for(p(tcp_socket_open, worker_ip, 8081), 60), "worker webui service didn't start"
+
+            spark_master.exec_run("nc -lk 9999", detach=True)
+            spark_master.exec_run(
+                f"bin/spark-submit --master spark://{master_ip}:7077 --conf spark.driver.host={master_ip} {SPARK_APP}",
+                detach=True,
+            )
+            assert wait_for(p(tcp_socket_open, master_ip, 4040), 60), "application service didn't start"
+
+            config = config.format(master_ip=master_ip, worker_ip=worker_ip)
+            with Agent.run(config) as agent:
+                verify(agent, metrics, timeout=60)
+                assert has_datapoint_with_dim(
+                    agent.fake_services, "plugin", "apache_spark"
+                ), "Didn't get spark datapoints"
+
+
+def test_spark_included():
+    run(
+        """
+        monitors:
+        - type: collectd/spark
+          host: {master_ip}
+          port: 8080
+          clusterType: Standalone
+          isMaster: true
+          collectApplicationMetrics: true
+        - type: collectd/spark
+          host: {worker_ip}
+          port: 8081
+          clusterType: Standalone
+          isMaster: false
+        """,
+        METADATA.included_metrics,
+    )
+
+
+def test_spark_all():
+    run(
+        """
+        monitors:
+        - type: collectd/spark
+          host: {master_ip}
+          port: 8080
+          clusterType: Standalone
+          isMaster: true
+          collectApplicationMetrics: true
+          enhancedMetrics: true
+        - type: collectd/spark
+          host: {worker_ip}
+          port: 8081
+          clusterType: Standalone
+          isMaster: false
+          enhancedMetrics: true
+        """,
+        METADATA.all_metrics - EXCLUDED,
+    )


### PR DESCRIPTION
The collectApplicationMetrics and enhancedMetrics options were not being
interpreted correctly in the Python plugin due to being bools instead of
strings.