### PR TITLE
Update couchbase monitor doc

### DIFF
--- a/docs/monitors/collectd-couchbase.md
+++ b/docs/monitors/collectd-couchbase.md
@@ -61,7 +61,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `collectTarget` | **yes** | `string` | Define what this Module block will monitor: "NODE", for a Couchbase node, or "BUCKET" for a Couchbase bucket. |
 | `collectBucket` | no | `string` | If CollectTarget is "BUCKET", CollectBucket specifies the name of the bucket that this will monitor. |
 | `clusterName` | no | `string` | Name of this Couchbase cluster. (**default**:"default") |
-| `collectMode` | no | `string` | Change to "detailed" to collect all available metrics from Couchbase stats API. Defaults to "default", collecting a curated set that works well with SignalFx. See [metric_info.py](https://github.com/signalfx/collectd-couchbase/blob/master/metric_info.py) for more information. |
+| `collectMode` | no | `string` | Change to "detailed" to collect all available metrics from Couchbase stats API. Defaults to "default", collecting a curated set that works well with SignalFx. |
 | `username` | no | `string` | Username to authenticate with |
 | `password` | no | `string` | Password to authenticate with |
 

--- a/internal/monitors/collectd/couchbase/couchbase.go
+++ b/internal/monitors/collectd/couchbase/couchbase.go
@@ -39,7 +39,7 @@ type Config struct {
 	ClusterName string `yaml:"clusterName"`
 	// Change to "detailed" to collect all available metrics from Couchbase
 	// stats API. Defaults to "default", collecting a curated set that works
-	// well with SignalFx. See [metric_info.py](https://github.com/signalfx/collectd-couchbase/blob/master/metric_info.py) for more information.
+	// well with SignalFx.
 	CollectMode string `yaml:"collectMode"`
 	// Username to authenticate with
 	Username string `yaml:"username"`

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -3499,7 +3499,7 @@
           },
           {
             "yamlName": "collectMode",
-            "doc": "Change to \"detailed\" to collect all available metrics from Couchbase stats API. Defaults to \"default\", collecting a curated set that works well with SignalFx. See [metric_info.py](https://github.com/signalfx/collectd-couchbase/blob/master/metric_info.py) for more information.",
+            "doc": "Change to \"detailed\" to collect all available metrics from Couchbase stats API. Defaults to \"default\", collecting a curated set that works well with SignalFx.",
             "default": "",
             "required": false,
             "type": "string",


### PR DESCRIPTION
The link to the `metric_info.py` is misleading because the "default" vs "detailed" metrics in that list do *not* match our version of "standard" vs "custom".

Removing to link to that list of metrics will prevent confusion and encourage users to use the list of metrics below instead.


Also, fixed a broken conviva link.