### PR TITLE
Update MongoDB plugin to latest version

### DIFF
--- a/collectd-plugins.yaml
+++ b/collectd-plugins.yaml
@@ -50,7 +50,7 @@
   repo: signalfx/collectd-marathon
 
 - name: mongodb
-  version: v1.2.2
+  version: v1.2.3
   repo: signalfx/collectd-mongodb
   pip_packages:
     - pymongo[tls]==3.3.1


### PR DESCRIPTION
Changes the version checker from `StrictVersion` to `LooseVersion` to allow versions like "3.1.0-1.10" to pass the version check.