### PR TITLE
Add globalDimensions passthrough to Helm chart

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -44,6 +44,9 @@ data:
 
     globalDimensions:
       kubernetes_cluster: {{ .Values.clusterName }}
+      {{- range $k, $v := .Values.globalDimensions }}
+      {{ $k }}: {{ $v }}
+      {{- end }}
 
     sendMachineID: false
 

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -5,6 +5,11 @@ agentVersion: 4.13.0
 # The access token for SignalFx.  REQUIRED
 signalFxAccessToken: ""
 
+# An additional set of global dimension to set on all datapoints coming out of
+# the agent.  The `kubernetes_cluster` dimension will always be set as a global
+# dimension based on the `clusterName` value.
+globalDimensions:
+
 # Docker image configuration
 image:
   # Image pull policy for the agent pod


### PR DESCRIPTION
Allows specifying arbitrary additional global dimensions for the agent.

Fixes #1040.