### PR TITLE
Handle unique ids from Azure Scale Set VM

### DIFF
--- a/internal/core/hostid/azure.go
+++ b/internal/core/hostid/azure.go
@@ -5,16 +5,19 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 )
 
 // AzureUniqueID constructs the unique ID of the underlying Azure VM.  If
 // not running on Azure VM, returns the empty string.
+// Details about Azure Instance Metadata ednpoint:
+// https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
 func AzureUniqueID() string {
 	c := http.Client{
 		Timeout: 1 * time.Second,
 	}
-	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2017-08-01", nil)
+	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2018-10-01", nil)
 	if err != nil {
 		return ""
 	}
@@ -34,6 +37,7 @@ func AzureUniqueID() string {
 		SubscriptionID    string `json:"subscriptionId"`
 		ResourceGroupName string `json:"resourceGroupName"`
 		Name              string `json:"name"`
+		VMScaleSetName    string `json:"vmScaleSetName"`
 	}
 
 	var compute struct {
@@ -49,5 +53,19 @@ func AzureUniqueID() string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.Name)
+	if compute.Doc.VMScaleSetName == "" {
+		return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.Name)
+	}
+
+	parsedName := strings.Split(compute.Doc.Name, "_")
+
+	// names of VM's in VMScalesets seem to follow the of `<scale-set-name>_<instance-id>`
+	// where scale-set-name is alphanumeric (and is the same as compute.vmScaleSetName
+	// field from the metadata endpoint)
+	if len(parsedName) != 2 {
+		return ""
+	}
+
+	return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachinescalesets/%s/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.VMScaleSetName, parsedName[1])
+
 }

--- a/internal/core/hostid/azure.go
+++ b/internal/core/hostid/azure.go
@@ -57,7 +57,7 @@ func AzureUniqueID() string {
 		return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.Name)
 	}
 
-	instanceID := strings.TrimLeft(compute.Doc.Name, compute.Doc.VMScaleSetName + "_")
+	instanceID := strings.TrimLeft(compute.Doc.Name, compute.Doc.VMScaleSetName+"_")
 
 	// names of VM's in VMScalesets seem to follow the of `<scale-set-name>_<instance-id>`
 	// where scale-set-name is alphanumeric (and is the same as compute.vmScaleSetName

--- a/internal/core/hostid/azure.go
+++ b/internal/core/hostid/azure.go
@@ -57,15 +57,15 @@ func AzureUniqueID() string {
 		return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.Name)
 	}
 
-	parsedName := strings.Split(compute.Doc.Name, "_")
+	instanceID := strings.TrimLeft(compute.Doc.Name, compute.Doc.VMScaleSetName + "_")
 
 	// names of VM's in VMScalesets seem to follow the of `<scale-set-name>_<instance-id>`
 	// where scale-set-name is alphanumeric (and is the same as compute.vmScaleSetName
 	// field from the metadata endpoint)
-	if len(parsedName) != 2 {
+	if instanceID == "" {
 		return ""
 	}
 
-	return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachinescalesets/%s/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.VMScaleSetName, parsedName[1])
+	return fmt.Sprintf("%s/%s/microsoft.compute/virtualmachinescalesets/%s/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.VMScaleSetName, instanceID)
 
 }


### PR DESCRIPTION
- Use newer version of instance metadata endpoint `2018-10-01`
- Make `azure_resource_id` correctly for Azure Scale Set VMs

Followed: https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service

Tested manually by starting up an agent with the changes both in a standalone VM and also a VM in a Scale Set.