### PR TITLE
Changes for Non-Docker Kubernetes runtime

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -46,6 +46,14 @@ data:
     - type: kubelet-stats
       kubeletAPI:
         authType: serviceAccount
+      datapointsToExclude:
+      - dimensions:
+          container_image:
+           - '*pause-amd64*'
+           - 'k8s.gcr.io/pause*'
+        metricNames:
+          - '*'
+          - '!*network*'
 
     # Collects k8s cluster-level metrics
     - type: kubernetes-cluster

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -80,6 +80,14 @@ data:
       kubeletAPI:
         {{ toYaml .Values.kubeletAPI | indent 8 | trim }}
       {{- end }}
+      datapointsToExclude:
+      - dimensions:
+          container_image:
+           - '*pause-amd64*'
+           - 'k8s.gcr.io/pause*'
+        metricNames:
+          - '*'
+          - '!*network*'
 
     {{ if .Values.gatherClusterMetrics -}}
     # Collects k8s cluster-level metrics

--- a/docs/monitors/cadvisor.md
+++ b/docs/monitors/cadvisor.md
@@ -17,12 +17,12 @@ monitor because many K8s nodes do not expose cAdvisor on a network port,
 even though they are running it within Kubelet.
 
 If you are running containers with Docker, there is a fair amount of
-duplication with the `collectd/docker` monitor in terms of the metrics sent
-(under distinct metric names) so you may want to consider not enabling the
-Docker monitor in a K8s environment, or else use filtering to whitelist only
-certain metrics.  Note that this will cause the built-in Docker dashboards
-to be blank, but container metrics will be available on the Kubernetes
-dashboards instead.
+duplication with the `docker-container-stats` monitor in terms of the
+metrics sent (under distinct metric names) so you may want to consider not
+enabling the Docker monitor in a K8s environment, or else use filtering to
+whitelist only certain metrics.  Note that this will cause the built-in
+Docker dashboards to be blank, but container metrics will be available on
+the Kubernetes dashboards instead.
 
 
 ## Configuration
@@ -91,14 +91,14 @@ Metrics that are categorized as
  - ***`machine_cpu_cores`*** (*gauge*)<br>    Number of CPU cores on the node.
  - `machine_cpu_frequency_khz` (*gauge*)<br>    Node's CPU frequency.
  - ***`machine_memory_bytes`*** (*gauge*)<br>    Amount of memory installed on the node.
- - ***`pod_network_receive_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes received
- - ***`pod_network_receive_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while receiving
- - `pod_network_receive_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while receiving
- - `pod_network_receive_packets_total` (*cumulative*)<br>    Cumulative count of packets received
- - ***`pod_network_transmit_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes transmitted
- - ***`pod_network_transmit_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while transmitting
- - `pod_network_transmit_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while transmitting
- - `pod_network_transmit_packets_total` (*cumulative*)<br>    Cumulative count of packets transmitted
+ - ***`pod_network_receive_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes received. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_receive_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_receive_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_receive_packets_total` (*cumulative*)<br>    Cumulative count of packets received. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_transmit_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_transmit_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_transmit_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_transmit_packets_total` (*cumulative*)<br>    Cumulative count of packets transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
 
 ### Non-default metrics (version 4.7.0+)
 

--- a/docs/monitors/kubelet-stats.md
+++ b/docs/monitors/kubelet-stats.md
@@ -13,6 +13,38 @@ Monitor Type: `kubelet-stats` ([Source](https://github.com/signalfx/signalfx-age
 This monitor pulls cadvisor metrics through a
 Kubernetes kubelet instance via the `/stats/container` endpoint.
 
+### Pause Containers
+Network stats for a Kubernetes pod are traditionally accounted for on the
+"pause" container, which is the container responsible for "owning" the
+network namespace that the other containers in the pod will use, among
+other things.  Therefore, the network stats are usually zero for all
+non-pause containers and accounted for in an aggregated way via the pause
+container.
+
+Since the only generally useful stats of the pause container are network
+stats, this montior will omit non-network metrics for any containers named
+`POD`. This is the standard name for the "pause" container in Kubernetes
+when using the Docker runtime, but the pause container has no name under
+other runtimes. Therefore, you need to explicitly filter out non-network
+metrics from pause containers when using non-Docker runtimes.  The following
+configuration will do that:
+
+```yaml
+monitors:
+- type: kubelet-stats
+  datapointsToExclude:
+  - dimensions:
+      container_image:
+       - '*pause-amd64*'
+       - 'k8s.gcr.io/pause*'
+    metricNames:
+      - '*'
+      - '!*network*'
+```
+
+If your K8s deployment using an image name for the pause container that
+does not fit the given patterns, you should tweak it as needed.
+
 
 ## Configuration
 
@@ -93,14 +125,14 @@ Metrics that are categorized as
  - ***`machine_cpu_cores`*** (*gauge*)<br>    Number of CPU cores on the node.
  - `machine_cpu_frequency_khz` (*gauge*)<br>    Node's CPU frequency.
  - ***`machine_memory_bytes`*** (*gauge*)<br>    Amount of memory installed on the node.
- - ***`pod_network_receive_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes received
- - ***`pod_network_receive_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while receiving
- - `pod_network_receive_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while receiving
- - `pod_network_receive_packets_total` (*cumulative*)<br>    Cumulative count of packets received
- - ***`pod_network_transmit_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes transmitted
- - ***`pod_network_transmit_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while transmitting
- - `pod_network_transmit_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while transmitting
- - `pod_network_transmit_packets_total` (*cumulative*)<br>    Cumulative count of packets transmitted
+ - ***`pod_network_receive_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes received. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_receive_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_receive_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_receive_packets_total` (*cumulative*)<br>    Cumulative count of packets received. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_transmit_bytes_total`*** (*cumulative*)<br>    Cumulative count of bytes transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - ***`pod_network_transmit_errors_total`*** (*cumulative*)<br>    Cumulative count of errors encountered while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_transmit_packets_dropped_total` (*cumulative*)<br>    Cumulative count of packets dropped while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
+ - `pod_network_transmit_packets_total` (*cumulative*)<br>    Cumulative count of packets transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
 
 #### Group podEphemeralStats
 All of the following metrics are part of the `podEphemeralStats` metric group. All of

--- a/internal/monitors/cadvisor/metadata.yaml
+++ b/internal/monitors/cadvisor/metadata.yaml
@@ -24,12 +24,13 @@ monitors:
     even though they are running it within Kubelet.
 
     If you are running containers with Docker, there is a fair amount of
-    duplication with the `collectd/docker` monitor in terms of the metrics sent
-    (under distinct metric names) so you may want to consider not enabling the
-    Docker monitor in a K8s environment, or else use filtering to whitelist only
-    certain metrics.  Note that this will cause the built-in Docker dashboards
-    to be blank, but container metrics will be available on the Kubernetes
-    dashboards instead.
+    duplication with the `docker-container-stats` monitor in terms of the
+    metrics sent (under distinct metric names) so you may want to consider not
+    enabling the Docker monitor in a K8s environment, or else use filtering to
+    whitelist only certain metrics.  Note that this will cause the built-in
+    Docker dashboards to be blank, but container metrics will be available on
+    the Kubernetes dashboards instead.
+
   metrics:
     container_cpu_cfs_periods:
       description: Total number of elapsed CFS enforcement intervals
@@ -194,35 +195,35 @@ monitors:
       default: true
       type: gauge
     pod_network_receive_bytes_total:
-      description: Cumulative count of bytes received
+      description: Cumulative count of bytes received. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: true
       type: cumulative
     pod_network_receive_errors_total:
-      description: Cumulative count of errors encountered while receiving
+      description: Cumulative count of errors encountered while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: true
       type: cumulative
     pod_network_receive_packets_dropped_total:
-      description: Cumulative count of packets dropped while receiving
+      description: Cumulative count of packets dropped while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: false
       type: cumulative
     pod_network_receive_packets_total:
-      description: Cumulative count of packets received
+      description: Cumulative count of packets received. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: false
       type: cumulative
     pod_network_transmit_bytes_total:
-      description: Cumulative count of bytes transmitted
+      description: Cumulative count of bytes transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: true
       type: cumulative
     pod_network_transmit_errors_total:
-      description: Cumulative count of errors encountered while transmitting
+      description: Cumulative count of errors encountered while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: true
       type: cumulative
     pod_network_transmit_packets_dropped_total:
-      description: Cumulative count of packets dropped while transmitting
+      description: Cumulative count of packets dropped while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: false
       type: cumulative
     pod_network_transmit_packets_total:
-      description: Cumulative count of packets transmitted
+      description: Cumulative count of packets transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**
       default: false
       type: cumulative
   monitorType: cadvisor
@@ -231,6 +232,39 @@ monitors:
   doc: |
     This monitor pulls cadvisor metrics through a
     Kubernetes kubelet instance via the `/stats/container` endpoint.
+
+    ### Pause Containers
+    Network stats for a Kubernetes pod are traditionally accounted for on the
+    "pause" container, which is the container responsible for "owning" the
+    network namespace that the other containers in the pod will use, among
+    other things.  Therefore, the network stats are usually zero for all
+    non-pause containers and accounted for in an aggregated way via the pause
+    container.
+    
+    Since the only generally useful stats of the pause container are network
+    stats, this montior will omit non-network metrics for any containers named
+    `POD`. This is the standard name for the "pause" container in Kubernetes
+    when using the Docker runtime, but the pause container has no name under
+    other runtimes. Therefore, you need to explicitly filter out non-network
+    metrics from pause containers when using non-Docker runtimes.  The following
+    configuration will do that:
+
+    ```yaml
+    monitors:
+    - type: kubelet-stats
+      datapointsToExclude:
+      - dimensions:
+          container_image:
+           - '*pause-amd64*'
+           - 'k8s.gcr.io/pause*'
+        metricNames:
+          - '*'
+          - '!*network*'
+    ```
+
+    If your K8s deployment using an image name for the pause container that
+    does not fit the given patterns, you should tweak it as needed.
+
   monitorType: kubelet-stats
   metrics:
     pod_ephemeral_storage_capacity_bytes:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -921,7 +921,7 @@
           "description": "The UID of the pod instance under which this container runs"
         }
       },
-      "doc": "This monitor pulls metrics directly from cadvisor, which\nconventionally runs on port 4194, but can be configured to anything.  If you\nare running on Kubernetes, consider the [kubelet-stats](./kubelet-stats.md)\nmonitor because many K8s nodes do not expose cAdvisor on a network port,\neven though they are running it within Kubelet.\n\nIf you are running containers with Docker, there is a fair amount of\nduplication with the `collectd/docker` monitor in terms of the metrics sent\n(under distinct metric names) so you may want to consider not enabling the\nDocker monitor in a K8s environment, or else use filtering to whitelist only\ncertain metrics.  Note that this will cause the built-in Docker dashboards\nto be blank, but container metrics will be available on the Kubernetes\ndashboards instead.\n",
+      "doc": "This monitor pulls metrics directly from cadvisor, which\nconventionally runs on port 4194, but can be configured to anything.  If you\nare running on Kubernetes, consider the [kubelet-stats](./kubelet-stats.md)\nmonitor because many K8s nodes do not expose cAdvisor on a network port,\neven though they are running it within Kubelet.\n\nIf you are running containers with Docker, there is a fair amount of\nduplication with the `docker-container-stats` monitor in terms of the\nmetrics sent (under distinct metric names) so you may want to consider not\nenabling the Docker monitor in a K8s environment, or else use filtering to\nwhitelist only certain metrics.  Note that this will cause the built-in\nDocker dashboards to be blank, but container metrics will be available on\nthe Kubernetes dashboards instead.\n",
       "groups": {
         "": {
           "description": "",
@@ -1206,49 +1206,49 @@
         },
         "pod_network_receive_bytes_total": {
           "type": "cumulative",
-          "description": "Cumulative count of bytes received",
+          "description": "Cumulative count of bytes received. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_receive_errors_total": {
           "type": "cumulative",
-          "description": "Cumulative count of errors encountered while receiving",
+          "description": "Cumulative count of errors encountered while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_receive_packets_dropped_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets dropped while receiving",
+          "description": "Cumulative count of packets dropped while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_receive_packets_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets received",
+          "description": "Cumulative count of packets received. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_transmit_bytes_total": {
           "type": "cumulative",
-          "description": "Cumulative count of bytes transmitted",
+          "description": "Cumulative count of bytes transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_transmit_errors_total": {
           "type": "cumulative",
-          "description": "Cumulative count of errors encountered while transmitting",
+          "description": "Cumulative count of errors encountered while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_transmit_packets_dropped_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets dropped while transmitting",
+          "description": "Cumulative count of packets dropped while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_transmit_packets_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets transmitted",
+          "description": "Cumulative count of packets transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         }
@@ -24694,7 +24694,7 @@
           "description": "The UID of the pod instance under which this container runs"
         }
       },
-      "doc": "This monitor pulls cadvisor metrics through a\nKubernetes kubelet instance via the `/stats/container` endpoint.\n",
+      "doc": "This monitor pulls cadvisor metrics through a\nKubernetes kubelet instance via the `/stats/container` endpoint.\n\n### Pause Containers\nNetwork stats for a Kubernetes pod are traditionally accounted for on the\n\"pause\" container, which is the container responsible for \"owning\" the\nnetwork namespace that the other containers in the pod will use, among\nother things.  Therefore, the network stats are usually zero for all\nnon-pause containers and accounted for in an aggregated way via the pause\ncontainer.\n\nSince the only generally useful stats of the pause container are network\nstats, this montior will omit non-network metrics for any containers named\n`POD`. This is the standard name for the \"pause\" container in Kubernetes\nwhen using the Docker runtime, but the pause container has no name under\nother runtimes. Therefore, you need to explicitly filter out non-network\nmetrics from pause containers when using non-Docker runtimes.  The following\nconfiguration will do that:\n\n```yaml\nmonitors:\n- type: kubelet-stats\n  datapointsToExclude:\n  - dimensions:\n      container_image:\n       - '*pause-amd64*'\n       - 'k8s.gcr.io/pause*'\n    metricNames:\n      - '*'\n      - '!*network*'\n```\n\nIf your K8s deployment using an image name for the pause container that\ndoes not fit the given patterns, you should tweak it as needed.\n",
       "groups": {
         "": {
           "description": "",
@@ -24998,49 +24998,49 @@
         },
         "pod_network_receive_bytes_total": {
           "type": "cumulative",
-          "description": "Cumulative count of bytes received",
+          "description": "Cumulative count of bytes received. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_receive_errors_total": {
           "type": "cumulative",
-          "description": "Cumulative count of errors encountered while receiving",
+          "description": "Cumulative count of errors encountered while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_receive_packets_dropped_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets dropped while receiving",
+          "description": "Cumulative count of packets dropped while receiving. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_receive_packets_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets received",
+          "description": "Cumulative count of packets received. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_transmit_bytes_total": {
           "type": "cumulative",
-          "description": "Cumulative count of bytes transmitted",
+          "description": "Cumulative count of bytes transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_transmit_errors_total": {
           "type": "cumulative",
-          "description": "Cumulative count of errors encountered while transmitting",
+          "description": "Cumulative count of errors encountered while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": true
         },
         "pod_network_transmit_packets_dropped_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets dropped while transmitting",
+          "description": "Cumulative count of packets dropped while transmitting. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         },
         "pod_network_transmit_packets_total": {
           "type": "cumulative",
-          "description": "Cumulative count of packets transmitted",
+          "description": "Cumulative count of packets transmitted. **Note that this metric is not emitted when using the cri-o container runtime.**",
           "group": null,
           "default": false
         }


### PR DESCRIPTION
See individual commits.

This gives us a decent support for cri-o and containerd, but there are still some gaps:

 - cri-o is missing pod networks stats
 - containerd is missing container filesystem usage stats
 - both cri-o and containerd are missing collectd/df metrics.  This is mitigated by #1016.