### PR TITLE
Update test_kubernetes_cluster_in_k8s to get StatefulSet metrics

### DIFF
--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -21,6 +21,7 @@ def test_kubernetes_cluster_in_k8s(k8s_cluster):
         SCRIPT_DIR / "resource_quota.yaml",
         TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml",
         SCRIPT_DIR / "cronjob.yaml",
+        SCRIPT_DIR / "statefulset.yaml",
     ]
     with k8s_cluster.create_resources(yamls):
         with k8s_cluster.run_agent(agent_yaml=config) as agent:

--- a/tests/monitors/kubernetes_cluster/perf_test.py
+++ b/tests/monitors/kubernetes_cluster/perf_test.py
@@ -220,7 +220,7 @@ def test_service_tag_sync():
                             return False
                 return True
 
-            assert wait_for(missing_service_tags, interval_seconds=2, timeout_seconds=60)
+            assert wait_for(missing_service_tags, interval_seconds=2, timeout_seconds=90)
 
             agent.pprof_client.assert_goroutine_count_under(150)
             agent.pprof_client.assert_heap_alloc_under(200 * 1024 * 1024)


### PR DESCRIPTION
Need to deploy the StatefulSet for the test since the kubernetes_cluster monitor now includes kubernetes.stateful_set.* metrics.