### PR TITLE
Add k8s_workload property to other workloads

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,8 +20,7 @@ issues:
       linters:
         - gosec
 
-    - path: internal/monitors/kubernetes/cluster
-      text: Job
+    - path: internal/monitors/kubernetes/cluster/metrics
       linters:
         - goconst
 

--- a/internal/monitors/kubernetes/cluster/metrics/cache.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cache.go
@@ -128,6 +128,7 @@ func (dc *DatapointCache) HandleAdd(newObj runtime.Object) interface{} {
 		kind = "ReplicationController"
 	case *v1beta1.DaemonSet:
 		dps = datapointsForDaemonSet(o)
+		dimProps = dimPropsForDaemonSet(o)
 		kind = "DaemonSet"
 	case *v1beta1.Deployment:
 		dps = datapointsForDeployment(o)

--- a/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
@@ -31,7 +31,6 @@ func datapointsForCronJob(cj *batchv1beta1.CronJob) []*datapoint.Datapoint {
 func dimPropsForCronJob(cj *batchv1beta1.CronJob) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cj.Labels)
 
-	props["kubernetes_name"] = cj.Name
 	props["k8s_workload"] = "CronJob"
 	props["schedule"] = cj.Spec.Schedule
 	props["concurrency_policy"] = string(cj.Spec.ConcurrencyPolicy)

--- a/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
@@ -3,9 +3,11 @@ package metrics
 import (
 	"time"
 
-	"k8s.io/api/extensions/v1beta1"
-
 	"github.com/signalfx/golib/datapoint"
+	k8sutil "github.com/signalfx/signalfx-agent/internal/monitors/kubernetes/utils"
+	atypes "github.com/signalfx/signalfx-agent/internal/monitors/types"
+	"github.com/signalfx/signalfx-agent/internal/utils"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 func datapointsForDaemonSet(ds *v1beta1.DaemonSet) []*datapoint.Datapoint {
@@ -41,5 +43,29 @@ func datapointsForDaemonSet(ds *v1beta1.DaemonSet) []*datapoint.Datapoint {
 			datapoint.NewIntValue(int64(ds.Status.NumberReady)),
 			datapoint.Gauge,
 			time.Now()),
+	}
+}
+
+func dimPropsForDaemonSet(ds *v1beta1.DaemonSet) *atypes.DimProperties {
+	props, tags := k8sutil.PropsAndTagsFromLabels(ds.Labels)
+	props["kubernetes_name"] = ds.Name
+	props["k8s_workload"] = "DaemonSet"
+
+	for _, or := range ds.OwnerReferences {
+		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
+		props[utils.LowercaseFirstChar(or.Kind)+"_uid"] = string(or.UID)
+	}
+
+	if len(props) == 0 && len(tags) == 0 {
+		return nil
+	}
+
+	return &atypes.DimProperties{
+		Dimension: atypes.Dimension{
+			Name:  "kubernetes_uid",
+			Value: string(ds.UID),
+		},
+		Properties: props,
+		Tags:       tags,
 	}
 }

--- a/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
@@ -48,7 +48,6 @@ func datapointsForDaemonSet(ds *v1beta1.DaemonSet) []*datapoint.Datapoint {
 
 func dimPropsForDaemonSet(ds *v1beta1.DaemonSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(ds.Labels)
-	props["kubernetes_name"] = ds.Name
 	props["k8s_workload"] = "DaemonSet"
 
 	for _, or := range ds.OwnerReferences {

--- a/internal/monitors/kubernetes/cluster/metrics/deployments.go
+++ b/internal/monitors/kubernetes/cluster/metrics/deployments.go
@@ -28,7 +28,6 @@ func datapointsForDeployment(dep *v1beta1.Deployment) []*datapoint.Datapoint {
 func dimPropsForDeployment(dep *v1beta1.Deployment) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(dep.Labels)
 	props["deployment"] = dep.Name
-	props["kubernetes_name"] = dep.Name
 	props["k8s_workload"] = "Deployment"
 
 	for _, or := range dep.OwnerReferences {

--- a/internal/monitors/kubernetes/cluster/metrics/deployments.go
+++ b/internal/monitors/kubernetes/cluster/metrics/deployments.go
@@ -28,6 +28,8 @@ func datapointsForDeployment(dep *v1beta1.Deployment) []*datapoint.Datapoint {
 func dimPropsForDeployment(dep *v1beta1.Deployment) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(dep.Labels)
 	props["deployment"] = dep.Name
+	props["kubernetes_name"] = dep.Name
+	props["k8s_workload"] = "Deployment"
 
 	for _, or := range dep.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/jobs.go
@@ -55,7 +55,6 @@ func datapointsForJob(job *batchv1.Job) []*datapoint.Datapoint {
 func dimPropsForJob(job *batchv1.Job) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(job.Labels)
 
-	props["kubernetes_name"] = job.Name
 	props["k8s_workload"] = "Job"
 
 	for _, or := range job.OwnerReferences {

--- a/internal/monitors/kubernetes/cluster/metrics/pods.go
+++ b/internal/monitors/kubernetes/cluster/metrics/pods.go
@@ -60,6 +60,7 @@ func dimPropsForPod(cachedPod *k8sutil.CachedPod, sc *k8sutil.ServiceCache,
 	rsc *k8sutil.ReplicaSetCache, jc *k8sutil.JobCache) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cachedPod.LabelSet)
 	for _, or := range cachedPod.OwnerReferences {
+		props["k8s_workload"] = or.Kind
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
 		props[utils.LowercaseFirstChar(or.Kind)+"_uid"] = string(or.UID)
 	}

--- a/internal/monitors/kubernetes/cluster/metrics/replicasets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/replicasets.go
@@ -27,7 +27,6 @@ func datapointsForReplicaSet(rs *v1beta1.ReplicaSet) []*datapoint.Datapoint {
 func dimPropsForReplicaSet(rs *v1beta1.ReplicaSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(rs.Labels)
 	props["name"] = rs.Name
-	props["kubernetes_name"] = rs.Name
 	props["k8s_workload"] = "ReplicaSet"
 
 	for _, or := range rs.OwnerReferences {

--- a/internal/monitors/kubernetes/cluster/metrics/replicasets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/replicasets.go
@@ -27,6 +27,8 @@ func datapointsForReplicaSet(rs *v1beta1.ReplicaSet) []*datapoint.Datapoint {
 func dimPropsForReplicaSet(rs *v1beta1.ReplicaSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(rs.Labels)
 	props["name"] = rs.Name
+	props["kubernetes_name"] = rs.Name
+	props["k8s_workload"] = "ReplicaSet"
 
 	for _, or := range rs.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
@@ -53,7 +53,6 @@ func datapointsForStatefulSet(ss *appsv1.StatefulSet) []*datapoint.Datapoint {
 
 func dimPropsForStatefulSet(ss *appsv1.StatefulSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(ss.Labels)
-	props["kubernetes_name"] = ss.Name
 	props["k8s_workload"] = "StatefulSet"
 	props["current_revision"] = ss.Status.CurrentRevision
 	props["update_revision"] = ss.Status.UpdateRevision

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -134,7 +134,7 @@ def test_stateful_sets(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"kubernetes_name": "web", "k8s_workload": "StatefulSet"},
+                    props={"k8s_workload": "StatefulSet"},
                 )
             )
 
@@ -164,7 +164,7 @@ def test_jobs(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"k8s_workload": "Job", "kubernetes_name": "pi"},
+                    props={"k8s_workload": "Job"},
                 ),
                 timeout_seconds=300,
             )
@@ -200,7 +200,7 @@ def test_cronjobs(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"k8s_workload": "CronJob", "kubernetes_name": "pi-cron"},
+                    props={"k8s_workload": "CronJob"},
                 ),
                 timeout_seconds=300,
             )


### PR DESCRIPTION
For consistency with other workloads.

- Added dimProps for DaemonSets
- Added `k8s_workload` and `kubernetes_name` for Deployments (double publishing k8s name)
- Added `k8s_workload` and `kubernetes_name` for ReplicaSets (double publishing k8s name)
- Added `k8s_workload` for Pods, to be set to the OwnersReferences Kind
