### PR TITLE
Don't sync cluster property to kubernetes_node

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -213,6 +213,13 @@ func StreamDatapoints(configPath string, metric string, dims string) (io.ReadClo
 
 func startSyncClusterProperty(propertyChan chan *types.DimProperties, cluster string, hostDims map[string]string, setOnHost bool) {
 	for dimName, dimValue := range hostDims {
+		// Exclude kubernetes_node since it is also managed by the
+		// kubernetes-cluster monitor and it is very tricky getting them to
+		// merge cleanly without it clobbing the cluster property.
+		if dimName == "kubernetes_node" {
+			continue
+		}
+
 		if len(hostDims) > 1 && dimName == "host" && !setOnHost {
 			// If we also have a platform-specific host-id dimension that isn't
 			// the generic 'host' dimension, then skip setting the property on

--- a/tests/basic/cluster_property_test.py
+++ b/tests/basic/cluster_property_test.py
@@ -58,8 +58,7 @@ def test_cluster_prop_sync_cluster_on_host_dim():
         syncClusterOnHostDimension: true
         writer:
           propertiesSendDelaySeconds: 1
-    """,
-        extra_env={"MY_NODE_NAME": "testnode"},
+    """
     ) as agent:
 
         def assert_cluster_property():
@@ -67,33 +66,5 @@ def test_cluster_prop_sync_cluster_on_host_dim():
             dim = agent.fake_services.dims["host"]["myhost"]
             assert dim["customProperties"] == {"cluster": "prod"}
             assert dim["tags"] in [None, []]
-
-            assert "testnode" in agent.fake_services.dims["kubernetes_node"]
-            dim = agent.fake_services.dims["kubernetes_node"]["testnode"]
-            assert dim["customProperties"] == {"cluster": "prod"}
-            assert dim["tags"] in [None, []]
-
-        wait_for_assertion(assert_cluster_property)
-
-
-def test_cluster_prop_platform_dim_get_priority():
-    with Agent.run(
-        """
-        cluster: prod
-        hostname: myhost
-        writer:
-          propertiesSendDelaySeconds: 1
-    """,
-        extra_env={"MY_NODE_NAME": "testnode"},
-    ) as agent:
-
-        def assert_cluster_property():
-            assert "testnode" in agent.fake_services.dims["kubernetes_node"]
-            dim = agent.fake_services.dims["kubernetes_node"]["testnode"]
-            assert dim["customProperties"] == {"cluster": "prod"}
-            assert dim["tags"] in [None, []]
-
-            # Ensure it doesn't get synced to host dim
-            assert "myhost" not in agent.fake_services.dims["host"]
 
         wait_for_assertion(assert_cluster_property)


### PR DESCRIPTION
This is subject to races with the property syncs that kubernetes-cluster
monitor does and is very tricky to get right with the current /v2/dimension
API