### PR TITLE
Add kubernetesCluster helm config option

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -148,3 +148,4 @@ data:
       # ignore its containers
       - dimensions:
           container_spec_name: metadata-agent
+

--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -88,3 +88,4 @@ spec:
       - name: machine-id
         hostPath:
           path: /etc/machine-id
+

--- a/deployments/k8s/helm/signalfx-agent/templates/NOTES.txt
+++ b/deployments/k8s/helm/signalfx-agent/templates/NOTES.txt
@@ -1,27 +1,9 @@
-{{- if not .Values.clusterName -}}
-ERROR: You must set the value 'clusterName' to identify your cluster in
-SignalFx.  It can be any name you like.
-{{- end }}
-
-{{- if not .Values.signalFxAccessToken }}
-ERROR: You must set the value 'signalFxAccessToken' to your organization's
-access token.
-
-If you do not have an access token, visit
-
-https://docs.signalfx.com/en/latest/getting-started/index.html
-
-and request a free trial.
-{{- end }}
-
-{{- if and .Values.signalFxAccessToken .Values.clusterName }}
 The SignalFx agent is being deployed in your Kubernetes cluster.  You should
 see metrics flowing once the agent image is downloaded and started (this may
 take a few minutes since it has to download the agent container image).
 
 Assuming you are logged into SignalFx in your browser, visit
 
-https://app.signalfx.com/#/navigator/kubernetes%20pods/kubernetes%20pods
+https://app.{{ .Values.signalFxRealm | default "us0" }}.signalfx.com/#/navigator/kubernetes%20pods/kubernetes%20pods
 
 to see all of the pods in your cluster.
-{{- end }}

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -1,4 +1,3 @@
-{{- if and .Values.clusterName .Values.signalFxAccessToken -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -37,13 +36,13 @@ data:
 
     intervalSeconds: {{ .Values.metricIntervalSeconds }}
 
-    cluster: {{.Values.clusterName}}
+    cluster: {{ required ".Values.clusterName is required" .Values.clusterName }}
 
     logging:
       level: {{ .Values.logLevel | default "info" }}
 
     globalDimensions:
-      kubernetes_cluster: {{ .Values.clusterName }}
+      kubernetes_cluster: {{ .Values.kubernetesClusterName | default .Values.clusterName }}
       {{- range $k, $v := .Values.globalDimensions }}
       {{ $k }}: {{ $v }}
       {{- end }}
@@ -143,4 +142,3 @@ data:
 {{ toYaml . | indent 6 }}
       {{- end }}
 {{- end }}
-{{- end -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -1,4 +1,3 @@
-{{- if and .Values.clusterName .Values.signalFxAccessToken -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -104,4 +103,3 @@ spec:
       - name: machine-id
         hostPath:
           path: /etc/machine-id
-{{- end -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/secrets.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/secrets.yaml
@@ -10,4 +10,4 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  access-token: {{ .Values.signalFxAccessToken | b64enc | quote }}
+  access-token: {{ (required ".Values.signalFxAccessToken is required. If you need an access token visit https://www.signalfx.com for a free trial." .Values.signalFxAccessToken) | b64enc | quote }}

--- a/deployments/k8s/helm/signalfx-agent/templates/secrets.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/secrets.yaml
@@ -10,4 +10,4 @@ metadata:
     release: {{ .Release.Name }}
 type: Opaque
 data:
-  access-token: {{ (required ".Values.signalFxAccessToken is required. If you need an access token visit https://www.signalfx.com for a free trial." .Values.signalFxAccessToken) | b64enc | quote }}
+  access-token: {{ (required ".Values.signalFxAccessToken is required. If you need an access token, check your profile page in the SignalFx web application, or visit https://www.signalfx.com for a free trial." .Values.signalFxAccessToken) | b64enc | quote }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -2,7 +2,7 @@
 # docker image tag if not overridden with imageTag
 agentVersion: 4.13.0
 
-# The access token for SignalFx.  REQUIRED
+# The access token for SignalFx. (REQUIRED)
 signalFxAccessToken: ""
 
 # An additional set of global dimension to set on all datapoints coming out of
@@ -83,12 +83,17 @@ traceEndpointUrl:
 # The SignalFx API base URL. (default: "https://api.signalfx.com")
 apiUrl:
 
-# clusterName must be provided.  It is an arbitrary value that identifies this
-# K8s cluster in SignalFx.  This will be the value of the 'kubernetes_cluster'
-# dimension on every metric sent by the agent.  It will also be the value of
-# the `cluster` config option that is used to set a `cluster` property on the
-# `kubernetes_node` dimension.
+# An arbitrary value that identifies this K8s cluster in SignalFx.  This value
+# must match the configured cluster name in the SignalFx Smart Gateway if it is
+# being used. This will be the value of the 'kubernetes_cluster' dimension on
+# every metric sent by the agent (unless overriden by `kubernetesClusterName`).
+# It will also be the value of the `cluster` config option that is used to set a
+# `cluster` property on the `kubernetes_node` dimension. (REQUIRED)
 clusterName:
+
+# Kubernetes cluster name that is sent as the `kubernetes_cluster` dimension on all metrics.
+# Defaults to `clusterName` value if not set. Setting this value does not change `clusterName`.
+kubernetesClusterName:
 
 # How frequently to send metrics by default in the agent.  This can be
 # overridden by individual monitors.


### PR DESCRIPTION
A user wanted to be able to use a different value for kubernetes_cluster than
that of cluster.

Also cleanup required values. Removed conditional from daemonset and configmap
because it would confusingly result in half the helm chart being deployed.