### PR TITLE
Windows CI test updates

### DIFF
--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -75,13 +75,13 @@ jobs:
   - powershell: |
       & ./scripts/windows/make.ps1 unit_test
     displayName: 'Run go test'
-    ignoreLASTEXITCODE: true
   - task: PublishTestResults@2
     inputs:
       searchFolder: '$(Build.SourcesDirectory)'
       testResultsFormat: 'JUnit'
       testResultsFiles: 'unit_results.xml'
       failTaskOnFailedTests: true
+    condition: succeededOrFailed()
 
 - job: 'win_bundle_build'
   pool:

--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -71,7 +71,7 @@ jobs:
   - template: 'templates/install-go.yml'
     parameters:
       version: $(GOVERSION)
-      packages: 'github.com/tebeka/go2xunit'
+      packages: 'gotest.tools/gotestsum'
   - powershell: |
       & ./scripts/windows/make.ps1 unit_test
     displayName: 'Run go test'

--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -120,14 +120,12 @@ jobs:
   dependsOn: 'win_bundle_build'
   steps:
   - template: 'templates/extract-bundle.yml'
-  # Install IIS for windows-iis integration test.
-  - template: 'templates/install-choco.yml'
-    parameters:
-      packages: '--source windowsfeatures IIS-WebServerRole'
   - template: 'templates/run-pytest.yml'
     parameters:
       markers: '(windows or windows_only) and not deployment and not installer'
       options: '-n4'
+      # Install IIS for windows-iis integration test.
+      chocoPackages: '--source windowsfeatures IIS-WebServerRole'
 
 - job: 'win_2016_integration_tests'
   pool:
@@ -135,14 +133,12 @@ jobs:
   dependsOn: 'win_bundle_build'
   steps:
   - template: 'templates/extract-bundle.yml'
-  # Install IIS for windows-iis integration test.
-  - template: 'templates/install-choco.yml'
-    parameters:
-      packages: '--source windowsfeatures IIS-WebServerRole'
   - template: 'templates/run-pytest.yml'
     parameters:
       markers: '(windows or windows_only) and not deployment and not installer'
       options: '-n4'
+      # Install IIS for windows-iis integration test.
+      chocoPackages: '--source windowsfeatures IIS-WebServerRole'
 
 - job: 'win_2012_chef_tests'
   pool:

--- a/.azure-pipelines/templates/install-go.yml
+++ b/.azure-pipelines/templates/install-go.yml
@@ -17,7 +17,11 @@ steps:
     echo $env:PATH
 - template: 'restore-go-cache.yml'
 - ${{ if ne(parameters.packages, '') }}:
-  - powershell: |
-      $env:GO111MODULE = "on"
-      go get ${{ parameters.packages }}
+  - bash: |
+      cd $TEMP
+      for i in $(seq 1 3); do
+          go get ${{ parameters.packages }} && exit 0
+          sleep 10
+      done
+      exit 1
     displayName: 'Install go packages'

--- a/.azure-pipelines/templates/run-pytest.yml
+++ b/.azure-pipelines/templates/run-pytest.yml
@@ -2,12 +2,15 @@ parameters:
   markers: 'windows or windows_only'
   options: ''
   changesInclude: ''
+  chocoPackages: ''
 
 steps:
 - template: 'changes-include.yml'
   parameters:
     paths: ${{ parameters.changesInclude }}
 - template: 'install-choco.yml'
+  parameters:
+    packages: ${{ parameters.chocoPackages }}
 - powershell: |
     if ((Get-Command "conda.exe" -ErrorAction SilentlyContinue) -eq $null) {
         choco install -y --no-progress --limitoutput miniconda3

--- a/.azure-pipelines/templates/run-pytest.yml
+++ b/.azure-pipelines/templates/run-pytest.yml
@@ -40,7 +40,6 @@ steps:
   env:
     MARKERS: ${{ parameters.markers }}
     OPTIONS: ${{ parameters.options }}
-  ignoreLASTEXITCODE: true
   displayName: 'Run pytest'
   condition: and(ne(variables.hasChanges, 'false'), ne(variables.hasChanges, False))
 - task: PublishBuildArtifacts@1

--- a/internal/observers/host/host_test.go
+++ b/internal/observers/host/host_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"testing"
@@ -128,6 +129,9 @@ func Test_HostObserver(t *testing.T) {
 		})
 
 		t.Run("UDP Ports", func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("skipping test on windows")
+			}
 			for _, conn := range udpConns {
 				host, port, _ := net.SplitHostPort(conn.LocalAddr().String())
 				expectedID := fmt.Sprintf("%s-%s-UDP-%d", host, port, selfPid)

--- a/scripts/windows/bundle.ps1
+++ b/scripts/windows/bundle.ps1
@@ -20,9 +20,9 @@ function get_collectd_plugins ([string]$buildDir=$BUILD_DIR) {
     $python = "$buildDir\python\python.exe"
     $env:PYTHONHOME="$buildDir\python"
     & $python -m pip install -qq -r $requirements
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
     & $python $script $collectdPlugins
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
     & $python -m pip list
     # unset the python home enviornment variable
     Remove-Item Env:\PYTHONHOME
@@ -66,10 +66,10 @@ function install_pip([string]$buildDir=$BUILD_DIR) {
     $arguments = "-m", "ensurepip", "--upgrade"
     $env:PYTHONHOME="$buildDir\python"
     & $python $arguments
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
     & $python -m pip -V
     & $python -m pip install -qq --upgrade pip==18.0
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
     & $python -m pip -V
     # unset the python home enviornment variable
     Remove-Item Env:\PYTHONHOME
@@ -82,12 +82,12 @@ function bundle_python_runner($buildDir=".\build") {
     $arguments = "-m", "pip", "install", "-qq", "$bundlePath", "--upgrade"
     $env:PYTHONHOME="$buildDir\python"
     & $python $arguments
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
 
     # Install the WMI package on windows as a convenience.
     $wmiInstallArgs = "-m", "pip", "install", "-qq", "WMI==1.4.9"
     & $python $wmiInstallArgs
-    if ($lastexitcode -ne 0){ throw $output }
+    if ($lastexitcode -ne 0){ throw }
 
     # unset the python home enviornment variable
     Remove-Item Env:\PYTHONHOME

--- a/scripts/windows/make.ps1
+++ b/scripts/windows/make.ps1
@@ -170,11 +170,14 @@ function unit_test() {
     compile_deps
     go generate ./internal/monitors/...
     if ($lastexitcode -ne 0){ throw }
-    $ErrorActionPreference = "Continue"
-    go test -v ./... 2>&1 | tee -variable output
-    if ($lastexitcode -gt 1){ throw }
-    $ErrorActionPreference = "Stop"
-    Write-Output $output | go2xunit -fail -output unit_results.xml
+    if ((Get-Command "gotestsum.exe" -ErrorAction SilentlyContinue) -eq $null) {
+        $cwd = get-location
+        cd $env:TEMP
+        go get gotest.tools/gotestsum
+        if ($lastexitcode -gt 0){ throw }
+        cd $cwd
+    }
+    gotestsum --format short-verbose --junitfile unit_results.xml
     if ($lastexitcode -gt 0){ throw }
 }
 


### PR DESCRIPTION
Should help speed up the unit test job and catch false-positives due to issues with go2xunit.

Failed unit test that previously wasn't caught (updated to be skipped when running on windows):
```
=== RUN   Test_HostObserver/Basic_connections/UDP_Ports
panic: interface conversion: services.Endpoint is nil, not *services.EndpointCore [recovered]
	panic: interface conversion: services.Endpoint is nil, not *services.EndpointCore

goroutine 31 [running]:
testing.tRunner.func1(0xc000340800)
	D:/a/_tool/go/1.12.1/x64/src/testing/testing.go:830 +0x399
panic(0xc15640, 0xc000372450)
	D:/a/_tool/go/1.12.1/x64/src/runtime/panic.go:522 +0x1c3
github.com/signalfx/signalfx-agent/internal/observers/host.Test_HostObserver.func2.2(0xc000340800)
	D:/a/1/s/internal/observers/host/host_test.go:134 +0x479
testing.tRunner(0xc000340800, 0xc0003723c0)
	D:/a/_tool/go/1.12.1/x64/src/testing/testing.go:865 +0xc7
created by testing.(*T).Run
	D:/a/_tool/go/1.12.1/x64/src/testing/testing.go:916 +0x361
FAIL	github.com/signalfx/signalfx-agent/internal/observers/host	1.254s
```