### PR TITLE
Fix windows pathing issue

### DIFF
--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -1,6 +1,6 @@
 # Main class that installs and configures the agent
 class signalfx_agent (
-  $config,
+  $config,                # add a hiera lookup function here
   $package_stage          = 'final',
   $repo_base              = 'dl.signalfx.com',
   $config_file_path       = $::osfamily ? {

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -11,7 +11,7 @@ class signalfx_agent (
   },
   $agent_version          = '',
   $package_version        = '',
-  $installation_directory = 'C:\\Program Files\\SignalFx\\',
+  $installation_directory = 'C:\\Program Files\\SignalFx',
 ) {
 
   $service_name = 'signalfx-agent'


### PR DESCRIPTION
The escaped '\\' in the init.pp file is not required at the end of $installation_directory. This causes windows to read certain parts of the paths as ```C:\Program Files\SignalFx\\etc...```

Also added commenting on the $config parameter as it would give more clarity on how to set this. For example: Hiera lookup functions.