### PR TITLE
Ignore everything under /var/lib/docker

### DIFF
--- a/docs/monitors/collectd-df.md
+++ b/docs/monitors/collectd-df.md
@@ -39,7 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `hostFSPath` | no | `string` | Path to the root of the host filesystem.  Useful when running in a container and the host filesystem is mounted in some subdirectory under /. |
 | `ignoreSelected` | no | `bool` | If true, the filesystems selected by `fsTypes` and `mountPoints` will be excluded and all others included. (**default:** `true`) |
 | `fsTypes` | no | `list of strings` | The filesystem types to include/exclude. (**default:** `[aufs overlay tmpfs proc sysfs nsfs cgroup devpts selinuxfs devtmpfs debugfs mqueue hugetlbfs securityfs pstore binfmt_misc autofs]`) |
-| `mountPoints` | no | `list of strings` | The mount paths to include/exclude, is interpreted as a regex if surrounded by `/`.  Note that you need to include the full path as the agent will see it, irrespective of the hostFSPath option. (**default:** `[/^/var/lib/docker/containers/ /^/var/lib/rkt/pods/ /^/net// /^/smb//]`) |
+| `mountPoints` | no | `list of strings` | The mount paths to include/exclude, is interpreted as a regex if surrounded by `/`.  Note that you need to include the full path as the agent will see it, irrespective of the hostFSPath option. (**default:** `[/^/var/lib/docker/ /^/var/lib/rkt/pods/ /^/net// /^/smb//]`) |
 | `reportByDevice` | no | `bool` |  (**default:** `false`) |
 | `reportInodes` | no | `bool` |  (**default:** `false`) |
 | `valuesPercentage` | no | `bool` | If true percent based metrics will be reported. (**default:** `false`) |

--- a/internal/monitors/collectd/df/df.go
+++ b/internal/monitors/collectd/df/df.go
@@ -36,7 +36,7 @@ type Config struct {
 	// The mount paths to include/exclude, is interpreted as a regex if
 	// surrounded by `/`.  Note that you need to include the full path as the
 	// agent will see it, irrespective of the hostFSPath option.
-	MountPoints    []string `yaml:"mountPoints" default:"[\"/^/var/lib/docker/containers/\", \"/^/var/lib/rkt/pods/\", \"/^/net//\", \"/^/smb//\"]"`
+	MountPoints    []string `yaml:"mountPoints" default:"[\"/^/var/lib/docker/\", \"/^/var/lib/rkt/pods/\", \"/^/net//\", \"/^/smb//\"]"`
 	ReportByDevice bool     `yaml:"reportByDevice" default:"false"`
 	ReportInodes   bool     `yaml:"reportInodes" default:"false"`
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -3883,7 +3883,7 @@
             "yamlName": "mountPoints",
             "doc": "The mount paths to include/exclude, is interpreted as a regex if surrounded by `/`.  Note that you need to include the full path as the agent will see it, irrespective of the hostFSPath option.",
             "default": [
-              "/^/var/lib/docker/containers/",
+              "/^/var/lib/docker/",
               "/^/var/lib/rkt/pods/",
               "/^/net//",
               "/^/smb//"


### PR DESCRIPTION
There can be other directories under /var/lib/docker besides containers. A
directory named overlay2 was observed.