### PR TITLE
k8s: Rename k8s_workload property to kubernetes_workload

### DIFF
--- a/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
@@ -31,7 +31,7 @@ func datapointsForCronJob(cj *batchv1beta1.CronJob) []*datapoint.Datapoint {
 func dimPropsForCronJob(cj *batchv1beta1.CronJob) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cj.Labels)
 
-	props["k8s_workload"] = "CronJob"
+	props["kubernetes_workload"] = "CronJob"
 	props["schedule"] = cj.Spec.Schedule
 	props["concurrency_policy"] = string(cj.Spec.ConcurrencyPolicy)
 

--- a/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
@@ -48,7 +48,7 @@ func datapointsForDaemonSet(ds *v1beta1.DaemonSet) []*datapoint.Datapoint {
 
 func dimPropsForDaemonSet(ds *v1beta1.DaemonSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(ds.Labels)
-	props["k8s_workload"] = "DaemonSet"
+	props["kubernetes_workload"] = "DaemonSet"
 
 	for _, or := range ds.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/deployments.go
+++ b/internal/monitors/kubernetes/cluster/metrics/deployments.go
@@ -28,7 +28,7 @@ func datapointsForDeployment(dep *v1beta1.Deployment) []*datapoint.Datapoint {
 func dimPropsForDeployment(dep *v1beta1.Deployment) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(dep.Labels)
 	props["deployment"] = dep.Name
-	props["k8s_workload"] = "Deployment"
+	props["kubernetes_workload"] = "Deployment"
 
 	for _, or := range dep.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/jobs.go
@@ -55,7 +55,7 @@ func datapointsForJob(job *batchv1.Job) []*datapoint.Datapoint {
 func dimPropsForJob(job *batchv1.Job) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(job.Labels)
 
-	props["k8s_workload"] = "Job"
+	props["kubernetes_workload"] = "Job"
 
 	for _, or := range job.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/pods.go
+++ b/internal/monitors/kubernetes/cluster/metrics/pods.go
@@ -60,7 +60,7 @@ func dimPropsForPod(cachedPod *k8sutil.CachedPod, sc *k8sutil.ServiceCache,
 	rsc *k8sutil.ReplicaSetCache, jc *k8sutil.JobCache) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cachedPod.LabelSet)
 	for _, or := range cachedPod.OwnerReferences {
-		props["k8s_workload"] = or.Kind
+		props["kubernetes_workload"] = or.Kind
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name
 		props[utils.LowercaseFirstChar(or.Kind)+"_uid"] = string(or.UID)
 	}

--- a/internal/monitors/kubernetes/cluster/metrics/replicasets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/replicasets.go
@@ -27,7 +27,7 @@ func datapointsForReplicaSet(rs *v1beta1.ReplicaSet) []*datapoint.Datapoint {
 func dimPropsForReplicaSet(rs *v1beta1.ReplicaSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(rs.Labels)
 	props["name"] = rs.Name
-	props["k8s_workload"] = "ReplicaSet"
+	props["kubernetes_workload"] = "ReplicaSet"
 
 	for _, or := range rs.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
@@ -53,7 +53,7 @@ func datapointsForStatefulSet(ss *appsv1.StatefulSet) []*datapoint.Datapoint {
 
 func dimPropsForStatefulSet(ss *appsv1.StatefulSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(ss.Labels)
-	props["k8s_workload"] = "StatefulSet"
+	props["kubernetes_workload"] = "StatefulSet"
 	props["current_revision"] = ss.Status.CurrentRevision
 	props["update_revision"] = ss.Status.UpdateRevision
 

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -134,7 +134,7 @@ def test_stateful_sets(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"k8s_workload": "StatefulSet"},
+                    props={"kubernetes_workload": "StatefulSet"},
                 )
             )
 
@@ -164,7 +164,7 @@ def test_jobs(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"k8s_workload": "Job"},
+                    props={"kubernetes_workload": "Job"},
                 ),
                 timeout_seconds=300,
             )
@@ -200,7 +200,7 @@ def test_cronjobs(k8s_cluster):
                     agent.fake_services,
                     dim_name="kubernetes_uid",
                     dim_value=resources[0].metadata.uid,
-                    props={"k8s_workload": "CronJob"},
+                    props={"kubernetes_workload": "CronJob"},
                 ),
                 timeout_seconds=300,
             )


### PR DESCRIPTION
To be consistent with our other kubernetes properties 

**Note** breaking change - renaming property `k8s_workload` to `kubernetes_workload`.
This was only released in 4.8.0 for jobs, cronjobs, and statefulsets. 
This property on pods, deployments, replicasets, and daemonsets was unreleased.

These are relatively new properties so not many people are using them probably, but still should go out with 5.0 release when we merge & release #941 
