### PR TITLE
K8s: Add resource syncing for jobs and cronjobs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,11 @@ issues:
       linters:
         - gosec
 
+    - path: internal/monitors/kubernetes/cluster
+      text: Job
+      linters:
+        - goconst
+
 linters:
   enable-all: true
   disable:
@@ -36,6 +41,7 @@ linters:
     - prealloc
     # There are many legitimate uses of globals
     - gochecknoglobals
+
 
 run:
   modules-download-mode: vendor

--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -66,6 +66,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
 - nonResourceURLs:
   - '/metrics'
   verbs:

--- a/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
@@ -71,6 +71,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - get
+  - list
+  - watch
 - nonResourceURLs:
   - '/metrics'
   verbs:

--- a/docs/monitors/kubernetes-cluster.md
+++ b/docs/monitors/kubernetes-cluster.md
@@ -79,12 +79,18 @@ Metrics that are categorized as
 
  - ***`kubernetes.container_ready`*** (*gauge*)<br>    Whether a container has passed its readiness probe (0 for no, 1 for yes)
  - ***`kubernetes.container_restart_count`*** (*gauge*)<br>    How many times the container has restarted in the recent past.  This value is pulled directly from [the K8s API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#containerstatus-v1-core) and the value can go indefinitely high and be reset to 0 at any time depending on how your [kubelet is configured to prune dead containers](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/). It is best to not depend too much on the exact value but rather look at it as either `== 0`, in which case you can conclude there were no restarts in the recent past, or `> 0`, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+ - ***`kubernetes.cronjob.active`*** (*gauge*)<br>    The number of actively running jobs for a cronjob.
  - ***`kubernetes.daemon_set.current_scheduled`*** (*gauge*)<br>    The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod
  - ***`kubernetes.daemon_set.desired_scheduled`*** (*gauge*)<br>    The total number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)
  - ***`kubernetes.daemon_set.misscheduled`*** (*gauge*)<br>    The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod
  - ***`kubernetes.daemon_set.ready`*** (*gauge*)<br>    The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready
  - ***`kubernetes.deployment.available`*** (*gauge*)<br>    Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
  - ***`kubernetes.deployment.desired`*** (*gauge*)<br>    Number of desired pods in this deployment
+ - ***`kubernetes.job.active`*** (*gauge*)<br>    The number of actively running pods for a job.
+ - ***`kubernetes.job.completions`*** (*gauge*)<br>    The desired number of successfully finished pods the job should be run with.
+ - ***`kubernetes.job.failed`*** (*counter*)<br>    The number of pods which reased phase Failed for a job.
+ - ***`kubernetes.job.parallelism`*** (*gauge*)<br>    The max desired number of pods the job should run at any given time.
+ - ***`kubernetes.job.succeeded`*** (*counter*)<br>    The number of pods which reached phase Succeeded for a job.
  - ***`kubernetes.namespace_phase`*** (*gauge*)<br>    The current phase of namespaces (`1` for _active_ and `0` for _terminating_)
  - ***`kubernetes.node_ready`*** (*gauge*)<br>    Whether this node is ready (1), not ready (0) or in an unknown state (-1)
  - ***`kubernetes.pod_phase`*** (*gauge*)<br>    Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)

--- a/docs/monitors/openshift-cluster.md
+++ b/docs/monitors/openshift-cluster.md
@@ -80,12 +80,18 @@ Metrics that are categorized as
 
  - ***`kubernetes.container_ready`*** (*gauge*)<br>    Whether a container has passed its readiness probe (0 for no, 1 for yes)
  - ***`kubernetes.container_restart_count`*** (*gauge*)<br>    How many times the container has restarted in the recent past.  This value is pulled directly from [the K8s API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#containerstatus-v1-core) and the value can go indefinitely high and be reset to 0 at any time depending on how your [kubelet is configured to prune dead containers](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/). It is best to not depend too much on the exact value but rather look at it as either `== 0`, in which case you can conclude there were no restarts in the recent past, or `> 0`, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.
+ - ***`kubernetes.cronjob.active`*** (*gauge*)<br>    The number of actively running jobs for a cronjob.
  - ***`kubernetes.daemon_set.current_scheduled`*** (*gauge*)<br>    The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod
  - ***`kubernetes.daemon_set.desired_scheduled`*** (*gauge*)<br>    The total number of nodes that should be running the daemon pod (including nodes currently running the daemon pod)
  - ***`kubernetes.daemon_set.misscheduled`*** (*gauge*)<br>    The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod
  - ***`kubernetes.daemon_set.ready`*** (*gauge*)<br>    The number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready
  - ***`kubernetes.deployment.available`*** (*gauge*)<br>    Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.
  - ***`kubernetes.deployment.desired`*** (*gauge*)<br>    Number of desired pods in this deployment
+ - ***`kubernetes.job.active`*** (*gauge*)<br>    The number of actively running pods for a job.
+ - ***`kubernetes.job.completions`*** (*gauge*)<br>    The desired number of successfully finished pods the job should be run with.
+ - ***`kubernetes.job.failed`*** (*counter*)<br>    The number of pods which reased phase Failed for a job.
+ - ***`kubernetes.job.parallelism`*** (*gauge*)<br>    The max desired number of pods the job should run at any given time.
+ - ***`kubernetes.job.succeeded`*** (*counter*)<br>    The number of pods which reached phase Succeeded for a job.
  - ***`kubernetes.namespace_phase`*** (*gauge*)<br>    The current phase of namespaces (`1` for _active_ and `0` for _terminating_)
  - ***`kubernetes.node_ready`*** (*gauge*)<br>    Whether this node is ready (1), not ready (0) or in an unknown state (-1)
  - ***`kubernetes.pod_phase`*** (*gauge*)<br>    Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)

--- a/internal/monitors/kubernetes/cluster/clusterstate.go
+++ b/internal/monitors/kubernetes/cluster/clusterstate.go
@@ -13,6 +13,8 @@ import (
 	quota "github.com/openshift/api/quota/v1"
 	quotav1 "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -68,7 +70,8 @@ func (cs *State) Start() {
 	coreClient := cs.clientset.CoreV1().RESTClient()
 	extV1beta1Client := cs.clientset.ExtensionsV1beta1().RESTClient()
 	appsV1Client := cs.clientset.AppsV1().RESTClient()
-
+	batchV1Client := cs.clientset.BatchV1().RESTClient()
+	batchBetaV1Client := cs.clientset.BatchV1beta1().RESTClient()
 	if cs.quotaClient != nil {
 		cs.beginSyncForType(ctx, &quota.ClusterResourceQuota{}, "clusterresourcequotas", v1.NamespaceAll,
 			cs.quotaClient.RESTClient())
@@ -82,6 +85,8 @@ func (cs *State) Start() {
 	cs.beginSyncForType(ctx, &v1beta1.ReplicaSet{}, "replicasets", cs.namespace, extV1beta1Client)
 	cs.beginSyncForType(ctx, &v1.ResourceQuota{}, "resourcequotas", cs.namespace, coreClient)
 	cs.beginSyncForType(ctx, &v1.Service{}, "services", cs.namespace, coreClient)
+	cs.beginSyncForType(ctx, &batchv1.Job{}, "jobs", cs.namespace, batchV1Client)
+	cs.beginSyncForType(ctx, &batchv1beta1.CronJob{}, "cronjobs", cs.namespace, batchBetaV1Client)
 	// Node and Namespace are NOT namespaced resources, so we don't need to
 	// fetch them if we are scoped to a specific namespace
 	if cs.namespace == "" {

--- a/internal/monitors/kubernetes/cluster/metadata.yaml
+++ b/internal/monitors/kubernetes/cluster/metadata.yaml
@@ -133,6 +133,31 @@ common:
         `kubernetes_uid` dimension for this StatefulSet.
       default: true
       type: gauge
+    kubernetes.job.completions:
+      description: The desired number of successfully finished pods the job should be
+        run with.
+      default: true
+      type: gauge
+    kubernetes.job.parallelism:
+      description: The max desired number of pods the job should run at any given time.
+      default: true
+      type: gauge
+    kubernetes.job.active:
+      description: The number of actively running pods for a job.
+      default: true
+      type: gauge
+    kubernetes.job.succeeded:
+      description: The number of pods which reached phase Succeeded for a job.
+      default: true
+      type: counter
+    kubernetes.job.failed:
+      description: The number of pods which reased phase Failed for a job.
+      default: true
+      type: counter
+    kubernetes.cronjob.active:
+      description: The number of actively running jobs for a cronjob.
+      default: true
+      type: gauge
   properties:
     <node label>:
       description: All non-blank labels on a given node will be synced as properties

--- a/internal/monitors/kubernetes/cluster/metrics/cache.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cache.go
@@ -11,6 +11,8 @@ import (
 	atypes "github.com/signalfx/signalfx-agent/internal/monitors/types"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +38,7 @@ type DatapointCache struct {
 	podCache                   *k8sutil.PodCache
 	serviceCache               *k8sutil.ServiceCache
 	replicaSetCache            *k8sutil.ReplicaSetCache
+	jobCache                   *k8sutil.JobCache
 	useNodeName                bool
 	nodeConditionTypesToReport []string
 }
@@ -49,6 +52,7 @@ func NewDatapointCache(useNodeName bool, nodeConditionTypesToReport []string) *D
 		podCache:                   k8sutil.NewPodCache(),
 		serviceCache:               k8sutil.NewServiceCache(),
 		replicaSetCache:            k8sutil.NewReplicaSetCache(),
+		jobCache:                   k8sutil.NewJobCache(),
 		useNodeName:                useNodeName,
 		nodeConditionTypesToReport: nodeConditionTypesToReport,
 	}
@@ -75,6 +79,8 @@ func (dc *DatapointCache) DeleteByKey(key interface{}) {
 		dc.handleDeleteService(cacheKey)
 	case "ReplicaSet":
 		dc.replicaSetCache.DeleteByKey(cacheKey)
+	case "Job":
+		dc.jobCache.DeleteByKey(cacheKey)
 	}
 	delete(dc.uidKindCache, cacheKey)
 	delete(dc.dpCache, cacheKey)
@@ -140,6 +146,13 @@ func (dc *DatapointCache) HandleAdd(newObj runtime.Object) interface{} {
 	case *quota.ClusterResourceQuota:
 		dps = datapointsForClusterQuotas(o)
 		kind = "ClusterResourceQuota"
+	case *batchv1.Job:
+		dps, dimProps = dc.handleAddJob(o)
+		kind = "Job"
+	case *batchv1beta1.CronJob:
+		dps = datapointsForCronJob(o)
+		dimProps = dimPropsForCronJob(o)
+		kind = "CronJob"
 	default:
 		log.WithFields(log.Fields{
 			"obj": spew.Sdump(newObj),
@@ -185,7 +198,7 @@ func (dc *DatapointCache) handleAddPod(pod *v1.Pod) ([]*datapoint.Datapoint,
 	cachedPod := dc.podCache.GetCachedPod(pod.UID)
 	dps := datapointsForPod(pod)
 	if cachedPod != nil {
-		dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
+		dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache, dc.jobCache)
 		return dps, dimProps
 	}
 	return dps, nil
@@ -201,7 +214,7 @@ func (dc *DatapointCache) handleAddService(svc *v1.Service) {
 			for _, podUID := range dc.podCache.GetPodsInNamespace(svc.Namespace) {
 				cachedPod := dc.podCache.GetCachedPod(podUID)
 				if cachedPod != nil {
-					dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
+					dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache, dc.jobCache)
 					if dimProps != nil {
 						dc.addDimPropsToCache(podUID, dimProps)
 					}
@@ -217,7 +230,7 @@ func (dc *DatapointCache) handleDeleteService(svcUID types.UID) {
 	for _, podUID := range dc.serviceCache.DeleteByKey(svcUID) {
 		cachedPod := dc.podCache.GetCachedPod(podUID)
 		if cachedPod != nil {
-			dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
+			dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache, dc.jobCache)
 			if dimProps != nil {
 				dc.addDimPropsToCache(podUID, dimProps)
 			}
@@ -233,7 +246,7 @@ func (dc *DatapointCache) handleAddReplicaSet(rs *v1beta1.ReplicaSet) ([]*datapo
 		for _, podUID := range dc.podCache.GetPodsInNamespace(rs.Namespace) {
 			cachedPod := dc.podCache.GetCachedPod(podUID)
 			if cachedPod != nil {
-				dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache)
+				dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache, dc.jobCache)
 				if dimProps != nil {
 					dc.addDimPropsToCache(podUID, dimProps)
 				}
@@ -243,6 +256,29 @@ func (dc *DatapointCache) handleAddReplicaSet(rs *v1beta1.ReplicaSet) ([]*datapo
 	dps := datapointsForReplicaSet(rs)
 	dimProps := dimPropsForReplicaSet(rs)
 	return dps, dimProps
+}
+
+// handleAddJob adds a job to the internal cache and returns the datapoints and dimProps
+// for the given job. Jobs should always be created before pods, but incase we receive
+// the job out of sync, we can still check if the pod came in before the job.
+// Potential optimization would be to not check this and always assume they come in order.
+func (dc *DatapointCache) handleAddJob(job *batchv1.Job) ([]*datapoint.Datapoint, *atypes.DimProperties) {
+	if !dc.jobCache.IsCached(job) {
+		dc.jobCache.AddJob(job)
+		for _, podUID := range dc.podCache.GetPodsInNamespace(job.Namespace) {
+			cachedPod := dc.podCache.GetCachedPod(podUID)
+			if cachedPod != nil {
+				dimProps := dimPropsForPod(cachedPod, dc.serviceCache, dc.replicaSetCache, dc.jobCache)
+				if dimProps != nil {
+					dc.addDimPropsToCache(podUID, dimProps)
+				}
+			}
+		}
+	}
+	dps := datapointsForJob(job)
+	dimProps := dimPropsForJob(job)
+	return dps, dimProps
+
 }
 
 // AllDatapoints returns all of the cached datapoints.

--- a/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	k8sutil "github.com/signalfx/signalfx-agent/internal/monitors/kubernetes/utils"
+	atypes "github.com/signalfx/signalfx-agent/internal/monitors/types"
+	"github.com/signalfx/signalfx-agent/internal/utils"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+)
+
+func datapointsForCronJob(cj *batchv1beta1.CronJob) []*datapoint.Datapoint {
+	dimensions := map[string]string{
+		"metric_source":        "kubernetes",
+		"kubernetes_namespace": cj.Namespace,
+		"kubernetes_uid":       string(cj.UID),
+		"kubernetes_name":      cj.Name,
+	}
+
+	return []*datapoint.Datapoint{
+		datapoint.New(
+			"kubernetes.cronjob.active",
+			dimensions,
+			datapoint.NewIntValue(int64(len(cj.Status.Active))),
+			datapoint.Gauge,
+			time.Now()),
+	}
+}
+
+func dimPropsForCronJob(cj *batchv1beta1.CronJob) *atypes.DimProperties {
+	props, tags := k8sutil.PropsAndTagsFromLabels(cj.Labels)
+
+	props["kubernetes_name"] = cj.Name
+	props["k8s_workload"] = "CronJob"
+	props["schedule"] = cj.Spec.Schedule
+	props["concurrency_policy"] = string(cj.Spec.ConcurrencyPolicy)
+
+	for _, or := range cj.OwnerReferences {
+		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
+		props[utils.LowercaseFirstChar(or.Kind)+"_uid"] = string(or.UID)
+	}
+
+	if len(props) == 0 && len(tags) == 0 {
+		return nil
+	}
+
+	return &atypes.DimProperties{
+		Dimension: atypes.Dimension{
+			Name:  "kubernetes_uid",
+			Value: string(cj.UID),
+		},
+		Properties: props,
+		Tags:       tags,
+	}
+}

--- a/internal/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/jobs.go
@@ -1,0 +1,78 @@
+package metrics
+
+import (
+	"time"
+
+	"github.com/signalfx/golib/datapoint"
+	k8sutil "github.com/signalfx/signalfx-agent/internal/monitors/kubernetes/utils"
+	atypes "github.com/signalfx/signalfx-agent/internal/monitors/types"
+	"github.com/signalfx/signalfx-agent/internal/utils"
+	batchv1 "k8s.io/api/batch/v1"
+)
+
+func datapointsForJob(job *batchv1.Job) []*datapoint.Datapoint {
+	dimensions := map[string]string{
+		"metric_source":        "kubernetes",
+		"kubernetes_namespace": job.Namespace,
+		"kubernetes_uid":       string(job.UID),
+		"kubernetes_name":      job.Name,
+	}
+
+	return []*datapoint.Datapoint{
+		datapoint.New(
+			"kubernetes.job.completions",
+			dimensions,
+			datapoint.NewIntValue(int64(*job.Spec.Completions)),
+			datapoint.Gauge,
+			time.Now()),
+		datapoint.New(
+			"kubernetes.job.parallelism",
+			dimensions,
+			datapoint.NewIntValue(int64(*job.Spec.Parallelism)),
+			datapoint.Gauge,
+			time.Now()),
+		datapoint.New(
+			"kubernetes.job.active",
+			dimensions,
+			datapoint.NewIntValue(int64(job.Status.Active)),
+			datapoint.Gauge,
+			time.Now()),
+		datapoint.New(
+			"kubernetes.job.failed",
+			dimensions,
+			datapoint.NewIntValue(int64(job.Status.Failed)),
+			datapoint.Counter,
+			time.Now()),
+		datapoint.New(
+			"kubernetes.job.succeeded",
+			dimensions,
+			datapoint.NewIntValue(int64(job.Status.Succeeded)),
+			datapoint.Counter,
+			time.Now()),
+	}
+}
+
+func dimPropsForJob(job *batchv1.Job) *atypes.DimProperties {
+	props, tags := k8sutil.PropsAndTagsFromLabels(job.Labels)
+
+	props["kubernetes_name"] = job.Name
+	props["k8s_workload"] = "Job"
+
+	for _, or := range job.OwnerReferences {
+		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
+		props[utils.LowercaseFirstChar(or.Kind)+"_uid"] = string(or.UID)
+	}
+
+	if len(props) == 0 && len(tags) == 0 {
+		return nil
+	}
+
+	return &atypes.DimProperties{
+		Dimension: atypes.Dimension{
+			Name:  "kubernetes_uid",
+			Value: string(job.UID),
+		},
+		Properties: props,
+		Tags:       tags,
+	}
+}

--- a/internal/monitors/kubernetes/utils/jobcache.go
+++ b/internal/monitors/kubernetes/utils/jobcache.go
@@ -1,0 +1,112 @@
+package utils
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type jobSet map[types.UID]bool
+
+// JobCache is used for holding values we care about from a job
+// for quicker lookup than querying the API for them each time.
+type JobCache struct {
+	namespaceJobUIDCache map[string]jobSet
+	cachedJobs           map[types.UID]*CachedJob
+}
+
+// NewJobCache creates a new minimal job cache
+func NewJobCache() *JobCache {
+	return &JobCache{
+		namespaceJobUIDCache: make(map[string]jobSet),
+		cachedJobs:           make(map[types.UID]*CachedJob),
+	}
+}
+
+// CachedJob is used for holding only the neccesarry fields we need
+// for label syncing
+type CachedJob struct {
+	UID        types.UID
+	Name       string
+	Namespace  string
+	CronJob    *string
+	CronJobUID types.UID
+}
+
+// newCachedJob checks if a job was created by a cronjob caches
+// it if so. We only care about these types of jobs for linking
+// pods to cronjobs directly.
+func newCachedJob(job *batchv1.Job) *CachedJob {
+	var cronJob *string
+	var cronJobUID types.UID
+	for _, or := range job.OwnerReferences {
+		if or.Kind == "CronJob" {
+			cronJob = &or.Name
+			cronJobUID = or.UID
+			break
+		}
+	}
+	if cronJob != nil {
+		return &CachedJob{
+			UID:        job.UID,
+			Name:       job.Name,
+			Namespace:  job.Namespace,
+			CronJob:    cronJob,
+			CronJobUID: cronJobUID,
+		}
+	}
+
+	return nil
+}
+
+// IsCached checks if a job is already in the cache or if any of the
+// the cached fields have changed.
+func (jc *JobCache) IsCached(job *batchv1.Job) bool {
+	cachedJob, exists := jc.cachedJobs[job.UID]
+	return exists &&
+		(cachedJob.Name == job.Name) &&
+		(cachedJob.Namespace == job.Namespace)
+}
+
+// AddJob adds or updates a job in cache
+// This function should only be called after jc.IsCached
+// to prevent unnecessary updates to the internal cache.
+// Returns true if the job is added, false if it was ignored
+func (jc *JobCache) AddJob(job *batchv1.Job) bool {
+	// check if any jobs exist in this job namespace yet
+	if _, exists := jc.namespaceJobUIDCache[job.Namespace]; !exists {
+		jc.namespaceJobUIDCache[job.Namespace] = make(map[types.UID]bool)
+	}
+	cachedJob := newCachedJob(job)
+	if cachedJob != nil {
+		jc.cachedJobs[job.UID] = cachedJob
+		jc.namespaceJobUIDCache[job.Namespace][job.UID] = true
+		return true
+	}
+	return false
+}
+
+// DeleteByKey removes a job from the cache given a UID
+func (jc *JobCache) DeleteByKey(jobUID types.UID) {
+	namespace := jc.cachedJobs[jobUID].Namespace
+	delete(jc.namespaceJobUIDCache[namespace], jobUID)
+	if len(jc.namespaceJobUIDCache[namespace]) == 0 {
+		delete(jc.namespaceJobUIDCache, namespace)
+	}
+	delete(jc.cachedJobs, jobUID)
+}
+
+// GetMatchingCronJob finds a matching cronjob given a namespace and job name
+func (jc *JobCache) GetMatchingCronJob(namespace string, jobName string) (*string, types.UID) {
+	var cjName *string
+	var cjUID types.UID
+	for jobUID := range jc.namespaceJobUIDCache[namespace] {
+		cachedJob := jc.cachedJobs[jobUID]
+		if cachedJob.Name == jobName {
+			cjName = cachedJob.CronJob
+			cjUID = cachedJob.CronJobUID
+			break
+		}
+	}
+	return cjName, cjUID
+
+}

--- a/internal/neotest/k8s/testhelpers/fakek8s/fakek8s.go
+++ b/internal/neotest/k8s/testhelpers/fakek8s/fakek8s.go
@@ -57,24 +57,33 @@ func NewFakeK8s() *FakeK8s {
 
 	r := mux.NewRouter()
 
+	r.HandleFunc("/api/v1/{resource}", f.handleListResource).Methods("GET")
 	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("POST")
 	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("PUT")
 	r.HandleFunc(`/api/v1/namespaces`, f.handleCreateOrReplaceResource).Methods("DELETE")
-
-	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
-	r.HandleFunc(`/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
-
 	r.HandleFunc("/api/v1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
-	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
-	r.HandleFunc("/apis/extensions/v1beta1/{resource}", f.handleListResource).Methods("GET")
-	r.HandleFunc("/api/v1/{resource}", f.handleListResource).Methods("GET")
-
-	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleCreateOrReplaceResource).Methods("POST")
-	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}", f.handleDeleteResource).Methods("DELETE")
-
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}`, f.handleCreateOrReplaceResource).Methods("POST")
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleCreateOrReplaceResource).Methods("PUT")
 	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleDeleteResource).Methods("DELETE")
+	r.HandleFunc(`/api/v1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
+
+	r.HandleFunc("/apis/extensions/v1beta1/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc(`/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
+	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}", f.handleCreateOrReplaceResource).Methods("POST")
+	r.HandleFunc("/apis/extensions/v1beta1/namespaces/{namespace}/{resource}/{name}", f.handleDeleteResource).Methods("DELETE")
+
+	r.HandleFunc("/apis/batch/v1/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc("/apis/batch/v1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc("/apis/batch/v1/namespaces/{namespace}/{resource}", f.handleCreateOrReplaceResource).Methods("POST")
+	r.HandleFunc(`/apis/batch/v1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
+	r.HandleFunc("/apis/batch/v1/namespaces/{namespace}/{resource}/{name}", f.handleDeleteResource).Methods("DELETE")
+
+	r.HandleFunc("/apis/batch/v1beta1/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc("/apis/batch/v1beta1/namespaces/{namespace}/{resource}", f.handleListResource).Methods("GET")
+	r.HandleFunc("/apis/batch/v1beta1/namespaces/{namespace}/{resource}", f.handleCreateOrReplaceResource).Methods("POST")
+	r.HandleFunc(`/apis/batch/v1beta1/namespaces/{namespace}/{resource}/{name}`, f.handleGetResourceByName).Methods("GET")
+	r.HandleFunc("/apis/batch/v1beta1/namespaces/{namespace}/{resource}/{name}", f.handleDeleteResource).Methods("DELETE")
 
 	r.Use(loggingMiddleware)
 
@@ -355,6 +364,10 @@ func pluralNameToKind(name string) resourceKind {
 		return "Secret"
 	case "services":
 		return "Service"
+	case "jobs":
+		return "Job"
+	case "cronjobs":
+		return "CronJob"
 	default:
 		panic("Unknown resource type: " + name)
 	}
@@ -381,6 +394,10 @@ func typeMeta(rt resourceKind) metav1.TypeMeta {
 		return metav1.TypeMeta{Kind: "SecretList", APIVersion: "v1"}
 	case "Service":
 		return metav1.TypeMeta{Kind: "ServiceList", APIVersion: "v1"}
+	case "Job":
+		return metav1.TypeMeta{Kind: "JobList", APIVersion: "batch/v1"}
+	case "CronJob":
+		return metav1.TypeMeta{Kind: "CronJobList", APIVersion: "batch/v1beta1"}
 	default:
 		panic("Unknown resource type: " + string(rt))
 	}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -26263,12 +26263,18 @@
           "metrics": [
             "kubernetes.container_ready",
             "kubernetes.container_restart_count",
+            "kubernetes.cronjob.active",
             "kubernetes.daemon_set.current_scheduled",
             "kubernetes.daemon_set.desired_scheduled",
             "kubernetes.daemon_set.misscheduled",
             "kubernetes.daemon_set.ready",
             "kubernetes.deployment.available",
             "kubernetes.deployment.desired",
+            "kubernetes.job.active",
+            "kubernetes.job.completions",
+            "kubernetes.job.failed",
+            "kubernetes.job.parallelism",
+            "kubernetes.job.succeeded",
             "kubernetes.namespace_phase",
             "kubernetes.node_ready",
             "kubernetes.pod_phase",
@@ -26295,6 +26301,12 @@
         "kubernetes.container_restart_count": {
           "type": "gauge",
           "description": "How many times the container has restarted in the recent past.  This value is pulled directly from [the K8s API](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#containerstatus-v1-core) and the value can go indefinitely high and be reset to 0 at any time depending on how your [kubelet is configured to prune dead containers](https://kubernetes.io/docs/concepts/cluster-administration/kubelet-garbage-collection/). It is best to not depend too much on the exact value but rather look at it as either `== 0`, in which case you can conclude there were no restarts in the recent past, or `\u003e 0`, in which case you can conclude there were restarts in the recent past, and not try and analyze the value beyond that.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.cronjob.active": {
+          "type": "gauge",
+          "description": "The number of actively running jobs for a cronjob.",
           "group": null,
           "default": true
         },
@@ -26331,6 +26343,36 @@
         "kubernetes.deployment.desired": {
           "type": "gauge",
           "description": "Number of desired pods in this deployment",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.active": {
+          "type": "gauge",
+          "description": "The number of actively running pods for a job.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.completions": {
+          "type": "gauge",
+          "description": "The desired number of successfully finished pods the job should be run with.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.failed": {
+          "type": "counter",
+          "description": "The number of pods which reased phase Failed for a job.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.parallelism": {
+          "type": "gauge",
+          "description": "The max desired number of pods the job should run at any given time.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.succeeded": {
+          "type": "counter",
+          "description": "The number of pods which reached phase Succeeded for a job.",
           "group": null,
           "default": true
         },
@@ -27037,12 +27079,18 @@
           "metrics": [
             "kubernetes.container_ready",
             "kubernetes.container_restart_count",
+            "kubernetes.cronjob.active",
             "kubernetes.daemon_set.current_scheduled",
             "kubernetes.daemon_set.desired_scheduled",
             "kubernetes.daemon_set.misscheduled",
             "kubernetes.daemon_set.ready",
             "kubernetes.deployment.available",
             "kubernetes.deployment.desired",
+            "kubernetes.job.active",
+            "kubernetes.job.completions",
+            "kubernetes.job.failed",
+            "kubernetes.job.parallelism",
+            "kubernetes.job.succeeded",
             "kubernetes.namespace_phase",
             "kubernetes.node_ready",
             "kubernetes.pod_phase",
@@ -27100,6 +27148,12 @@
           "group": null,
           "default": true
         },
+        "kubernetes.cronjob.active": {
+          "type": "gauge",
+          "description": "The number of actively running jobs for a cronjob.",
+          "group": null,
+          "default": true
+        },
         "kubernetes.daemon_set.current_scheduled": {
           "type": "gauge",
           "description": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod",
@@ -27133,6 +27187,36 @@
         "kubernetes.deployment.desired": {
           "type": "gauge",
           "description": "Number of desired pods in this deployment",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.active": {
+          "type": "gauge",
+          "description": "The number of actively running pods for a job.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.completions": {
+          "type": "gauge",
+          "description": "The desired number of successfully finished pods the job should be run with.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.failed": {
+          "type": "counter",
+          "description": "The number of pods which reased phase Failed for a job.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.parallelism": {
+          "type": "gauge",
+          "description": "The max desired number of pods the job should run at any given time.",
+          "group": null,
+          "default": true
+        },
+        "kubernetes.job.succeeded": {
+          "type": "counter",
+          "description": "The number of pods which reached phase Succeeded for a job.",
           "group": null,
           "default": true
         },

--- a/tests/helpers/kubernetes/agent.py
+++ b/tests/helpers/kubernetes/agent.py
@@ -108,7 +108,6 @@ class Agent:
                 daemonset_base = load_resource_yaml(AGENT_DAEMONSET_PATH)
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["image"] = self.agent_image_name
-                daemonset_base["spec"]["template"]["spec"]["containers"][0]["imagePullPolicy"] = "Always"
                 daemonset_base["spec"]["template"]["spec"]["containers"][0]["resources"] = {"requests": {"cpu": "50m"}}
                 daemonset = utils.create_daemonset(body=daemonset_base, namespace=self.namespace)
                 print(f"Created agent daemonset:\n{daemonset_base}")

--- a/tests/helpers/kubernetes/tunnel.py
+++ b/tests/helpers/kubernetes/tunnel.py
@@ -8,7 +8,7 @@ import yaml
 from kubernetes import client as kube_client
 from tests.helpers.util import pull_from_reader_in_background, wait_for
 
-from .utils import get_pod_logs, pod_is_ready
+from .utils import get_pod_logs, pod_is_ready, K8S_CREATE_TIMEOUT
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
 
@@ -24,7 +24,7 @@ def deploy_fake_backend_proxy_pod(namespace):
     pod = corev1.create_namespaced_pod(body=yaml.safe_load(pod_yaml), namespace=namespace)
     name = pod.metadata.name
     try:
-        assert wait_for(p(pod_is_ready, name, namespace=namespace), timeout_seconds=45)
+        assert wait_for(p(pod_is_ready, name, namespace=namespace), timeout_seconds=K8S_CREATE_TIMEOUT)
         yield corev1.read_namespaced_pod(name, namespace=namespace).status.pod_ip
     finally:
         print("Fake backend proxy logs: %s" % (get_pod_logs(name, namespace=namespace)))

--- a/tests/helpers/kubernetes/utils.py
+++ b/tests/helpers/kubernetes/utils.py
@@ -128,6 +128,8 @@ def api_client_from_version(api_version):
     return {
         "v1": kube_client.CoreV1Api(),
         "apps/v1": kube_client.AppsV1Api(),
+        "batch/v1": kube_client.BatchV1Api(),
+        "batch/v1beta1": kube_client.BatchV1beta1Api(),
         "extensions/v1beta1": kube_client.ExtensionsV1beta1Api(),
         "rbac.authorization.k8s.io/v1beta1": kube_client.RbacAuthorizationV1beta1Api(),
         "rbac.authorization.k8s.io/v1": kube_client.RbacAuthorizationV1Api(),

--- a/tests/monitors/kubernetes_cluster/cronjob.yaml
+++ b/tests/monitors/kubernetes_cluster/cronjob.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: pi-cron
+spec:
+  schedule: "*/1 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: pi
+            image: perl
+            command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+          restartPolicy: OnFailure
+          imagePullPolicy: Always

--- a/tests/monitors/kubernetes_cluster/job.yaml
+++ b/tests/monitors/kubernetes_cluster/job.yaml
@@ -1,0 +1,17 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi
+spec:
+  completions: 3
+  parallelism: 1
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+      imagePullPolicy: Always
+  backoffLimit: 4

--- a/tests/monitors/kubernetes_cluster/perf_test.py
+++ b/tests/monitors/kubernetes_cluster/perf_test.py
@@ -381,3 +381,148 @@ def test_large_k8s_cluster_deployment_prop():
 
             agent.pprof_client.assert_goroutine_count_under(200)
             agent.pprof_client.assert_heap_alloc_under(heap_profile_baseline.total * 1.2)
+
+
+# pylint: disable=too-many-locals
+def test_large_k8s_cluster_cronjob_prop():
+    """
+    Creates 5000 jobs and 5000 pods. Each job has an owner
+    reference of a cronjob. Asserts that pods acquire the
+    cronjob property from the jobs owner reference.
+    """
+    job_count = 5000
+    pods_per_job = 1
+    with fake_k8s_api_server(print_logs=False) as [fake_k8s_client, k8s_envvars]:
+        v1_client = client.CoreV1Api(fake_k8s_client)
+        batchv1_client = client.BatchV1Api(fake_k8s_client)
+        jobs = {}
+        for i in range(0, job_count):
+            cj_name = f"cj-{i}"
+            cj_uid = f"cjuid{i}"
+            job_name = cj_name + "-job"
+            job_uid = cj_uid + "-job"
+            jobs[job_uid] = {
+                "cj_name": cj_name,
+                "cj_uid": cj_uid,
+                "job_name": job_name,
+                "job_uid": job_uid,
+                "pod_uids": [],
+                "pod_names": [],
+            }
+
+            batchv1_client.create_namespaced_job(
+                body={
+                    "apiVersion": "batch/v1",
+                    "kind": "Job",
+                    "metadata": {
+                        "name": job_name,
+                        "uid": job_uid,
+                        "namespace": "default",
+                        "ownerReferences": [{"kind": "CronJob", "name": cj_name, "uid": cj_uid}],
+                    },
+                    "spec": client.V1JobSpec(completions=1, parallelism=1, template=client.V1PodTemplateSpec()),
+                    "status": {},
+                },
+                namespace="default",
+            )
+
+            for j in range(0, pods_per_job):
+                pod_name = f"pod-{job_name}-{j}"
+                pod_uid = f"abcdef{i}-{j}"
+                jobs[job_uid]["pod_uids"].append(pod_uid)
+                jobs[job_uid]["pod_names"].append(pod_name)
+                v1_client.create_namespaced_pod(
+                    body={
+                        "apiVersion": "v1",
+                        "kind": "Pod",
+                        "metadata": {
+                            "name": pod_name,
+                            "uid": pod_uid,
+                            "namespace": "default",
+                            "labels": {"app": "my-app"},
+                            "ownerReferences": [{"kind": "Job", "name": job_name, "uid": job_uid}],
+                        },
+                        "spec": {},
+                    },
+                    namespace="default",
+                )
+        with Agent.run(
+            dedent(
+                f"""
+          writer:
+            maxRequests: 100
+            propertiesMaxRequests: 100
+            propertiesHistorySize: 10000
+          monitors:
+           - type: kubernetes-cluster
+             alwaysClusterReporter: true
+             intervalSeconds: 10
+             kubernetesAPI:
+                skipVerify: true
+                authType: none
+        """
+            ),
+            profiling=True,
+            debug=False,
+            extra_env=k8s_envvars,
+        ) as agent:
+            assert wait_for(p(has_datapoint, agent.fake_services, dimensions={"kubernetes_pod_name": "pod-cj-0-job-0"}))
+            assert wait_for(
+                p(has_datapoint, agent.fake_services, dimensions={"kubernetes_pod_name": "pod-cj-4999-job-0"})
+            )
+
+            ## get heap usage with 5k pods
+            heap_profile_baseline = agent.pprof_client.get_heap_profile()
+
+            def has_all_cronjob_props():
+                for _, job in jobs.items():
+                    for pod_uid in job["pod_uids"]:
+                        if not has_dim_prop(
+                            agent.fake_services,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="cronJob",
+                            prop_value=job["cj_name"],
+                        ):
+                            return False
+                        if not has_dim_prop(
+                            agent.fake_services,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="cronJob_uid",
+                            prop_value=job["cj_uid"],
+                        ):
+                            return False
+                    return True
+
+            def has_all_job_props():
+                for _, job in jobs.items():
+                    for pod_uid in job["pod_uids"]:
+                        if not has_dim_prop(
+                            agent.fake_services,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="job",
+                            prop_value=job["job_name"],
+                        ):
+                            return False
+                        if not has_dim_prop(
+                            agent.fake_services,
+                            dim_name="kubernetes_pod_uid",
+                            dim_value=pod_uid,
+                            prop_name="job_uid",
+                            prop_value=job["job_uid"],
+                        ):
+                            return False
+                    return True
+
+            assert wait_for(has_all_job_props, interval_seconds=2, timeout_seconds=60)
+            assert wait_for(has_all_cronjob_props, interval_seconds=2, timeout_seconds=60)
+
+            for _, job in jobs.items():
+                batchv1_client.delete_namespaced_job(name=job["job_name"], namespace="default", body={})
+                for pod_name in job["pod_names"]:
+                    v1_client.delete_namespaced_pod(name=pod_name, namespace="default", body={})
+
+            agent.pprof_client.assert_goroutine_count_under(200)
+            agent.pprof_client.assert_heap_alloc_under(heap_profile_baseline.total * 1.2)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -635,6 +635,8 @@ gopkg.in/tomb.v1
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20181110191121-a33c8200050f
 k8s.io/api/apps/v1
+k8s.io/api/batch/v1
+k8s.io/api/batch/v1beta1
 k8s.io/api/core/v1
 k8s.io/api/extensions/v1beta1
 k8s.io/api/apps/v1beta1
@@ -648,8 +650,6 @@ k8s.io/api/authorization/v1
 k8s.io/api/authorization/v1beta1
 k8s.io/api/autoscaling/v1
 k8s.io/api/autoscaling/v2beta1
-k8s.io/api/batch/v1
-k8s.io/api/batch/v1beta1
 k8s.io/api/batch/v2alpha1
 k8s.io/api/certificates/v1beta1
 k8s.io/api/events/v1beta1


### PR DESCRIPTION
**Work in progress**
PR to sync jobs and cronjob metrics

Metrics:
- kubernetes.job.completions
- kubernetes.job.parallelism
- kubernetes.job.active
- kubernetes.job.succeeded
- kubernetes.job.failed
- kubernetes.cronjob.active

Added a new job cache so we can link pods to the cronjobs they were created by,
via pods --> jobs --> cronjob link


To do:
- [x] add tests for cron jobs
- [x] add link for pod --> job --> cronjob to generate property
- [x] add test for cronjob property existing on kubernetes_pod_uid
- [x] add perf test for jobs (~5k jobs)
- [x] fix tests