### PR TITLE
Fix statsd metric aggregation

### DIFF
--- a/internal/monitors/statsd/monitor.go
+++ b/internal/monitors/statsd/monitor.go
@@ -141,12 +141,12 @@ func aggregateMetrics(metrics []*statsDMetric) map[string]*statsDMetric {
 	metricsMap := make(map[string]*statsDMetric)
 
 	for _, metric := range metrics {
-		if _, exists := metricsMap[metric.metricName]; exists && metricTypeMap[metric.metricType] == datapoint.Count {
+		if _, exists := metricsMap[metric.rawMetricName]; exists && metricTypeMap[metric.metricType] == datapoint.Count {
 			// Add up
-			metricsMap[metric.metricName].value += metric.value
+			metricsMap[metric.rawMetricName].value += metric.value
 		} else {
 			// Create a new one or drop older metric by overwriting
-			metricsMap[metric.metricName] = metric
+			metricsMap[metric.rawMetricName] = metric
 		}
 	}
 

--- a/internal/monitors/statsd/statsd.go
+++ b/internal/monitors/statsd/statsd.go
@@ -19,10 +19,11 @@ type statsDListener struct {
 }
 
 type statsDMetric struct {
-	metricName string
-	metricType string
-	value      float64
-	dimensions map[string]string
+	rawMetricName string
+	metricName    string
+	metricType    string
+	value         float64
+	dimensions    map[string]string
 }
 
 func (sl *statsDListener) Listen() error {
@@ -150,10 +151,11 @@ func parseMetrics(raw []string, converters []*converter, prefix string) []*stats
 
 		if err == nil {
 			metrics = append(metrics, &statsDMetric{
-				metricName: metricName,
-				metricType: metricType,
-				value:      value,
-				dimensions: dims,
+				rawMetricName: rawMetricName,
+				metricName:    metricName,
+				metricType:    metricType,
+				value:         value,
+				dimensions:    dims,
 			})
 		} else {
 			logger.WithError(err).Errorf("Failed parsing metric value %s", strValue)


### PR DESCRIPTION
Statsd monitor currently aggregate metrics by the metric name after parsing. Then, same type of metrics with different dimensions(mesh, service, etc.) will be merged together and form incorrect values / omit metrics for certain services. This PR fixes the issue by aggregating metrics by the raw metric name before parsing all the dimensions.