### PR TITLE
Make creation timestamp property name k8s resource specific

### DIFF
--- a/docs/monitors/kubernetes-cluster.md
+++ b/docs/monitors/kubernetes-cluster.md
@@ -164,7 +164,13 @@ are set on the dimension values of the dimension specified.
 | ---  | ---       | ---         |
 | `<node label>` | `machine_id/kubernetes_node` | All non-blank labels on a given node will be synced as properties to the `machine_id` or `kubernetes_node` dimension value for that node.  Which dimension gets the properties is determined by the `useNodeName` config option.  Any blank values will be synced as tags on that same dimension. |
 | `<pod label>` | `kubernetes_pod_uid` | Any labels with non-blank values on the pod will be synced as properties to the `kubernetes_pod_uid` dimension. Any blank labels will be synced as tags on that same dimension. |
-| `creation_timestamp` | `kubernetes_pod_uid/kubernetes_uid` | CreationTimestamp is a timestamp representing the server time when this object was created and is in UTC. This property is synced onto `kubernetes_pod_uid` or `kubernetes_uid` depending on whether it's a node or Kubernetes workload. |
+| `cronjob_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the cron job was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `daemonset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the daemon set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `deployment_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the deployment was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `job_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the job was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `pod_creation_timestamp` | `kubernetes_pod_uid` | Timestamp representing the server time when the pod was created and is in UTC. This property is synced onto `kubernetes_pod_uid`. |
+| `replicaset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the replica set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `statefulset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the stateful set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
 
 
 

--- a/docs/monitors/openshift-cluster.md
+++ b/docs/monitors/openshift-cluster.md
@@ -193,7 +193,13 @@ are set on the dimension values of the dimension specified.
 | ---  | ---       | ---         |
 | `<node label>` | `machine_id/kubernetes_node` | All non-blank labels on a given node will be synced as properties to the `machine_id` or `kubernetes_node` dimension value for that node.  Which dimension gets the properties is determined by the `useNodeName` config option.  Any blank values will be synced as tags on that same dimension. |
 | `<pod label>` | `kubernetes_pod_uid` | Any labels with non-blank values on the pod will be synced as properties to the `kubernetes_pod_uid` dimension. Any blank labels will be synced as tags on that same dimension. |
-| `creation_timestamp` | `kubernetes_pod_uid/kubernetes_uid` | CreationTimestamp is a timestamp representing the server time when this object was created and is in UTC. This property is synced onto `kubernetes_pod_uid` or `kubernetes_uid` depending on whether it's a node or Kubernetes workload. |
+| `cronjob_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the cron job was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `daemonset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the daemon set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `deployment_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the deployment was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `job_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the job was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `pod_creation_timestamp` | `kubernetes_pod_uid` | Timestamp representing the server time when the pod was created and is in UTC. This property is synced onto `kubernetes_pod_uid`. |
+| `replicaset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the replica set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
+| `statefulset_creation_timestamp` | `kubernetes_uid` | Timestamp representing the server time when the stateful set was created and is in UTC. This property is synced onto `kubernetes_uid`. |
 
 
 

--- a/internal/monitors/kubernetes/cluster/metadata.yaml
+++ b/internal/monitors/kubernetes/cluster/metadata.yaml
@@ -170,11 +170,34 @@ common:
         to the `kubernetes_pod_uid` dimension. Any blank labels will be synced as
         tags on that same dimension.
       dimension: kubernetes_pod_uid
-    creation_timestamp:
-      description: CreationTimestamp is a timestamp representing the server time when this object was
-        created and is in UTC. This property is synced onto `kubernetes_pod_uid` or `kubernetes_uid`
-        depending on whether it's a node or Kubernetes workload.
-      dimension: kubernetes_pod_uid/kubernetes_uid
+    cronjob_creation_timestamp:
+      description: Timestamp representing the server time when the cron job was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
+    daemonset_creation_timestamp:
+      description: Timestamp representing the server time when the daemon set was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
+    deployment_creation_timestamp:
+      description: Timestamp representing the server time when the deployment was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
+    job_creation_timestamp:
+      description: Timestamp representing the server time when the job was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
+    pod_creation_timestamp:
+      description: Timestamp representing the server time when the pod was created and
+        is in UTC. This property is synced onto `kubernetes_pod_uid`.
+      dimension: kubernetes_pod_uid
+    replicaset_creation_timestamp:
+      description: Timestamp representing the server time when the replica set was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
+    statefulset_creation_timestamp:
+      description: Timestamp representing the server time when the stateful set was created and
+        is in UTC. This property is synced onto `kubernetes_uid`.
+      dimension: kubernetes_uid
 
 
 monitors:

--- a/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/cronjobs.go
@@ -31,7 +31,7 @@ func datapointsForCronJob(cj *batchv1beta1.CronJob) []*datapoint.Datapoint {
 func dimPropsForCronJob(cj *batchv1beta1.CronJob) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cj.Labels)
 
-	props["creation_timestamp"] = cj.GetCreationTimestamp().Format(time.RFC3339)
+	props["cronjob_creation_timestamp"] = cj.GetCreationTimestamp().Format(time.RFC3339)
 	props["kubernetes_workload"] = "CronJob"
 	props["schedule"] = cj.Spec.Schedule
 	props["concurrency_policy"] = string(cj.Spec.ConcurrencyPolicy)

--- a/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/daemonsets.go
@@ -49,7 +49,7 @@ func datapointsForDaemonSet(ds *v1beta1.DaemonSet) []*datapoint.Datapoint {
 func dimPropsForDaemonSet(ds *v1beta1.DaemonSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(ds.Labels)
 	props["kubernetes_workload"] = "DaemonSet"
-	props["creation_timestamp"] = ds.GetCreationTimestamp().Format(time.RFC3339)
+	props["daemonset_creation_timestamp"] = ds.GetCreationTimestamp().Format(time.RFC3339)
 
 	for _, or := range ds.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/deployments.go
+++ b/internal/monitors/kubernetes/cluster/metrics/deployments.go
@@ -31,7 +31,7 @@ func dimPropsForDeployment(dep *v1beta1.Deployment) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(dep.Labels)
 	props["deployment"] = dep.Name
 	props["kubernetes_workload"] = "Deployment"
-	props["creation_timestamp"] = dep.GetCreationTimestamp().Format(time.RFC3339)
+	props["deployment_creation_timestamp"] = dep.GetCreationTimestamp().Format(time.RFC3339)
 
 	for _, or := range dep.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/internal/monitors/kubernetes/cluster/metrics/jobs.go
@@ -56,7 +56,7 @@ func dimPropsForJob(job *batchv1.Job) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(job.Labels)
 
 	props["kubernetes_workload"] = "Job"
-	props["creation_timestamp"] = job.GetCreationTimestamp().Format(time.RFC3339)
+	props["job_creation_timestamp"] = job.GetCreationTimestamp().Format(time.RFC3339)
 
 	for _, or := range job.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/pods.go
+++ b/internal/monitors/kubernetes/cluster/metrics/pods.go
@@ -60,7 +60,7 @@ func dimPropsForPod(cachedPod *k8sutil.CachedPod, sc *k8sutil.ServiceCache,
 	rsc *k8sutil.ReplicaSetCache, jc *k8sutil.JobCache) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(cachedPod.LabelSet)
 
-	props["creation_timestamp"] = cachedPod.CreationTimestamp.Format(time.RFC3339)
+	props["pod_creation_timestamp"] = cachedPod.CreationTimestamp.Format(time.RFC3339)
 
 	for _, or := range cachedPod.OwnerReferences {
 		props["kubernetes_workload"] = or.Kind

--- a/internal/monitors/kubernetes/cluster/metrics/replicasets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/replicasets.go
@@ -30,7 +30,7 @@ func dimPropsForReplicaSet(rs *v1beta1.ReplicaSet) *atypes.DimProperties {
 	props, tags := k8sutil.PropsAndTagsFromLabels(rs.Labels)
 	props["name"] = rs.Name
 	props["kubernetes_workload"] = "ReplicaSet"
-	props["creation_timestamp"] = rs.GetCreationTimestamp().Format(time.RFC3339)
+	props["replicaset_creation_timestamp"] = rs.GetCreationTimestamp().Format(time.RFC3339)
 
 	for _, or := range rs.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
+++ b/internal/monitors/kubernetes/cluster/metrics/statefulsets.go
@@ -56,7 +56,7 @@ func dimPropsForStatefulSet(ss *appsv1.StatefulSet) *atypes.DimProperties {
 	props["kubernetes_workload"] = "StatefulSet"
 	props["current_revision"] = ss.Status.CurrentRevision
 	props["update_revision"] = ss.Status.UpdateRevision
-	props["creation_timestamp"] = ss.GetCreationTimestamp().Format(time.RFC3339)
+	props["statefulset_creation_timestamp"] = ss.GetCreationTimestamp().Format(time.RFC3339)
 
 	for _, or := range ss.OwnerReferences {
 		props[utils.LowercaseFirstChar(or.Kind)] = or.Name

--- a/scripts/docs/templates/observer-main.md.tmpl
+++ b/scripts/docs/templates/observer-main.md.tmpl
@@ -3,7 +3,7 @@
 {{ $doc_types := (ds "agent").doc_types -}}
 # Observer Configuration
 
-Observers are what discover service endpoints that can then be monitored.  They
+Observers discover service endpoints that can then be monitored.  They
 are configured in a list called `observers` in the [main agent config
 file](./config-schema.md). These are all of the observers included in the agent
 along with their possible configuration options:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -27139,9 +27139,33 @@
           "dimension": "kubernetes_pod_uid",
           "description": "Any labels with non-blank values on the pod will be synced as properties to the `kubernetes_pod_uid` dimension. Any blank labels will be synced as tags on that same dimension."
         },
-        "creation_timestamp": {
-          "dimension": "kubernetes_pod_uid/kubernetes_uid",
-          "description": "CreationTimestamp is a timestamp representing the server time when this object was created and is in UTC. This property is synced onto `kubernetes_pod_uid` or `kubernetes_uid` depending on whether it's a node or Kubernetes workload."
+        "cronjob_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the cron job was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "daemonset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the daemon set was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "deployment_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the deployment was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "job_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the job was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "pod_creation_timestamp": {
+          "dimension": "kubernetes_pod_uid",
+          "description": "Timestamp representing the server time when the pod was created and is in UTC. This property is synced onto `kubernetes_pod_uid`."
+        },
+        "replicaset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the replica set was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "statefulset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the stateful set was created and is in UTC. This property is synced onto `kubernetes_uid`."
         }
       },
       "metricsExhaustive": false,
@@ -29808,9 +29832,33 @@
           "dimension": "kubernetes_pod_uid",
           "description": "Any labels with non-blank values on the pod will be synced as properties to the `kubernetes_pod_uid` dimension. Any blank labels will be synced as tags on that same dimension."
         },
-        "creation_timestamp": {
-          "dimension": "kubernetes_pod_uid/kubernetes_uid",
-          "description": "CreationTimestamp is a timestamp representing the server time when this object was created and is in UTC. This property is synced onto `kubernetes_pod_uid` or `kubernetes_uid` depending on whether it's a node or Kubernetes workload."
+        "cronjob_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the cron job was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "daemonset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the daemon set was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "deployment_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the deployment was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "job_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the job was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "pod_creation_timestamp": {
+          "dimension": "kubernetes_pod_uid",
+          "description": "Timestamp representing the server time when the pod was created and is in UTC. This property is synced onto `kubernetes_pod_uid`."
+        },
+        "replicaset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the replica set was created and is in UTC. This property is synced onto `kubernetes_uid`."
+        },
+        "statefulset_creation_timestamp": {
+          "dimension": "kubernetes_uid",
+          "description": "Timestamp representing the server time when the stateful set was created and is in UTC. This property is synced onto `kubernetes_uid`."
         }
       },
       "metricsExhaustive": false,

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -208,7 +208,7 @@ def test_cronjobs(k8s_cluster):
 
 
 @pytest.mark.kubernetes
-def test_creation_timestamp(k8s_cluster):
+def test_pods(k8s_cluster):
     config = """
     monitors:
      - type: kubernetes-cluster
@@ -217,14 +217,10 @@ def test_creation_timestamp(k8s_cluster):
     with k8s_cluster.create_resources(yamls):
         with k8s_cluster.run_agent(agent_yaml=config) as agent:
             assert wait_for(
-                p(any_dim_val_has_prop, agent.fake_services, dim_name="kubernetes_uid", prop_name="creation_timestamp")
-            )
-
-            assert wait_for(
                 p(
                     any_dim_val_has_prop,
                     agent.fake_services,
                     dim_name="kubernetes_pod_uid",
-                    prop_name="creation_timestamp",
+                    prop_name="pod_creation_timestamp",
                 )
             )


### PR DESCRIPTION
Previously `creation_timestamp` was put on to `kubernetes_uid`/`kubernetes_pod_uid`. This will result in an arbitrary `creation_timestamp` show up on MTSes if there are more than one of above mentioned dimensions on a single MTS. This in turn could result in situations such as a MTS from a pod ends up with the creation timestamp of node. 

To prevent that from happening, I propose adding a prefix to the property name to specifically point out the k8s resource to which the property belongs.