### PR TITLE
Add exclude dimensions monitor configuration parameter

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -34,7 +34,7 @@ if not set.
 
 ## Config Schema
 
-  
+
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
 | `signalFxAccessToken` | no | string | The access token for the org that should receive the metrics emitted by the agent. |
@@ -103,6 +103,7 @@ The following are generic options that apply to all monitors.  Each monitor type
 | `solo` | no | bool | If one or more configurations have this set to true, only those configurations will be considered. This setting can be useful for testing. (**default:** `false`) |
 | `metricsToExclude` | no | [list of objects (see below)](#metricstoexclude) | DEPRECATED in favor of the `datapointsToExclude` option.  That option handles negation of filter items differently. |
 | `datapointsToExclude` | no | [list of objects (see below)](#datapointstoexclude) | A list of datapoint filters.  These filters allow you to comprehensively define which datapoints to exclude by metric name or dimension set, as well as the ability to define overrides to re-include metrics excluded by previous patterns within the same filter item.  See [monitor filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/filtering.md#monitor-level-filtering) for examples and more information. |
+| `dimensionsToExclude` | no | list of strings | A list of dimensions names to drop from datapoints emitted by the monitor(s) created from this configuration. |
 | `disableHostDimensions` | no | bool | Some monitors pull metrics from services not running on the same host and should not get the host-specific dimensions set on them (e.g. `host`, `AWSUniqueId`, etc).  Setting this to `true` causes those dimensions to be omitted.  You can disable this globally with the `disableHostDimensions` option on the top level of the config. (**default:** `false`) |
 | `disableEndpointDimensions` | no | bool | This can be set to true if you don't want to include the dimensions that are specific to the endpoint that was discovered by an observer.  This is useful when you have an endpoint whose identity is not particularly important since it acts largely as a proxy or adapter for other metrics. (**default:** `false`) |
 | `dimensionTransformations` | no | map of strings | A map from dimension names emitted by the monitor to the desired dimension name that will be emitted in the datapoint that goes to SignalFx.  This can be useful if you have custom metrics from your applications and want to make the dimensions from a monitor match those. Also can be useful when scraping free-form metrics, say with the `prometheus-exporter` monitor.  Right now, only static key/value transformations are supported.  Note that filtering by dimensions will be done on the *original* dimension name and not the new name. |
@@ -372,23 +373,23 @@ where applicable:
 
 
 ```yaml
-  signalFxAccessToken: 
-  ingestUrl: 
-  traceEndpointUrl: 
-  apiUrl: 
+  signalFxAccessToken:
+  ingestUrl:
+  traceEndpointUrl:
+  apiUrl:
   signalFxRealm: "us0"
-  hostname: 
-  useFullyQualifiedHost: 
+  hostname:
+  useFullyQualifiedHost:
   disableHostDimensions: false
   intervalSeconds: 10
-  globalDimensions: 
+  globalDimensions:
   sendMachineID: false
-  cluster: 
+  cluster:
   syncClusterOnHostDimension: false
   validateDiscoveryRules: true
   observers: []
   monitors: []
-  writer: 
+  writer:
     datapointMaxBatchSize: 1000
     maxDatapointsBuffered: 5000
     traceSpanMaxBatchSize: 1000
@@ -408,10 +409,10 @@ where applicable:
     staleServiceTimeout: "5m"
     traceHostCorrelationMetricsInterval: "1m"
     maxTraceSpansInFlight: 100000
-  logging: 
+  logging:
     level: "info"
     format: "text"
-  collectd: 
+  collectd:
     disableCollectd: false
     timeout: 40
     readThreads: 5
@@ -432,44 +433,44 @@ where applicable:
   profiling: false
   profilingHost: "127.0.0.1"
   profilingPort: 6060
-  bundleDir: 
-  scratch: 
-  configSources: 
+  bundleDir:
+  scratch:
+  configSources:
     watch: true
-    file: 
+    file:
       pollRateSeconds: 5
-    zookeeper: 
+    zookeeper:
       endpoints: []
       timeoutSeconds: 10
-    etcd2: 
+    etcd2:
       endpoints: []
-      username: 
-      password: 
-    consul: 
-      endpoint: 
-      username: 
-      password: 
-      token: 
-      datacenter: 
-    vault: 
-      vaultAddr: 
-      vaultToken: 
+      username:
+      password:
+    consul:
+      endpoint:
+      username:
+      password:
+      token:
+      datacenter:
+    vault:
+      vaultAddr:
+      vaultToken:
       kvV2PollInterval: "60s"
-      authMethod: 
-      iam: 
-        awsAccessKeyId: 
-        awsSecretAccessKey: 
-        awsSecurityToken: 
-        headerValue: 
-        mount: 
-        role: 
-      gcp: 
-        role: 
-        mount: 
-        credentials: 
-        jwt_exp: 
-        service_account: 
-        project: 
+      authMethod:
+      iam:
+        awsAccessKeyId:
+        awsSecretAccessKey:
+        awsSecurityToken:
+        headerValue:
+        mount:
+        role:
+      gcp:
+        role:
+        mount:
+        credentials:
+        jwt_exp:
+        service_account:
+        project:
   procPath: "/proc"
   etcPath: "/etc"
   varPath: "/var"

--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -33,6 +33,7 @@ The following config options are common to all monitors:
 | `solo` | `false` | no | `bool` | If one or more configurations have this set to true, only those configurations will be considered. This setting can be useful for testing. |
 | `metricsToExclude` |  | no | `list of objects` | DEPRECATED in favor of the `datapointsToExclude` option.  That option handles negation of filter items differently. |
 | `datapointsToExclude` |  | no | `list of objects` | A list of datapoint filters.  These filters allow you to comprehensively define which datapoints to exclude by metric name or dimension set, as well as the ability to define overrides to re-include metrics excluded by previous patterns within the same filter item.  See [monitor filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/filtering.md#monitor-level-filtering) for examples and more information. |
+| `dimensionsToExclude` | no | list of strings | A list of dimensions names to drop from datapoints emitted by the monitor(s) created from this configuration. |
 | `disableHostDimensions` | `false` | no | `bool` | Some monitors pull metrics from services not running on the same host and should not get the host-specific dimensions set on them (e.g. `host`, `AWSUniqueId`, etc).  Setting this to `true` causes those dimensions to be omitted.  You can disable this globally with the `disableHostDimensions` option on the top level of the config. |
 | `disableEndpointDimensions` | `false` | no | `bool` | This can be set to true if you don't want to include the dimensions that are specific to the endpoint that was discovered by an observer.  This is useful when you have an endpoint whose identity is not particularly important since it acts largely as a proxy or adapter for other metrics. |
 | `dimensionTransformations` |  | no | `map of strings` | A map from dimension names emitted by the monitor to the desired dimension name that will be emitted in the datapoint that goes to SignalFx.  This can be useful if you have custom metrics from your applications and want to make the dimensions from a monitor match those. Also can be useful when scraping free-form metrics, say with the `prometheus-exporter` monitor.  Right now, only static key/value transformations are supported.  Note that filtering by dimensions will be done on the *original* dimension name and not the new name. |
@@ -143,5 +144,3 @@ These are all of the monitors included in the agent, along with their possible c
 - [vmem](./monitors/vmem.md)
 - [windows-iis](./monitors/windows-iis.md)
 - [windows-legacy](./monitors/windows-legacy.md)
-
-

--- a/internal/core/config/monitor.go
+++ b/internal/core/config/monitor.go
@@ -60,6 +60,9 @@ type MonitorConfig struct {
 	// filtering](https://github.com/signalfx/signalfx-agent/tree/master/docs/filtering.md#monitor-level-filtering)
 	// for examples and more information.
 	DatapointsToExclude []MetricFilter `yaml:"datapointsToExclude" json:"datapointsToExclude" default:"[]"`
+	// A list of dimensions names to drop from datapoints emitted by the
+	// monitor(s) created from this configuration.
+	DimensionsToExclude []string `yaml:"dimensionsToExclude" json:"dimensionsToExclude" default:"[]"`
 	// Some monitors pull metrics from services not running on the same host
 	// and should not get the host-specific dimensions set on them (e.g.
 	// `host`, `AWSUniqueId`, etc).  Setting this to `true` causes those

--- a/internal/monitors/cadvisor/converter/converter.go
+++ b/internal/monitors/cadvisor/converter/converter.go
@@ -669,10 +669,6 @@ func (c *CadvisorCollector) sendDatapoint(dp *datapoint.Datapoint) {
 		dims[k] = v
 	}
 
-	// remove high cardinality dimensions
-	delete(dims, "id")
-	delete(dims, "name")
-
 	c.sendDP(dp)
 }
 

--- a/internal/monitors/manager.go
+++ b/internal/monitors/manager.go
@@ -364,6 +364,7 @@ func (mm *MonitorManager) createAndConfigureNewMonitor(config config.MonitorCust
 		dimPropChan:               mm.DimensionProps,
 		spanChan:                  mm.TraceSpans,
 		extraDims:                 map[string]string{},
+		excludeDims:               coreConfig.DimensionsToExclude,
 		dimensionTransformations:  coreConfig.DimensionTransformations,
 		monitorFiltering:          monFiltering,
 	}

--- a/internal/monitors/output.go
+++ b/internal/monitors/output.go
@@ -24,6 +24,7 @@ type monitorOutput struct {
 	spanChan                  chan<- *trace.Span
 	dimPropChan               chan<- *types.DimProperties
 	extraDims                 map[string]string
+	excludeDims               []string
 	dimensionTransformations  map[string]string
 }
 
@@ -68,6 +69,13 @@ func (mo *monitorOutput) SendDatapoint(dp *datapoint.Datapoint) {
 			dp.Dimensions[newName] = v
 			delete(dp.Dimensions, origName)
 		}
+	}
+
+	// Finally, remove any dimensions which the monitor has been configured to exclude.
+	// This includes monitor specific dimensions, and extra dimensions add via config
+	// or code.
+	for _, excludeDim := range mo.excludeDims {
+		delete(dp.Dimensions, excludeDim)
 	}
 
 	mo.dpChan <- dp

--- a/internal/monitors/output_test.go
+++ b/internal/monitors/output_test.go
@@ -1,0 +1,91 @@
+package monitors
+
+import (
+	"testing"
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	"github.com/signalfx/signalfx-agent/internal/core/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func helperTestMonitorOuput() (*monitorOutput, error) {
+	config := &config.MonitorConfig{}
+
+	var metadata *Metadata
+
+	monFiltering, err := newMonitorFiltering(config, metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	output := &monitorOutput{
+		monitorType:      "testMonitor",
+		monitorID:        "testMonitor1",
+		monitorFiltering: monFiltering,
+	}
+	return output, nil
+
+}
+
+func TestSendDatapoint(t *testing.T) {
+	// Setup our 'fixture' super basic monitorOutput
+	testMO, err := helperTestMonitorOuput()
+	assert.Nil(t, err)
+
+	// And our Datapoint channel to receive Datapoints
+	dpChan := make(chan *datapoint.Datapoint)
+	testMO.dpChan = dpChan
+
+	// Create a test Datapoint
+	testDp := datapoint.New("test.metric.name", nil, datapoint.NewIntValue(1), datapoint.Gauge, time.Now())
+
+	// Send the datapoint
+	go func() { testMO.SendDatapoint(testDp) }()
+
+	// Receive the datapoint
+	resultDp := <-dpChan
+
+	// Make sure it's come through unscathed
+	assert.Equal(t, testDp, resultDp)
+
+	// Let's add some extra dimensions to our monitorOutput
+	testMO.extraDims = map[string]string{"testDim1": "testValue1"}
+
+	// Resend the datapoint
+	go func() { testMO.SendDatapoint(testDp) }()
+
+	// Receive the datapoint
+	resultDp = <-dpChan
+
+	// Make sure it's come through unscathed
+	assert.Equal(t, map[string]string{"testDim1": "testValue1"}, resultDp.Dimensions)
+
+	// Now let's add some dimensions in the test Datapoint
+	go func() {
+		testDp.Dimensions = map[string]string{"testDim2": "testValue2"}
+		testMO.SendDatapoint(testDp)
+	}()
+
+	// Receive the datapoint
+	resultDp = <-dpChan
+
+	// Make sure it's come through unscathed
+	assert.Equal(t, map[string]string{"testDim1": "testValue1", "testDim2": "testValue2"}, resultDp.Dimensions)
+
+	// Let's now test removing an unwanted dimension
+	testMO.excludeDims = []string{"highCardDim"}
+
+	// Send the datapoint with a high cardinality dimension
+	go func() {
+		testDp.Dimensions = map[string]string{"highCardDim": "highCardValue"}
+		testMO.SendDatapoint(testDp)
+	}()
+
+	// Receive the datapoint
+	resultDp = <-dpChan
+
+	// Make sure it's come through unscathed
+	assert.Equal(t, map[string]string{"testDim1": "testValue1"}, resultDp.Dimensions)
+
+}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -179,6 +179,14 @@
         }
       },
       {
+        "yamlName": "dimensionsToExclude",
+        "doc": "A list of dimensions names to drop from datapoints emitted by the monitor(s) created from this configuration.",
+        "default": "",
+        "required": false,
+        "type": "slice",
+        "elementKind": ""
+      },
+      {
         "yamlName": "disableHostDimensions",
         "doc": "Some monitors pull metrics from services not running on the same host and should not get the host-specific dimensions set on them (e.g. `host`, `AWSUniqueId`, etc).  Setting this to `true` causes those dimensions to be omitted.  You can disable this globally with the `disableHostDimensions` option on the top level of the config.",
         "default": false,
@@ -35932,6 +35940,14 @@
                   }
                 ]
               }
+            },
+            {
+              "yamlName": "dimensionsToExclude",
+              "doc": "A list of dimensions names to drop from datapoints emitted by the monitor(s) created from this configuration.",
+              "default": "",
+              "required": false,
+              "type": "slice",
+              "elementKind": ""
             },
             {
               "yamlName": "disableHostDimensions",


### PR DESCRIPTION
Added a new configuration parameter to monitor configuration, giving the ability to explicitly drop dimensions by name from a datapoint before it gets sent. This is to deal with monitors that add potentially high cardinality tags with no way to disable them otherwise.

My editor also removed some whitespace from `config-schema.md`.

I also removed two lines from cadvisor plugin because if you read the code the lines actually do nothing. The high cardinality dimensions are `container-id` and `container-name` respectively.

