### PR TITLE
Don't convert empty dim prop values to nil

### DIFF
--- a/internal/core/writer/dimensions/client.go
+++ b/internal/core/writer/dimensions/client.go
@@ -268,19 +268,15 @@ func (dc *DimensionClient) makePatchRequest(key, value string, props map[string]
 		}
 	}
 
-	propsWithNil := map[string]interface{}{}
-	// Set any empty string props to nil so they get removed from the
-	// dimension altogether.
-	for k, v := range props {
-		if v == "" {
-			propsWithNil[k] = nil
-		} else {
-			propsWithNil[k] = v
-		}
+	if props == nil {
+		props = map[string]string{}
 	}
 
+	// The patch endpoint will also accept properties with a null value, in
+	// which case they will be deleted, but the agent's Dimension type doesn't
+	// support this yet.
 	json, err := json.Marshal(map[string]interface{}{
-		"customProperties": propsWithNil,
+		"customProperties": props,
 		"tags":             tagsToAdd,
 		"tagsToRemove":     tagsToRemove,
 	})

--- a/internal/core/writer/dimensions/client_test.go
+++ b/internal/core/writer/dimensions/client_test.go
@@ -179,6 +179,34 @@ func TestDimensionClient(t *testing.T) {
 		})
 	})
 
+	t.Run("property with empty value", func(t *testing.T) {
+		require.NoError(t, client.AcceptDimension(&types.Dimension{
+			Name:  "host",
+			Value: "empty-box",
+			Properties: map[string]string{
+				"a": "",
+			},
+			Tags: map[string]bool{
+				"active": false,
+			},
+			MergeIntoExisting: true,
+		}))
+
+		dims = waitForDims(dimCh, 1, 3)
+		require.Equal(t, dims, []dim{
+			{
+				Key:   "host",
+				Value: "empty-box",
+				Properties: map[string]string{
+					"a": "",
+				},
+				Tags:         []string{},
+				TagsToRemove: []string{"active"},
+				WasPatch:     true,
+			},
+		})
+	})
+
 	require.NoError(t, client.AcceptDimension(&types.Dimension{
 		Name:  "AWSUniqueID",
 		Value: "abcd",


### PR DESCRIPTION
There is an issue with the api patch endpoint when the dimension is
created by virtue of this request.