### PR TITLE
Exclude buffer cache memory from docker memory.usage.total metric

### DIFF
--- a/docs/monitors/docker-container-stats.md
+++ b/docs/monitors/docker-container-stats.md
@@ -162,11 +162,11 @@ monitor config option `extraGroups`:
  - `memory.stats.writeback` (*gauge*)<br>    The amount of memory from file/anon cache that are queued for syncing to the disk
  - ***`memory.usage.limit`*** (*gauge*)<br>    Memory usage limit of the container, in bytes
  - `memory.usage.max` (*gauge*)<br>    Maximum measured memory usage of the container, in bytes
- - ***`memory.usage.total`*** (*gauge*)<br>    Bytes of memory used by the container. Note that this **includes the
-    buffer cache** attributed to the process by the kernel from files that
-    have been read by processes in the container.  If you don't want to
-    count that when monitoring containers, enable the metric
-    `memory.stats.total_cache` and subtract that metric from this one.
+ - ***`memory.usage.total`*** (*gauge*)<br>    Bytes of memory used by the container. Note that this **excludes** the
+    buffer cache accounted to the process by the kernel from files that
+    have been read by processes in the container, as well as tmpfs usage.
+    If you want to count that when monitoring containers, enable the metric
+    `memory.stats.total_cache` and add it to this metric in SignalFlow.
 
 
 #### Group network

--- a/internal/monitors/docker/conversion.go
+++ b/internal/monitors/docker/conversion.go
@@ -146,9 +146,13 @@ func calculateCPUPercent(previous *dtypes.CPUStats, v *dtypes.CPUStats) float64 
 func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*datapoint.Datapoint {
 	var out []*datapoint.Datapoint
 
+	// If not present, default value will be 0.
+	bufferCacheUsage := stats.Stats["total_cache"]
+
 	out = append(out, []*datapoint.Datapoint{
 		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
-		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage)),
+		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
+		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
 	}...)
 
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled

--- a/internal/monitors/docker/metadata.yaml
+++ b/internal/monitors/docker/metadata.yaml
@@ -450,11 +450,11 @@ monitors:
       group: memory
     memory.usage.total:
       description: |
-        Bytes of memory used by the container. Note that this **includes the
-        buffer cache** attributed to the process by the kernel from files that
-        have been read by processes in the container.  If you don't want to
-        count that when monitoring containers, enable the metric
-        `memory.stats.total_cache` and subtract that metric from this one.
+        Bytes of memory used by the container. Note that this **excludes** the
+        buffer cache accounted to the process by the kernel from files that
+        have been read by processes in the container, as well as tmpfs usage.
+        If you want to count that when monitoring containers, enable the metric
+        `memory.stats.total_cache` and add it to this metric in SignalFlow.
       default: true
       type: gauge
       group: memory

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -19234,7 +19234,7 @@
         },
         "memory.usage.total": {
           "type": "gauge",
-          "description": "Bytes of memory used by the container. Note that this **includes the\nbuffer cache** attributed to the process by the kernel from files that\nhave been read by processes in the container.  If you don't want to\ncount that when monitoring containers, enable the metric\n`memory.stats.total_cache` and subtract that metric from this one.\n",
+          "description": "Bytes of memory used by the container. Note that this **excludes** the\nbuffer cache accounted to the process by the kernel from files that\nhave been read by processes in the container, as well as tmpfs usage.\nIf you want to count that when monitoring containers, enable the metric\n`memory.stats.total_cache` and add it to this metric in SignalFlow.\n",
           "group": "memory",
           "default": true
         },


### PR DESCRIPTION
See https://github.com/signalfx/signalfx-agent/issues/1009 for discussion.