### PR TITLE
let newer chef versions use yum_repository

### DIFF
--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'SignalFx, Inc.'
 maintainer_email 'support@signalfx.com'
 license 'Apache-2.0'
 description 'Installs/Configures the SignalFx Agent'
-version '0.2.5'
+version '0.2.6'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 supports 'amazon'

--- a/deployments/chef/recipes/yum_repo.rb
+++ b/deployments/chef/recipes/yum_repo.rb
@@ -1,26 +1,37 @@
 
-file '/etc/yum.repos.d/signalfx-agent.repo' do
-  content <<-EOH
-[signalfx-agent]
-name=SignalFx Agent Repository
-baseurl=#{node['signalfx_agent']['rhel_repo_url']}/#{node['signalfx_agent']['package_stage']}
-gpgcheck=1
-gpgkey=#{node['signalfx_agent']['rhel_gpg_key_url']}
-enabled=1
-  EOH
-  mode '0644'
-  notifies :run, 'execute[add-rhel-key]', :immediately
-end
+if Gem::Requirement.new('>= 12.14').satisfied_by?(Gem::Version.new(Chef::VERSION))
+  yum_repository 'signalfx-agent' do
+    description 'SignalFx Agent Repository'
+    baseurl "#{node['signalfx_agent']['rhel_repo_url']}/#{node['signalfx_agent']['package_stage']}"
+    gpgcheck true
+    gpgkey node['signalfx_agent']['rhel_gpg_key_url']
+    enabled true
+    action :create
+  end
+else
+  file '/etc/yum.repos.d/signalfx-agent.repo' do
+    content <<-EOH
+  [signalfx-agent]
+  name=SignalFx Agent Repository
+  baseurl=#{node['signalfx_agent']['rhel_repo_url']}/#{node['signalfx_agent']['package_stage']}
+  gpgcheck=1
+  gpgkey=#{node['signalfx_agent']['rhel_gpg_key_url']}
+  enabled=1
+    EOH
+    mode '0644'
+    notifies :run, 'execute[add-rhel-key]', :immediately
+  end
 
-execute 'add-rhel-key' do
-  command "rpm --import #{node['signalfx_agent']['rhel_gpg_key_url']}"
-  action :nothing
-end
+  execute 'add-rhel-key' do
+    command "rpm --import #{node['signalfx_agent']['rhel_gpg_key_url']}"
+    action :nothing
+  end
 
-execute 'yum-clean' do
-  command "yum clean all --disablerepo='*' --enablerepo='signalfx-agent'"
-end
+  execute 'yum-clean' do
+    command "yum clean all --disablerepo='*' --enablerepo='signalfx-agent'"
+  end
 
-execute 'yum-metadata-refresh' do
-  command "yum -q -y makecache --disablerepo=* --enablerepo='signalfx-agent'"
+  execute 'yum-metadata-refresh' do
+    command "yum -q -y makecache --disablerepo=* --enablerepo='signalfx-agent'"
+  end
 end

--- a/deployments/chef/recipes/yum_repo.rb
+++ b/deployments/chef/recipes/yum_repo.rb
@@ -11,12 +11,12 @@ if Gem::Requirement.new('>= 12.14').satisfied_by?(Gem::Version.new(Chef::VERSION
 else
   file '/etc/yum.repos.d/signalfx-agent.repo' do
     content <<-EOH
-  [signalfx-agent]
-  name=SignalFx Agent Repository
-  baseurl=#{node['signalfx_agent']['rhel_repo_url']}/#{node['signalfx_agent']['package_stage']}
-  gpgcheck=1
-  gpgkey=#{node['signalfx_agent']['rhel_gpg_key_url']}
-  enabled=1
+[signalfx-agent]
+name=SignalFx Agent Repository
+baseurl=#{node['signalfx_agent']['rhel_repo_url']}/#{node['signalfx_agent']['package_stage']}
+gpgcheck=1
+gpgkey=#{node['signalfx_agent']['rhel_gpg_key_url']}
+enabled=1
     EOH
     mode '0644'
     notifies :run, 'execute[add-rhel-key]', :immediately


### PR DESCRIPTION
We are seeing the issue from https://github.com/signalfx/signalfx-agent/issues/585 again, although this time it is difficult to reproduce it as only select groups of instances manifest it (amazon linux 1/2, but not consistently across environments). The below has been tested on a group that was failing and they succeeded.

The approach is pretty simple, use the native chef resource where it is available and try to fall back otherwise.