### PR TITLE
allow configuring the dbname

### DIFF
--- a/docs/monitors/postgresql.md
+++ b/docs/monitors/postgresql.md
@@ -88,6 +88,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | --- | --- | --- | --- |
 | `host` | no | `string` |  |
 | `port` | no | `integer` |  (**default:** `0`) |
+| `masterDBName` | no | `string` | The "master" database to which the agent first connects to query the list of databases available in the server.  This database should be accessible to the user specified with `connectionString` and `params` below, and that user should have permission to query `pg_database`.  If you want to filter which databases are monitored, use the `databases` option below. (**default:** `postgres`) |
 | `connectionString` | no | `string` | See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters. |
 | `params` | no | `map of strings` | Parameters to the connection string that can be templated into the connection string with the syntax `{{.key}}`. |
 | `databases` | no | `list of strings` | List of databases to send database-specific metrics about.  If omitted, metrics about all databases will be sent.  This is an [overridable set](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html#overridable-filters). (**default:** `[*]`) |

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -28781,6 +28781,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "masterDBName",
+            "doc": "The \"master\" database to which the agent first connects to query the list of databases available in the server.  This database should be accessible to the user specified with `connectionString` and `params` below, and that user should have permission to query `pg_database`.  If you want to filter which databases are monitored, use the `databases` option below.",
+            "default": "postgres",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "connectionString",
             "doc": "See https://godoc.org/github.com/lib/pq#hdr-Connection_String_Parameters.",
             "default": "",


### PR DESCRIPTION
Not all services have "postgres" database available and
adding dbname= to connectionString had no effect as it
would be "overridden" by hardcoded dbname=postgres.