### PR TITLE
Remove collectd/processes from k8s configmap

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -43,11 +43,6 @@ data:
     - type: collectd/uptime
     - type: collectd/vmem
 
-    - type: collectd/processes
-      processes:
-      - collectd
-      - signalfx-agent
-
     - type: kubelet-stats
       kubeletAPI:
         authType: serviceAccount

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -69,11 +69,6 @@ data:
     - type: collectd/uptime
     - type: collectd/vmem
 
-    - type: collectd/processes
-      processes:
-      - collectd
-      - signalfx-agent
-
     - type: kubelet-stats
       {{- if .Values.containerStatsIntervalSeconds }}
       intervalSeconds: {{ .Values.containerStatsIntervalSeconds }}


### PR DESCRIPTION
These metrics are categorized as custom, and are not used by default in any of our built-in content. We should remove them from our k8s config map and helm chart.
I did not see any use of these in any other deployment configs.