### PR TITLE
Fix python-monitor error logging

### DIFF
--- a/internal/monitors/subproc/signalfx/handler.go
+++ b/internal/monitors/subproc/signalfx/handler.go
@@ -178,6 +178,7 @@ func HandleLogMessage(logReader io.Reader, logger logrus.FieldLogger) error {
 	case "WARNING":
 		logger.WithFields(fields).Warn(msg.Message)
 	case "ERROR":
+		logger.WithFields(fields).Error(msg.Message)
 	case "SEVERE":
 		logger.WithFields(fields).Error(msg.Message)
 	case "CRITICAL":


### PR DESCRIPTION
Logging messages at error level was a noop and exceptions were logged as errors
so those were never logged.

Issue #1080