### PR TITLE
Mark openshift metrics as non-default

### DIFF
--- a/docs/monitors/openshift-cluster.md
+++ b/docs/monitors/openshift-cluster.md
@@ -117,34 +117,34 @@ Metrics that are categorized as
     StatefulSet version indicated by the `update_revision` property on the
     `kubernetes_uid` dimension for this StatefulSet.
 
- - ***`openshift.appliedclusterquota.cpu.hard`*** (*gauge*)<br>    Hard limit for number of cpu by namespace
- - ***`openshift.appliedclusterquota.cpu.used`*** (*gauge*)<br>    Consumed number of cpu by namespace
- - ***`openshift.appliedclusterquota.memory.hard`*** (*gauge*)<br>    Hard limit for amount of memory by namespace
- - ***`openshift.appliedclusterquota.memory.used`*** (*gauge*)<br>    Consumed amount of memory by namespace
- - ***`openshift.appliedclusterquota.persistentvolumeclaims.hard`*** (*gauge*)<br>    Hard limit for number of persistentvolumeclaims by namespace
- - ***`openshift.appliedclusterquota.persistentvolumeclaims.used`*** (*gauge*)<br>    Consumed number of persistentvolumeclaims by namespace
- - ***`openshift.appliedclusterquota.pods.hard`*** (*gauge*)<br>    Hard limit for number of pods by namespace
- - ***`openshift.appliedclusterquota.pods.used`*** (*gauge*)<br>    Consumed number of pods by namespace
- - ***`openshift.appliedclusterquota.services.hard`*** (*gauge*)<br>    Hard limit for number of services by namespace
- - ***`openshift.appliedclusterquota.services.loadbalancers.hard`*** (*gauge*)<br>    Hard limit for number of services.loadbalancers by namespace
- - ***`openshift.appliedclusterquota.services.loadbalancers.used`*** (*gauge*)<br>    Consumed number of services.loadbalancers by namespace
- - ***`openshift.appliedclusterquota.services.nodeports.hard`*** (*gauge*)<br>    Hard limit for number of services.nodeports by namespace
- - ***`openshift.appliedclusterquota.services.nodeports.used`*** (*gauge*)<br>    Consumed number of services.nodeports by namespace
- - ***`openshift.appliedclusterquota.services.used`*** (*gauge*)<br>    Consumed number of services by namespace
- - ***`openshift.clusterquota.cpu.hard`*** (*gauge*)<br>    Hard limit for number of cpu across all namespaces
- - ***`openshift.clusterquota.cpu.used`*** (*gauge*)<br>    Consumed number of cpu across all namespaces
- - ***`openshift.clusterquota.memory.hard`*** (*gauge*)<br>    Hard limit for amount of memory across all namespaces
- - ***`openshift.clusterquota.memory.used`*** (*gauge*)<br>    Consumed amount of memory across all namespaces
- - ***`openshift.clusterquota.persistentvolumeclaims.hard`*** (*gauge*)<br>    Hard limit for number of persistentvolumeclaims across all namespaces
- - ***`openshift.clusterquota.persistentvolumeclaims.used`*** (*gauge*)<br>    Consumed number of persistentvolumeclaims across all namespaces
- - ***`openshift.clusterquota.pods.hard`*** (*gauge*)<br>    Hard limit for number of pods across all namespaces
- - ***`openshift.clusterquota.pods.used`*** (*gauge*)<br>    Consumed number of pods across all namespaces
- - ***`openshift.clusterquota.services.hard`*** (*gauge*)<br>    Hard limit for number of services across all namespaces
- - ***`openshift.clusterquota.services.loadbalancers.hard`*** (*gauge*)<br>    Hard limit for number of services.loadbalancers across all namespaces
- - ***`openshift.clusterquota.services.loadbalancers.used`*** (*gauge*)<br>    Consumed number of services.loadbalancers across all namespaces
- - ***`openshift.clusterquota.services.nodeports.hard`*** (*gauge*)<br>    Hard limit for number of services.nodeports across all namespaces
- - ***`openshift.clusterquota.services.nodeports.used`*** (*gauge*)<br>    Consumed number of services.nodeports across all namespaces
- - ***`openshift.clusterquota.services.used`*** (*gauge*)<br>    Consumed number of services across all namespaces
+ - `openshift.appliedclusterquota.cpu.hard` (*gauge*)<br>    Hard limit for number of cpu by namespace
+ - `openshift.appliedclusterquota.cpu.used` (*gauge*)<br>    Consumed number of cpu by namespace
+ - `openshift.appliedclusterquota.memory.hard` (*gauge*)<br>    Hard limit for amount of memory by namespace
+ - `openshift.appliedclusterquota.memory.used` (*gauge*)<br>    Consumed amount of memory by namespace
+ - `openshift.appliedclusterquota.persistentvolumeclaims.hard` (*gauge*)<br>    Hard limit for number of persistentvolumeclaims by namespace
+ - `openshift.appliedclusterquota.persistentvolumeclaims.used` (*gauge*)<br>    Consumed number of persistentvolumeclaims by namespace
+ - `openshift.appliedclusterquota.pods.hard` (*gauge*)<br>    Hard limit for number of pods by namespace
+ - `openshift.appliedclusterquota.pods.used` (*gauge*)<br>    Consumed number of pods by namespace
+ - `openshift.appliedclusterquota.services.hard` (*gauge*)<br>    Hard limit for number of services by namespace
+ - `openshift.appliedclusterquota.services.loadbalancers.hard` (*gauge*)<br>    Hard limit for number of services.loadbalancers by namespace
+ - `openshift.appliedclusterquota.services.loadbalancers.used` (*gauge*)<br>    Consumed number of services.loadbalancers by namespace
+ - `openshift.appliedclusterquota.services.nodeports.hard` (*gauge*)<br>    Hard limit for number of services.nodeports by namespace
+ - `openshift.appliedclusterquota.services.nodeports.used` (*gauge*)<br>    Consumed number of services.nodeports by namespace
+ - `openshift.appliedclusterquota.services.used` (*gauge*)<br>    Consumed number of services by namespace
+ - `openshift.clusterquota.cpu.hard` (*gauge*)<br>    Hard limit for number of cpu across all namespaces
+ - `openshift.clusterquota.cpu.used` (*gauge*)<br>    Consumed number of cpu across all namespaces
+ - `openshift.clusterquota.memory.hard` (*gauge*)<br>    Hard limit for amount of memory across all namespaces
+ - `openshift.clusterquota.memory.used` (*gauge*)<br>    Consumed amount of memory across all namespaces
+ - `openshift.clusterquota.persistentvolumeclaims.hard` (*gauge*)<br>    Hard limit for number of persistentvolumeclaims across all namespaces
+ - `openshift.clusterquota.persistentvolumeclaims.used` (*gauge*)<br>    Consumed number of persistentvolumeclaims across all namespaces
+ - `openshift.clusterquota.pods.hard` (*gauge*)<br>    Hard limit for number of pods across all namespaces
+ - `openshift.clusterquota.pods.used` (*gauge*)<br>    Consumed number of pods across all namespaces
+ - `openshift.clusterquota.services.hard` (*gauge*)<br>    Hard limit for number of services across all namespaces
+ - `openshift.clusterquota.services.loadbalancers.hard` (*gauge*)<br>    Hard limit for number of services.loadbalancers across all namespaces
+ - `openshift.clusterquota.services.loadbalancers.used` (*gauge*)<br>    Consumed number of services.loadbalancers across all namespaces
+ - `openshift.clusterquota.services.nodeports.hard` (*gauge*)<br>    Hard limit for number of services.nodeports across all namespaces
+ - `openshift.clusterquota.services.nodeports.used` (*gauge*)<br>    Consumed number of services.nodeports across all namespaces
+ - `openshift.clusterquota.services.used` (*gauge*)<br>    Consumed number of services across all namespaces
 
 #### Group hpa
 All of the following metrics are part of the `hpa` metric group. All of

--- a/internal/monitors/kubernetes/cluster/metadata.yaml
+++ b/internal/monitors/kubernetes/cluster/metadata.yaml
@@ -357,113 +357,113 @@ monitors:
   metrics:
     openshift.appliedclusterquota.cpu.hard:
       description: Hard limit for number of cpu by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.cpu.used:
       description: Consumed number of cpu by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.memory.hard:
       description: Hard limit for amount of memory by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.memory.used:
       description: Consumed amount of memory by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.persistentvolumeclaims.hard:
       description: Hard limit for number of persistentvolumeclaims by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.persistentvolumeclaims.used:
       description: Consumed number of persistentvolumeclaims by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.pods.hard:
       description: Hard limit for number of pods by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.pods.used:
       description: Consumed number of pods by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.hard:
       description: Hard limit for number of services by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.loadbalancers.hard:
       description: Hard limit for number of services.loadbalancers by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.loadbalancers.used:
       description: Consumed number of services.loadbalancers by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.nodeports.hard:
       description: Hard limit for number of services.nodeports by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.nodeports.used:
       description: Consumed number of services.nodeports by namespace
-      default: true
+      default: false
       type: gauge
     openshift.appliedclusterquota.services.used:
       description: Consumed number of services by namespace
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.cpu.hard:
       description: Hard limit for number of cpu across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.cpu.used:
       description: Consumed number of cpu across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.memory.hard:
       description: Hard limit for amount of memory across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.memory.used:
       description: Consumed amount of memory across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.persistentvolumeclaims.hard:
       description: Hard limit for number of persistentvolumeclaims across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.persistentvolumeclaims.used:
       description: Consumed number of persistentvolumeclaims across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.pods.hard:
       description: Hard limit for number of pods across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.pods.used:
       description: Consumed number of pods across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.hard:
       description: Hard limit for number of services across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.loadbalancers.hard:
       description: Hard limit for number of services.loadbalancers across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.loadbalancers.used:
       description: Consumed number of services.loadbalancers across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.nodeports.hard:
       description: Hard limit for number of services.nodeports across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.nodeports.used:
       description: Consumed number of services.nodeports across all namespaces
-      default: true
+      default: false
       type: gauge
     openshift.clusterquota.services.used:
       description: Consumed number of services across all namespaces
-      default: true
+      default: false
       type: gauge

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -36480,169 +36480,169 @@
           "type": "gauge",
           "description": "Hard limit for number of cpu by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.cpu.used": {
           "type": "gauge",
           "description": "Consumed number of cpu by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.memory.hard": {
           "type": "gauge",
           "description": "Hard limit for amount of memory by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.memory.used": {
           "type": "gauge",
           "description": "Consumed amount of memory by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.persistentvolumeclaims.hard": {
           "type": "gauge",
           "description": "Hard limit for number of persistentvolumeclaims by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.persistentvolumeclaims.used": {
           "type": "gauge",
           "description": "Consumed number of persistentvolumeclaims by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.pods.hard": {
           "type": "gauge",
           "description": "Hard limit for number of pods by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.pods.used": {
           "type": "gauge",
           "description": "Consumed number of pods by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.loadbalancers.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services.loadbalancers by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.loadbalancers.used": {
           "type": "gauge",
           "description": "Consumed number of services.loadbalancers by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.nodeports.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services.nodeports by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.nodeports.used": {
           "type": "gauge",
           "description": "Consumed number of services.nodeports by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.appliedclusterquota.services.used": {
           "type": "gauge",
           "description": "Consumed number of services by namespace",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.cpu.hard": {
           "type": "gauge",
           "description": "Hard limit for number of cpu across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.cpu.used": {
           "type": "gauge",
           "description": "Consumed number of cpu across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.memory.hard": {
           "type": "gauge",
           "description": "Hard limit for amount of memory across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.memory.used": {
           "type": "gauge",
           "description": "Consumed amount of memory across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.persistentvolumeclaims.hard": {
           "type": "gauge",
           "description": "Hard limit for number of persistentvolumeclaims across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.persistentvolumeclaims.used": {
           "type": "gauge",
           "description": "Consumed number of persistentvolumeclaims across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.pods.hard": {
           "type": "gauge",
           "description": "Hard limit for number of pods across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.pods.used": {
           "type": "gauge",
           "description": "Consumed number of pods across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.loadbalancers.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services.loadbalancers across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.loadbalancers.used": {
           "type": "gauge",
           "description": "Consumed number of services.loadbalancers across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.nodeports.hard": {
           "type": "gauge",
           "description": "Hard limit for number of services.nodeports across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.nodeports.used": {
           "type": "gauge",
           "description": "Consumed number of services.nodeports across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         },
         "openshift.clusterquota.services.used": {
           "type": "gauge",
           "description": "Consumed number of services across all namespaces",
           "group": null,
-          "default": true
+          "default": false
         }
       },
       "properties": {


### PR DESCRIPTION
None of these metrics are used in built-in content so this violates our "rule" of default vs non-default metrics. These metrics have been categorized as custom on the backend already, so this is just a doc fix.