### PR TITLE
Make cpu.idle on by default

### DIFF
--- a/docs/monitors/collectd-cpu.md
+++ b/docs/monitors/collectd-cpu.md
@@ -43,7 +43,7 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
- - `cpu.idle` (*cumulative*)<br>    CPU time spent not in any other state. In order to get a percentage this value must be compared against the sum of all CPU states.
+ - ***`cpu.idle`*** (*cumulative*)<br>    CPU time spent not in any other state. In order to get a percentage this value must be compared against the sum of all CPU states.
 
  - `cpu.interrupt` (*cumulative*)<br>    CPU time spent while servicing hardware interrupts. A hardware interrupt happens at the physical layer. When this occurs, the CPU will stop whatever else it is doing and service the interrupt. This metric measures how many jiffies were spent handling these interrupts. In order to get a percentage this value must be compared against the sum of all CPU states. A sustained high value for this metric may be caused by faulty hardware such as a broken peripheral.
 

--- a/docs/monitors/collectd-memcached.md
+++ b/docs/monitors/collectd-memcached.md
@@ -60,6 +60,7 @@ Metrics that are categorized as
  - ***`df.cache.used`*** (*gauge*)<br>    Current number of bytes used to store items
  - `memcached_command.flush` (*cumulative*)<br>    Number of flush requests
  - ***`memcached_command.get`*** (*cumulative*)<br>    Number of retrieval requests
+ - `memcached_command.meta` (*cumulative*)<br>    Number of meta requests
  - ***`memcached_command.set`*** (*cumulative*)<br>    Number of storage requests
  - `memcached_command.touch` (*cumulative*)<br>    Number of touch requests
  - ***`memcached_connections.current`*** (*gauge*)<br>    Current number of open connections

--- a/internal/monitors/collectd/cpu/metadata.yaml
+++ b/internal/monitors/collectd/cpu/metadata.yaml
@@ -16,7 +16,7 @@ monitors:
         CPU time spent not in any other state. In order to get a percentage
         this value must be compared against the sum of all CPU states.
       group:
-      default: false
+      default: true
       type: cumulative
     cpu.interrupt:
       description: >

--- a/internal/monitors/collectd/memcached/metadata.yaml
+++ b/internal/monitors/collectd/memcached/metadata.yaml
@@ -22,6 +22,10 @@ monitors:
       description: Current number of bytes used to store items
       default: true
       type: gauge
+    memcached_command.meta:
+      description: Number of meta requests
+      default: false
+      type: cumulative
     memcached_command.flush:
       description: Number of flush requests
       default: false

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -3574,7 +3574,7 @@
           "type": "cumulative",
           "description": "CPU time spent not in any other state. In order to get a percentage this value must be compared against the sum of all CPU states.\n",
           "group": null,
-          "default": false
+          "default": true
         },
         "cpu.interrupt": {
           "type": "cumulative",

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -11041,6 +11041,7 @@
             "df.cache.used",
             "memcached_command.flush",
             "memcached_command.get",
+            "memcached_command.meta",
             "memcached_command.set",
             "memcached_command.touch",
             "memcached_connections.current",
@@ -11093,6 +11094,12 @@
           "description": "Number of retrieval requests",
           "group": null,
           "default": true
+        },
+        "memcached_command.meta": {
+          "type": "cumulative",
+          "description": "Number of meta requests",
+          "group": null,
+          "default": false
         },
         "memcached_command.set": {
           "type": "cumulative",

--- a/tests/monitors/collectd_cpu/cpu_test.py
+++ b/tests/monitors/collectd_cpu/cpu_test.py
@@ -1,29 +1,23 @@
 """
 Tests for the collectd/cpu monitor
 """
-import time
-
 import pytest
-
-from tests.helpers.agent import Agent
 from tests.helpers.metadata import Metadata
-from tests.helpers.verify import run_agent_verify_all_metrics
+from tests.helpers.verify import run_agent_verify_all_metrics, run_agent_verify_default_metrics
 
 pytestmark = [pytest.mark.collectd, pytest.mark.cpu, pytest.mark.monitor_without_endpoints]
 
-METDATA = Metadata.from_package("collectd/cpu")
+METADATA = Metadata.from_package("collectd/cpu")
 
 
 def test_collectd_cpu_default():
-    with Agent.run(
+    run_agent_verify_default_metrics(
         """
         monitors:
         - type: collectd/cpu
-        """
-    ) as agent:
-        # There aren't any default.
-        time.sleep(15)
-        assert not agent.fake_services.datapoints
+        """,
+        METADATA,
+    )
 
 
 def test_collectd_cpu_all():
@@ -33,5 +27,5 @@ def test_collectd_cpu_all():
         - type: collectd/cpu
           extraMetrics: ["*"]
         """,
-        METDATA,
+        METADATA,
     )


### PR DESCRIPTION
It is in built-in content in multiple places and therefore should be default.

Fixes #1007.