### PR TITLE
Set SSL_CERT_FILE envvar so Python uses the bundled certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -351,6 +351,8 @@ FROM scratch as final-image
 CMD ["/bin/signalfx-agent"]
 
 COPY --from=collectd /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
+
 COPY --from=collectd /etc/nsswitch.conf /etc/nsswitch.conf
 COPY --from=collectd /usr/local/bin/patchelf /bin/
 


### PR DESCRIPTION
Apparently some Python libraries don't recognize the bundled certs at
the standard Ubuntu 16.04 path, so this tells it where to look.

Fixes #1026.