### PR TITLE
Clarify metric memory.usage.total in docker-container-stats

### DIFF
--- a/docs/monitors/docker-container-stats.md
+++ b/docs/monitors/docker-container-stats.md
@@ -162,7 +162,12 @@ monitor config option `extraGroups`:
  - `memory.stats.writeback` (*gauge*)<br>    The amount of memory from file/anon cache that are queued for syncing to the disk
  - ***`memory.usage.limit`*** (*gauge*)<br>    Memory usage limit of the container, in bytes
  - `memory.usage.max` (*gauge*)<br>    Maximum measured memory usage of the container, in bytes
- - ***`memory.usage.total`*** (*gauge*)<br>    Bytes of memory used by the container
+ - ***`memory.usage.total`*** (*gauge*)<br>    Bytes of memory used by the container. Note that this **includes the
+    buffer cache** attributed to the process by the kernel from files that
+    have been read by processes in the container.  If you don't want to
+    count that when monitoring containers, enable the metric
+    `memory.stats.total_cache` and subtract that metric from this one.
+
 
 #### Group network
 All of the following metrics are part of the `network` metric group. All of

--- a/internal/monitors/docker/metadata.yaml
+++ b/internal/monitors/docker/metadata.yaml
@@ -449,7 +449,12 @@ monitors:
       type: gauge
       group: memory
     memory.usage.total:
-      description: Bytes of memory used by the container
+      description: |
+        Bytes of memory used by the container. Note that this **includes the
+        buffer cache** attributed to the process by the kernel from files that
+        have been read by processes in the container.  If you don't want to
+        count that when monitoring containers, enable the metric
+        `memory.stats.total_cache` and subtract that metric from this one.
       default: true
       type: gauge
       group: memory

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -19234,7 +19234,7 @@
         },
         "memory.usage.total": {
           "type": "gauge",
-          "description": "Bytes of memory used by the container",
+          "description": "Bytes of memory used by the container. Note that this **includes the\nbuffer cache** attributed to the process by the kernel from files that\nhave been read by processes in the container.  If you don't want to\ncount that when monitoring containers, enable the metric\n`memory.stats.total_cache` and subtract that metric from this one.\n",
           "group": "memory",
           "default": true
         },


### PR DESCRIPTION
Clarifies the issue raised in #1009.