### PR TITLE
Enable discovery of containers without ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ run-minikube:
 
 .PHONY: push-minikube-agent
 push-minikube-agent:
-	PUSH_DOCKER_IMAGE=yes \
+	PUSH=yes \
 	  AGENT_IMAGE_NAME=localhost:5000/signalfx-agent \
 	  AGENT_VERSION=latest \
 	  SKIP_BUILD_PULL=yes \

--- a/docs/observers/docker.md
+++ b/docs/observers/docker.md
@@ -128,6 +128,7 @@ can be used in discovery rules.
 | Name | Type | Description |
 | ---  | ---  | ---         |
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
+| `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
 | `network_port` | `string` | An alias for `port` |
 | `private_port` | `string` | The port that the service endpoint runs on inside the container |
@@ -136,17 +137,18 @@ can be used in discovery rules.
 | `container_command` | `string` | The command used when running the container exposing the endpoint |
 | `container_id` | `string` | The ID of the container exposing the endpoint |
 | `container_image` | `string` | The image name of the container exposing the endpoint |
-| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
+| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper. |
 | `container_names` | `list of string` | A list of container names of the container exposing the endpoint |
 | `container_state` | `string` | The container state, will usually be "running" since otherwise the container wouldn't have a port exposed to be discovered. |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |
 | `id` | `string` |  |
-| `name` | `string` | A observer assigned name of the endpoint |
+| `name` | `string` | A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any. |
 | `orchestrator` | `integer` |  |
 | `port` | `integer` | The TCP/UDP port number of the endpoint |
 | `port_labels` | `map of string` | A map of labels on the container port. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
 | `port_type` | `string` | TCP or UDP |
+| `target` | `string` | The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits. |
 
 ## Dimensions
 

--- a/docs/observers/ecs.md
+++ b/docs/observers/ecs.md
@@ -120,6 +120,7 @@ can be used in discovery rules.
 | Name | Type | Description |
 | ---  | ---  | ---         |
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
+| `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
 | `network_port` | `string` | An alias for `port` |
 | `private_port` | `string` | The port that the service endpoint runs on inside the container |
@@ -128,17 +129,18 @@ can be used in discovery rules.
 | `container_command` | `string` | The command used when running the container exposing the endpoint |
 | `container_id` | `string` | The ID of the container exposing the endpoint |
 | `container_image` | `string` | The image name of the container exposing the endpoint |
-| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
+| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper. |
 | `container_names` | `list of string` | A list of container names of the container exposing the endpoint |
 | `container_state` | `string` | The container state, will usually be "running" since otherwise the container wouldn't have a port exposed to be discovered. |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |
 | `id` | `string` |  |
-| `name` | `string` | A observer assigned name of the endpoint |
+| `name` | `string` | A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any. |
 | `orchestrator` | `integer` |  |
 | `port` | `integer` | The TCP/UDP port number of the endpoint |
 | `port_labels` | `map of string` | A map of labels on the container port. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
 | `port_type` | `string` | TCP or UDP |
+| `target` | `string` | The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits. |
 
 ## Dimensions
 

--- a/docs/observers/host.md
+++ b/docs/observers/host.md
@@ -31,14 +31,16 @@ can be used in discovery rules.
 | Name | Type | Description |
 | ---  | ---  | ---         |
 | `command` | `string` | The full command used to invoke this process, including the executable itself at the beginning. |
+| `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
 | `network_port` | `string` | An alias for `port` |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |
 | `id` | `string` |  |
-| `name` | `string` | A observer assigned name of the endpoint |
+| `name` | `string` | A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any. |
 | `port` | `integer` | The TCP/UDP port number of the endpoint |
 | `port_type` | `string` | TCP or UDP |
+| `target` | `string` | The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits. |
 
 ## Dimensions
 

--- a/docs/observers/k8s-api.md
+++ b/docs/observers/k8s-api.md
@@ -50,25 +50,30 @@ can be used in discovery rules.
 | Name | Type | Description |
 | ---  | ---  | ---         |
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
+| `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
+| `kubernetes_annotations` | `string` | The set of annotations on the discovered pod. |
 | `network_port` | `string` | An alias for `port` |
+| `pod_metadata` | `string` | The full pod metadata object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta. |
+| `pod_spec` | `string` | The full pod spec object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec. |
 | `private_port` | `string` | The port that the service endpoint runs on inside the container |
 | `public_port` | `string` | The port exposed outside the container |
 | `alternate_port` | `integer` | Used for services that are accessed through some kind of NAT redirection as Docker does.  This could be either the public port or the private one. |
 | `container_command` | `string` | The command used when running the container exposing the endpoint |
 | `container_id` | `string` | The ID of the container exposing the endpoint |
 | `container_image` | `string` | The image name of the container exposing the endpoint |
-| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
+| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper. |
 | `container_names` | `list of string` | A list of container names of the container exposing the endpoint |
 | `container_state` | `string` | The container state, will usually be "running" since otherwise the container wouldn't have a port exposed to be discovered. |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |
 | `id` | `string` |  |
-| `name` | `string` | A observer assigned name of the endpoint |
+| `name` | `string` | A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any. |
 | `orchestrator` | `integer` |  |
 | `port` | `integer` | The TCP/UDP port number of the endpoint |
 | `port_labels` | `map of string` | A map of labels on the container port. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
 | `port_type` | `string` | TCP or UDP |
+| `target` | `string` | The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits. |
 
 ## Dimensions
 

--- a/docs/observers/k8s-kubelet.md
+++ b/docs/observers/k8s-kubelet.md
@@ -2,9 +2,9 @@
 
 # k8s-kubelet
 
- Discovers service endpoints running on the same node
-as the agent by querying the local kubelet instance.  It is generally
-recommended to use the [k8s-api](./k8s-api.md) observer because
+ **DEPRECATED** Discovers service endpoints running on
+the same node as the agent by querying the local kubelet instance.  It is
+generally recommended to use the [k8s-api](./k8s-api.md) observer because
 authentication to the local kubelet can be more difficult to setup, and also
 the kubelet API is technically not documented for public consumption, so
 this observer may break more easily in future K8s versions.
@@ -45,6 +45,7 @@ can be used in discovery rules.
 | Name | Type | Description |
 | ---  | ---  | ---         |
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
+| `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
 | `network_port` | `string` | An alias for `port` |
 | `private_port` | `string` | The port that the service endpoint runs on inside the container |
@@ -53,17 +54,18 @@ can be used in discovery rules.
 | `container_command` | `string` | The command used when running the container exposing the endpoint |
 | `container_id` | `string` | The ID of the container exposing the endpoint |
 | `container_image` | `string` | The image name of the container exposing the endpoint |
-| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
+| `container_labels` | `map of string` | A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper. |
 | `container_names` | `list of string` | A list of container names of the container exposing the endpoint |
 | `container_state` | `string` | The container state, will usually be "running" since otherwise the container wouldn't have a port exposed to be discovered. |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |
 | `id` | `string` |  |
-| `name` | `string` | A observer assigned name of the endpoint |
+| `name` | `string` | A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any. |
 | `orchestrator` | `integer` |  |
 | `port` | `integer` | The TCP/UDP port number of the endpoint |
 | `port_labels` | `map of string` | A map of labels on the container port. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
 | `port_type` | `string` | TCP or UDP |
+| `target` | `string` | The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits. |
 
 ## Dimensions
 

--- a/internal/core/services/container.go
+++ b/internal/core/services/container.go
@@ -20,7 +20,10 @@ type Container struct {
 	State string `yaml:"container_state"`
 	// A map that contains container label key/value pairs. You can use the
 	// `Contains` and `Get` helper functions in discovery rules to make use of
-	// this. See [Endpoint Discovery](../auto-discovery.md#additional-functions).
+	// this. See [Endpoint
+	// Discovery](../auto-discovery.md#additional-functions). For containers
+	// managed by Kubernetes, this will be set to the pod's labels, as
+	// individual containers do not have labels in Kubernetes proper.
 	Labels map[string]string `yaml:"container_labels"`
 }
 

--- a/internal/core/services/endpointcore.go
+++ b/internal/core/services/endpointcore.go
@@ -1,10 +1,21 @@
 package services
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/signalfx/signalfx-agent/internal/core/config"
 	"github.com/signalfx/signalfx-agent/internal/utils"
+)
+
+// TargetType represents the type of the resource an endpoint refers to.
+type TargetType string
+
+const (
+	TargetTypePod       TargetType = "pod"
+	TargetTypeHostPort  TargetType = "hostport"
+	TargetTypeContainer TargetType = "container"
+	TargetTypeHost      TargetType = "host"
 )
 
 // PortType represents the transport protocol used to communicate with this port
@@ -21,10 +32,13 @@ var ipAddrRegexp = regexp.MustCompile(`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`)
 
 var _ config.CustomConfigurable = &EndpointCore{}
 
-// EndpointCore represents an exposed network port
+// EndpointCore represents an exposed network target.  This target can be a
+// full host/port endpoint or simply a hostname/ip.
 type EndpointCore struct {
 	ID ID `yaml:"id"`
-	// A observer assigned name of the endpoint
+	// A observer assigned name of the endpoint. For example, if using the
+	// `k8s-api` observer, `name` will be the port name in the pod spec, if
+	// any.
 	Name string `yaml:"name"`
 	// The hostname/IP address of the endpoint.  If this is an IPv6 address, it
 	// will be surrounded by `[` and `]`.
@@ -33,6 +47,12 @@ type EndpointCore struct {
 	PortType PortType `yaml:"port_type"`
 	// The TCP/UDP port number of the endpoint
 	Port uint16 `yaml:"port"`
+	// The type of the thing that this endpoint directly refers to.  If the
+	// endpoint has a host and port associated with it (most common), the value
+	// will be `hostport`.  Other possible values are: `pod`, `container`,
+	// `host`.  See the docs for the specific observer you are using for more
+	// details on what types that observer emits.
+	Target TargetType `yaml:"target"`
 	// The observer that discovered this endpoint
 	DiscoveredBy  string                 `yaml:"discovered_by"`
 	Configuration map[string]interface{} `yaml:"-"`
@@ -62,6 +82,10 @@ func NewEndpointCore(id string, name string, discoveredBy string, dims map[strin
 	return ec
 }
 
+func (e *EndpointCore) String() string {
+	return fmt.Sprintf("id: %s; name: %s; host: %s; port-type: %s; port: %d; target: %s; discovered-by: %s", e.ID, e.Name, e.Host, e.PortType, e.Port, e.Target, e.DiscoveredBy)
+}
+
 // Core returns the EndpointCore since it will be embedded in an Endpoint
 // instance
 func (e *EndpointCore) Core() *EndpointCore {
@@ -69,8 +93,13 @@ func (e *EndpointCore) Core() *EndpointCore {
 }
 
 // ENDPOINT_VAR(network_port): An alias for `port`
+
 // ENDPOINT_VAR(ip_address): The IP address of the endpoint if the `host` is in
 // the from of an IPv4 address
+
+// ENDPOINT_VAR(has_port): Set to `true` if the endpoint has a port assigned to
+// it.  This will be `false` for endpoints that represent a host/container as a
+// whole.
 
 // DerivedFields returns aliased and computed variable fields for this endpoint
 func (e *EndpointCore) DerivedFields() map[string]interface{} {
@@ -80,17 +109,30 @@ func (e *EndpointCore) DerivedFields() map[string]interface{} {
 	if ipAddrRegexp.MatchString(e.Host) {
 		out["ip_address"] = e.Host
 	}
+	out["has_port"] = e.Port != 0
+
 	return utils.MergeInterfaceMaps(utils.CloneInterfaceMap(e.extraFields), utils.StringMapToInterfaceMap(e.Dimensions()), out)
 }
 
-// ExtraConfig returns a map of values to be considered when configuring a monitor
+// ExtraConfig returns a map of values to be considered when configuring a
+// monitor.  These values will take precedence over anything the user
+// specifies.
 func (e *EndpointCore) ExtraConfig() (map[string]interface{}, error) {
-	return utils.MergeInterfaceMaps(
-		map[string]interface{}{
-			"host": e.Host,
-			"port": e.Port,
-			"name": utils.FirstNonEmpty(e.Name, string(e.ID)),
-		}, e.Configuration), nil
+	vars := map[string]interface{}{
+		"name": utils.FirstNonEmpty(e.Name, string(e.ID)),
+	}
+
+	if e.Host != "" {
+		vars["host"] = e.Host
+	}
+
+	// Port 0 is never valid and so it means that the port is unknown or not
+	// applicable to this endpoint.
+	if e.Port != 0 {
+		vars["port"] = e.Port
+	}
+
+	return utils.MergeInterfaceMaps(vars, e.Configuration), nil
 }
 
 // IsSelfConfigured tells whether this endpoint comes with enough configuration

--- a/internal/observers/host/host.go
+++ b/internal/observers/host/host.go
@@ -159,6 +159,7 @@ func (o *Observer) discover() []services.Endpoint {
 			}
 			se.Port = uint16(c.Laddr.Port)
 			se.PortType = portTypeToProtocol(c.Type)
+			se.Target = services.TargetTypeHostPort
 
 			endpoints = append(endpoints, se)
 		}

--- a/internal/observers/kubelet/kubelet_test.go
+++ b/internal/observers/kubelet/kubelet_test.go
@@ -91,6 +91,15 @@ func TestNoPods(t *testing.T) {
 		}
 	}
 
+	t.Run("One pod without container port", func(t *testing.T) {
+		RegisterTestingT(t)
+		setup("testdata/pods-without-ports.json")
+		Eventually(func() int { return len(endpoints) }).Should(Equal(1))
+		re := endpoints[services.ID("redis-3165242388-n1vc7-2fafcdf-portless")].(*services.ContainerEndpoint)
+		Expect(re.Port).To(Equal(uint16(0)))
+		Expect(re.Host).To(Equal("10.2.83.18"))
+	})
+
 	t.Run("No pods at all", func(t *testing.T) {
 		RegisterTestingT(t)
 		setup("testdata/pods-no-pods.json")
@@ -100,7 +109,7 @@ func TestNoPods(t *testing.T) {
 	t.Run("Two running pods", func(t *testing.T) {
 		RegisterTestingT(t)
 		setup("testdata/pods-two-running.json")
-		Eventually(func() int { return len(endpoints) }).Should(Equal(3))
+		Eventually(func() int { return len(endpoints) }).Should(Equal(5))
 
 		re := endpoints[services.ID("redis-3165242388-n1vc7-2fafcdf-6379")].(*services.ContainerEndpoint)
 		Expect(re.Port).To(Equal(uint16(6379)))

--- a/internal/observers/kubelet/testdata/pods-without-ports.json
+++ b/internal/observers/kubelet/testdata/pods-without-ports.json
@@ -1,0 +1,114 @@
+{
+  "kind": "PodList",
+  "apiVersion": "v1",
+  "metadata": {},
+  "items": [
+    {
+      "metadata": {
+        "name": "redis-3165242388-n1vc7",
+        "generateName": "redis-3165242388-",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/redis-3165242388-n1vc7",
+        "uid": "2fafcdfe-f3a7-11e6-99cc-066fe1d5e5f9",
+        "resourceVersion": "2576367",
+        "creationTimestamp": "2017-02-15T17:50:06Z",
+        "labels": {
+          "app": "redis",
+          "pod-template-hash": "3165242388",
+          "run": "redis"
+        },
+        "annotations": {
+          "kubernetes.io/config.seen": "2017-02-15T17:50:06.680880298Z",
+          "kubernetes.io/config.source": "api",
+          "kubernetes.io/created-by": "{\"kind\":\"SerializedReference\",\"apiVersion\":\"v1\",\"reference\":{\"kind\":\"ReplicaSet\",\"namespace\":\"default\",\"name\":\"redis-3165242388\",\"uid\":\"2faac8db-f3a7-11e6-99cc-066fe1d5e5f9\",\"apiVersion\":\"extensions\",\"resourceVersion\":\"2576358\"}}\n"
+        },
+        "ownerReferences": [
+          {
+            "apiVersion": "extensions/v1beta1",
+            "kind": "ReplicaSet",
+            "name": "redis-3165242388",
+            "uid": "2faac8db-f3a7-11e6-99cc-066fe1d5e5f9",
+            "controller": true
+          }
+        ]
+      },
+      "spec": {
+        "volumes": [
+          {
+            "name": "default-token-jtt3b",
+            "secret": {
+              "secretName": "default-token-jtt3b",
+              "defaultMode": 420
+            }
+          }
+        ],
+        "containers": [
+          {
+            "name": "redis",
+            "image": "redis:latest",
+            "ports": [],
+            "resources": {},
+            "volumeMounts": [
+              {
+                "name": "default-token-jtt3b",
+                "readOnly": true,
+                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"
+              }
+            ],
+            "terminationMessagePath": "/dev/termination-log",
+            "imagePullPolicy": "Always"
+          }
+        ],
+        "restartPolicy": "Always",
+        "terminationGracePeriodSeconds": 30,
+        "dnsPolicy": "ClusterFirst",
+        "serviceAccountName": "default",
+        "serviceAccount": "default",
+        "nodeName": "ip-10-0-0-96.us-west-2.compute.internal",
+        "securityContext": {}
+      },
+      "status": {
+        "phase": "Running",
+        "conditions": [
+          {
+            "type": "Initialized",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-15T17:50:06Z"
+          },
+          {
+            "type": "Ready",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-15T17:50:09Z"
+          },
+          {
+            "type": "PodScheduled",
+            "status": "True",
+            "lastProbeTime": null,
+            "lastTransitionTime": "2017-02-15T17:50:06Z"
+          }
+        ],
+        "hostIP": "10.0.0.96",
+        "podIP": "10.2.83.18",
+        "startTime": "2017-02-15T17:50:06Z",
+        "containerStatuses": [
+          {
+            "name": "redis",
+            "state": {
+              "running": {
+                "startedAt": "2017-02-15T17:50:08Z"
+              }
+            },
+            "lastState": {},
+            "ready": true,
+            "restartCount": 0,
+            "image": "redis:latest",
+            "imageID": "docker-pullable://redis@sha256:afa4b429ef3ee08c8b198e50d684c5da0ffa43ae58631f61b08829bd6df3c500",
+            "containerID": "docker://e4e642986f4117063b5dd3bfeb72f7229eb25da94d4d7040c67c40b26877872e"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/observers/kubernetes/endpoint.go
+++ b/internal/observers/kubernetes/endpoint.go
@@ -1,0 +1,29 @@
+package kubernetes
+
+import (
+	"github.com/signalfx/signalfx-agent/internal/core/services"
+	"github.com/signalfx/signalfx-agent/internal/utils"
+)
+
+// PodEndpoint is an endpoint that represents an entire pod and not a specific
+// port in a container in the pod.
+type PodEndpoint struct {
+	services.EndpointCore `yaml:",inline"`
+	Orchestration         services.Orchestration `yaml:",inline"`
+}
+
+// NewPodEndpoint makes a new PodEndpoint and sets the Target properly.
+func NewPodEndpoint(ec *services.EndpointCore, orch *services.Orchestration) *PodEndpoint {
+	ec.Target = services.TargetTypePod
+	return &PodEndpoint{
+		EndpointCore:  *ec,
+		Orchestration: *orch,
+	}
+}
+
+// DerivedFields returns aliased and computed variable fields for this endpoint
+func (pe *PodEndpoint) DerivedFields() map[string]interface{} {
+	return utils.MergeInterfaceMaps(
+		pe.EndpointCore.DerivedFields(),
+		utils.StringMapToInterfaceMap(pe.Dimensions()))
+}

--- a/scripts/build
+++ b/scripts/build
@@ -27,7 +27,7 @@ then
   tar -C $tmpdir -zcf $output_tar.gz .
 fi
 
-if [[ "${PUSH_DOCKER_IMAGE-}" = "yes" ]]
+if [[ "${PUSH-}" = "yes" ]]
 then
     docker push ${AGENT_IMAGE_NAME}:${AGENT_VERSION}
 fi

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -39757,6 +39757,12 @@
           "description": "The first and primary name of the container as it is known to the container runtime (e.g. Docker)."
         },
         {
+          "name": "has_port",
+          "type": "string",
+          "elementKind": "",
+          "description": "Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole."
+        },
+        {
           "name": "ip_address",
           "type": "string",
           "elementKind": "",
@@ -39808,7 +39814,7 @@
           "name": "container_labels",
           "type": "map",
           "elementKind": "string",
-          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions)."
+          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper."
         },
         {
           "name": "container_names",
@@ -39844,7 +39850,7 @@
           "name": "name",
           "type": "string",
           "elementKind": "",
-          "description": "A observer assigned name of the endpoint"
+          "description": "A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any."
         },
         {
           "name": "orchestrator",
@@ -39869,6 +39875,12 @@
           "type": "string",
           "elementKind": "",
           "description": "TCP or UDP"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "elementKind": "",
+          "description": "The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits."
         }
       ]
     },
@@ -39914,6 +39926,12 @@
           "description": "The first and primary name of the container as it is known to the container runtime (e.g. Docker)."
         },
         {
+          "name": "has_port",
+          "type": "string",
+          "elementKind": "",
+          "description": "Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole."
+        },
+        {
           "name": "ip_address",
           "type": "string",
           "elementKind": "",
@@ -39965,7 +39983,7 @@
           "name": "container_labels",
           "type": "map",
           "elementKind": "string",
-          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions)."
+          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper."
         },
         {
           "name": "container_names",
@@ -40001,7 +40019,7 @@
           "name": "name",
           "type": "string",
           "elementKind": "",
-          "description": "A observer assigned name of the endpoint"
+          "description": "A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any."
         },
         {
           "name": "orchestrator",
@@ -40026,6 +40044,12 @@
           "type": "string",
           "elementKind": "",
           "description": "TCP or UDP"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "elementKind": "",
+          "description": "The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits."
         }
       ]
     },
@@ -40055,6 +40079,12 @@
           "type": "string",
           "elementKind": "",
           "description": "The full command used to invoke this process, including the executable itself at the beginning."
+        },
+        {
+          "name": "has_port",
+          "type": "string",
+          "elementKind": "",
+          "description": "Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole."
         },
         {
           "name": "ip_address",
@@ -40090,7 +40120,7 @@
           "name": "name",
           "type": "string",
           "elementKind": "",
-          "description": "A observer assigned name of the endpoint"
+          "description": "A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any."
         },
         {
           "name": "port",
@@ -40103,6 +40133,12 @@
           "type": "string",
           "elementKind": "",
           "description": "TCP or UDP"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "elementKind": "",
+          "description": "The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits."
         }
       ]
     },
@@ -40215,16 +40251,40 @@
           "description": "The first and primary name of the container as it is known to the container runtime (e.g. Docker)."
         },
         {
+          "name": "has_port",
+          "type": "string",
+          "elementKind": "",
+          "description": "Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole."
+        },
+        {
           "name": "ip_address",
           "type": "string",
           "elementKind": "",
           "description": "The IP address of the endpoint if the `host` is in the from of an IPv4 address"
         },
         {
+          "name": "kubernetes_annotations",
+          "type": "string",
+          "elementKind": "",
+          "description": "The set of annotations on the discovered pod."
+        },
+        {
           "name": "network_port",
           "type": "string",
           "elementKind": "",
           "description": "An alias for `port`"
+        },
+        {
+          "name": "pod_metadata",
+          "type": "string",
+          "elementKind": "",
+          "description": "The full pod metadata object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta."
+        },
+        {
+          "name": "pod_spec",
+          "type": "string",
+          "elementKind": "",
+          "description": "The full pod spec object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec."
         },
         {
           "name": "private_port",
@@ -40266,7 +40326,7 @@
           "name": "container_labels",
           "type": "map",
           "elementKind": "string",
-          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions)."
+          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper."
         },
         {
           "name": "container_names",
@@ -40302,7 +40362,7 @@
           "name": "name",
           "type": "string",
           "elementKind": "",
-          "description": "A observer assigned name of the endpoint"
+          "description": "A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any."
         },
         {
           "name": "orchestrator",
@@ -40327,12 +40387,18 @@
           "type": "string",
           "elementKind": "",
           "description": "TCP or UDP"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "elementKind": "",
+          "description": "The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits."
         }
       ]
     },
     {
       "name": "Config",
-      "doc": " Discovers service endpoints running on the same node\nas the agent by querying the local kubelet instance.  It is generally\nrecommended to use the [k8s-api](./k8s-api.md) observer because\nauthentication to the local kubelet can be more difficult to setup, and also\nthe kubelet API is technically not documented for public consumption, so\nthis observer may break more easily in future K8s versions.\n",
+      "doc": " **DEPRECATED** Discovers service endpoints running on\nthe same node as the agent by querying the local kubelet instance.  It is\ngenerally recommended to use the [k8s-api](./k8s-api.md) observer because\nauthentication to the local kubelet can be more difficult to setup, and also\nthe kubelet API is technically not documented for public consumption, so\nthis observer may break more easily in future K8s versions.\n",
       "package": "internal/observers/kubelet",
       "fields": [
         {
@@ -40447,6 +40513,12 @@
           "description": "The first and primary name of the container as it is known to the container runtime (e.g. Docker)."
         },
         {
+          "name": "has_port",
+          "type": "string",
+          "elementKind": "",
+          "description": "Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole."
+        },
+        {
           "name": "ip_address",
           "type": "string",
           "elementKind": "",
@@ -40498,7 +40570,7 @@
           "name": "container_labels",
           "type": "map",
           "elementKind": "string",
-          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions)."
+          "description": "A map that contains container label key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). For containers managed by Kubernetes, this will be set to the pod's labels, as individual containers do not have labels in Kubernetes proper."
         },
         {
           "name": "container_names",
@@ -40534,7 +40606,7 @@
           "name": "name",
           "type": "string",
           "elementKind": "",
-          "description": "A observer assigned name of the endpoint"
+          "description": "A observer assigned name of the endpoint. For example, if using the `k8s-api` observer, `name` will be the port name in the pod spec, if any."
         },
         {
           "name": "orchestrator",
@@ -40559,6 +40631,12 @@
           "type": "string",
           "elementKind": "",
           "description": "TCP or UDP"
+        },
+        {
+          "name": "target",
+          "type": "string",
+          "elementKind": "",
+          "description": "The type of the thing that this endpoint directly refers to.  If the endpoint has a host and port associated with it (most common), the value will be `hostport`.  Other possible values are: `pod`, `container`, `host`.  See the docs for the specific observer you are using for more details on what types that observer emits."
         }
       ]
     }

--- a/test-services/redis/redis-k8s-portless.yaml
+++ b/test-services/redis/redis-k8s-portless.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-portless-only
+  labels:
+    app: redis-portless
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-portless
+  template:
+    metadata:
+      labels:
+        app: redis-portless
+    spec:
+      containers:
+        - name: redis
+          image: redis:latest
+          readinessProbe:
+            tcpSocket:
+              port: 6379
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5

--- a/tests/helpers/kubernetes/__init__.py
+++ b/tests/helpers/kubernetes/__init__.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+if "K8S_VERSION" in os.environ and "K8S_MAX_VERSION" in os.environ:
+    K8S_IS_LATEST = os.environ["K8S_VERSION"] == os.environ["K8S_MAX_VERSION"]
+else:
+    K8S_IS_LATEST = False
+
+# Marker for only running kubernetes tests when it's the latest version.
+LATEST = pytest.mark.skipif(not K8S_IS_LATEST, reason="Skipping because K8S_LATEST is false")

--- a/tests/helpers/kubernetes/cluster.py
+++ b/tests/helpers/kubernetes/cluster.py
@@ -1,5 +1,6 @@
 import os
 import random
+import shlex
 import string
 import subprocess
 import time
@@ -59,12 +60,15 @@ class Cluster:
         """
         if namespace is None:
             namespace = self.test_namespace
-        args = f"kubectl --kubeconfig {self.kube_config_path} -n {namespace}"
+        args = ["kubectl", "-n", namespace]
+        if self.kube_config_path:
+            args += ["--kubeconfig", self.kube_config_path]
         if self.kube_context:
-            args += f" --context {self.kube_context}"
-        args += f" {command}"
+            args += ["--context", self.kube_context]
 
-        proc = subprocess.run(args, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+        args += shlex.split(command)
+
+        proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
         assert proc.returncode == 0, f"{args}:\n{proc.stdout}"
         return proc.stdout
 

--- a/tests/helpers/kubernetes/tunnel.py
+++ b/tests/helpers/kubernetes/tunnel.py
@@ -40,19 +40,20 @@ def start_tunneling_fake_service(local_host, local_port, namespace, kube_config_
     Run the client.sh script that sets up a remote tunnel from the cluster back
     to the fake backend components running locally.
     """
-    proc = subprocess.Popen(
-        ["/bin/bash", f"{SCRIPT_DIR}/tunnel/client.sh"],
-        env={
-            "KUBECONFIG": kube_config_path,
+    env = dict(os.environ)
+    env.update(
+        {
             "KUBE_CONTEXT": context or "",
+            "KUBECONFIG": kube_config_path or "",
             "LOCAL_HOST": local_host,
             "LOCAL_PORT": str(local_port),
             "REMOTE_PORT": str(local_port),
             "NAMESPACE": namespace,
-            "PATH": os.environ.get("PATH"),
-        },
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
+        }
+    )
+
+    proc = subprocess.Popen(
+        ["/bin/bash", f"{SCRIPT_DIR}/tunnel/client.sh"], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
     )
 
     get_output = pull_from_reader_in_background(proc.stdout)

--- a/tests/monitors/haproxy/haproxy_test.py
+++ b/tests/monitors/haproxy/haproxy_test.py
@@ -1,11 +1,10 @@
 from functools import partial as p
 
 import pytest
-
 from tests.helpers.agent import Agent
-from tests.helpers.assertions import datapoints_have_some_or_all_dims, has_log_message, any_metric_found
+from tests.helpers.assertions import any_metric_found, datapoints_have_some_or_all_dims, has_log_message
 from tests.helpers.metadata import Metadata
-from tests.helpers.util import container_ip, run_service, ensure_always
+from tests.helpers.util import container_ip, ensure_always, run_service
 from tests.helpers.verify import verify
 
 pytestmark = [pytest.mark.haproxy, pytest.mark.monitor_with_endpoints]
@@ -34,7 +33,6 @@ def test_haproxy_default_metrics_from_stats_page(version):
            """
         ) as agent:
             verify(agent, EXPECTED_DEFAULTS - EXPECTED_DEFAULTS_FROM_SOCKET, 10)
-            assert not has_log_message(agent.output.lower(), "error"), "error found in agent output!"
 
 
 @pytest.mark.parametrize("version", ["1.8"])
@@ -50,7 +48,6 @@ def test_haproxy_default_metrics_from_stats_page_by_discovery_rule(version):
            """
         ) as agent:
             verify(agent, EXPECTED_DEFAULTS - EXPECTED_DEFAULTS_FROM_SOCKET, 10)
-            assert not has_log_message(agent.output.lower(), "error"), "error found in agent output!"
 
 
 @pytest.mark.parametrize("version", ["1.8"])
@@ -67,7 +64,6 @@ def test_haproxy_default_and_status_metrics_from_stats_page(version):
            """
         ) as agent:
             verify(agent, (EXPECTED_DEFAULTS | {status_metric}) - EXPECTED_DEFAULTS_FROM_SOCKET, 10)
-            assert not has_log_message(agent.output.lower(), "error"), "error found in agent output!"
 
 
 @pytest.mark.parametrize("version", ["1.8"])
@@ -90,7 +86,6 @@ def test_haproxy_default_metrics_from_stats_page_proxies_to_monitor_frontend_200
                 ),
                 10,
             )
-            assert not has_log_message(agent.output.lower(), "error"), "error found in agent output!"
             assert any_metric_found(agent.fake_services, ["haproxy_response_2xx"])
 
 
@@ -116,7 +111,6 @@ def test_haproxy_default_metrics_from_stats_page_basic_auth(version):
                 ),
                 10,
             )
-            assert not has_log_message(agent.output.lower(), "error"), "error found in agent output!"
             assert any_metric_found(agent.fake_services, ["haproxy_response_2xx"])
 
 

--- a/tests/monitors/kubernetes_scheduler/kubernetes_scheduler_test.py
+++ b/tests/monitors/kubernetes_scheduler/kubernetes_scheduler_test.py
@@ -1,0 +1,24 @@
+import pytest
+from tests.helpers.kubernetes import LATEST
+from tests.helpers.metadata import Metadata
+from tests.helpers.verify import verify
+
+pytestmark = [pytest.mark.kubernetes]
+METADATA = Metadata.from_package("kubernetes/scheduler")
+
+
+@pytest.mark.kubernetes
+@LATEST
+def test_kubernetes_scheduler(k8s_cluster):
+    config = """
+        observers:
+        - type: k8s-api
+
+        monitors:
+        - type: kubernetes-scheduler
+          discoveryRule: kubernetes_pod_name =~ "kube-scheduler"
+          port: 10251
+          extraMetrics: ["*"]
+     """
+    with k8s_cluster.run_agent(config) as agent:
+        verify(agent, METADATA.all_metrics)

--- a/tests/observers/k8s_api_test.py
+++ b/tests/observers/k8s_api_test.py
@@ -89,3 +89,35 @@ def test_k8s_annotations_with_alt_ports(k8s_cluster):
         """
         with k8s_cluster.run_agent(config) as agent:
             assert wait_for(p(has_datapoint, agent.fake_services, metric_name="consul_runtime_malloc_count"))
+
+
+@pytest.mark.kubernetes
+def test_k8s_portless_pod(k8s_cluster):
+    with k8s_cluster.create_resources([TEST_SERVICES_DIR / "redis" / "redis-k8s-portless.yaml"]):
+        config = """
+            observers:
+            - type: k8s-api
+
+            monitors:
+            - type: collectd/redis
+              discoveryRule: target == "pod" && kubernetes_pod_name =~ "redis-portless-only"
+              port: 6379
+         """
+        with k8s_cluster.run_agent(config) as agent:
+            assert wait_for(p(has_datapoint, agent.fake_services, metric_name="bytes.used_memory_rss"))
+
+
+@pytest.mark.kubernetes
+def test_k8s_portless_pods_with_declared_port(k8s_cluster):
+    with k8s_cluster.create_resources([TEST_SERVICES_DIR / "redis" / "redis-k8s.yaml"]):
+        config = """
+            observers:
+            - type: k8s-api
+
+            monitors:
+            - type: collectd/redis
+              discoveryRule: target == "pod" && kubernetes_pod_name =~ "redis-deployment"
+              port: 6379
+         """
+        with k8s_cluster.run_agent(config) as agent:
+            assert wait_for(p(has_datapoint, agent.fake_services, metric_name="bytes.used_memory_rss"))

--- a/tests/paths.py
+++ b/tests/paths.py
@@ -5,7 +5,7 @@ from pathlib import Path
 REPO_ROOT_DIR = Path(__file__).parent.parent.resolve()
 PROJECT_DIR = REPO_ROOT_DIR / "tests"
 BUNDLE_DIR = Path(os.environ.get("BUNDLE_DIR", "/bundle"))
-TEST_SERVICES_DIR = Path(os.environ.get("TEST_SERVICES_DIR", "/test-services"))
+TEST_SERVICES_DIR = Path(os.environ.get("TEST_SERVICES_DIR", REPO_ROOT_DIR / "test-services"))
 SELFDESCRIBE_JSON = REPO_ROOT_DIR / "selfdescribe.json"
 
 if sys.platform == "win32":


### PR DESCRIPTION
Adds the kubernetes-scheduler monitor and some supporting changes:

* Add support for user-overridable ports on discovered services
* Allow tests to work with existing local minikube instance
* Add tar to docker image so that files can be copied into containers
  using `kubectl cp`