### PR TITLE
Add UseBasicParsing paramater to windows install script

### DIFF
--- a/deployments/installer/install.ps1
+++ b/deployments/installer/install.ps1
@@ -152,7 +152,7 @@ function verify_access_token([string]$access_token="", [string]$ingest_url=$INGE
     echo $url
     try {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        $resp = Invoke-WebRequest -Uri $url -Method POST -ContentType "application/json" -Headers @{"X-Sf-Token"="$access_token"} -Body "[]"
+        $resp = Invoke-WebRequest -Uri $url -Method POST -ContentType "application/json" -Headers @{"X-Sf-Token"="$access_token"} -Body "[]" -UseBasicParsing
     } catch {
         $err = $_.Exception.Message
         $message = "


### PR DESCRIPTION
Note: This parameter has been deprecated. Beginning with PowerShell 6.0.0, all Web requests use basic parsing only. This parameter is included for backwards compatibility only and any use of it will have no effect on the operation of the cmdlet.


