### PR TITLE
Force persmissions on gpg key to be default after downloading

### DIFF
--- a/deployments/installer/install.sh
+++ b/deployments/installer/install.sh
@@ -209,6 +209,7 @@ download_debian_key() {
     echo "Could not get the SignalFx Debian GPG signing key" >&2
     exit 1
   fi
+  chmod 644 /etc/apt/trusted.gpg.d/signalfx.gpg
 }
 
 install_debian_apt_source() {


### PR DESCRIPTION
We assume that the default unmask on user's systems will be 644. If they have modified it (e.g. 640 not world readable) then the install script fails. This is an assertion makes sure the permissions on the key will be default 644.