### PR TITLE
K8s: Exclude GKE pause containers by default

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -60,6 +60,7 @@ data:
       dockerURL: unix:///var/run/docker.sock
       excludedImages:
        - '*pause-amd64*'
+       - 'k8s.gcr.io/pause*'
       labelsToDimensions:
         io.kubernetes.container.name: container_spec_name
         io.kubernetes.pod.name: kubernetes_pod_name

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -94,6 +94,7 @@ data:
       dockerURL: unix:///var/run/docker.sock
       excludedImages:
        - '*pause-amd64*'
+       - 'k8s.gcr.io/pause*'
       labelsToDimensions:
         io.kubernetes.container.name: container_spec_name
         io.kubernetes.pod.name: kubernetes_pod_name


### PR DESCRIPTION
Tested against a GKE cluster running 1.12