### PR TITLE
Add shutdown and retry to internal status server

### DIFF
--- a/internal/core/agent.go
+++ b/internal/core/agent.go
@@ -151,6 +151,9 @@ func (a *Agent) shutdown() {
 	a.monitors.Shutdown()
 	//neopy.Instance().Shutdown()
 	a.writer.Shutdown()
+	if a.diagnosticServer != nil {
+		a.diagnosticServer.Close()
+	}
 }
 
 // Startup the agent.  Returns a function that can be called to shutdown the


### PR DESCRIPTION
This helps in situations where the agent restarts and the port is still
bound.