### PR TITLE
Rerun pytest failures in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ commands:
       markers:
         type: string
         default: ""
+      workers:
+        type: string
+        default: auto
       pytest_options:
         type: string
         default: ""
@@ -108,7 +111,8 @@ commands:
           no_output_timeout: 30m
           environment:
             MARKERS: << parameters.markers >>
-            PYTEST_OPTIONS: --verbose --junitxml=~/testresults/results.xml --html=~/testresults/results.html --self-contained-html << parameters.pytest_options >>
+            WORKERS: << parameters.workers >>
+            PYTEST_OPTIONS: << parameters.pytest_options >>
             TESTS_DIR: << parameters.tests_dir >>
             WITH_SUDO: << parameters.with_sudo >>
             SPLIT: << parameters.split >>
@@ -340,7 +344,7 @@ jobs:
       - import_image
       - run: .circleci/scripts/setup-integration-tests.sh
       - run_pytest:
-          pytest_options: -n auto
+          workers: auto
           with_sudo: true
           split: true
 
@@ -352,7 +356,7 @@ jobs:
       - run: .circleci/scripts/setup-perf-tests.sh
       - run_pytest:
           markers: perf_test
-          pytest_options: -n1
+          workers: "1"
 
   k8s_integration_tests:
     executor: machine_image
@@ -384,7 +388,8 @@ jobs:
                 k8s_version: << parameters.k8s_version >>
       - run_pytest:
           markers: kubernetes
-          pytest_options: -n auto --no-use-minikube --agent-image-name=localhost:5000/signalfx-agent:latest --kubeconfig=/home/circleci/.kube/config
+          workers: auto
+          pytest_options: --no-use-minikube --agent-image-name=localhost:5000/signalfx-agent:latest --kubeconfig=/home/circleci/.kube/config
 
   installer_tests:
     executor: machine_image
@@ -393,7 +398,7 @@ jobs:
       - run: .circleci/scripts/setup-installer-tests.sh
       - run_pytest:
           markers: installer
-          pytest_options: -n auto
+          workers: auto
           tests_dir: ./tests/packaging/
 
   package_tests:
@@ -411,7 +416,7 @@ jobs:
             PACKAGE_TYPE: << parameters.package_type >>
           command: .circleci/scripts/setup-package-tests.sh
       - run_pytest:
-          pytest_options: -n auto
+          workers: auto
           tests_dir: ./tests/packaging
 
   bundle_tests:
@@ -423,7 +428,8 @@ jobs:
       - run: .circleci/scripts/setup-bundle-tests.sh
       - run_pytest:
           markers: bundle
-          pytest_options: -n auto --test-bundle-path=/tmp/workspace/signalfx-agent-latest.tar.gz
+          workers: auto
+          pytest_options: --test-bundle-path=/tmp/workspace/signalfx-agent-latest.tar.gz
           tests_dir: ./tests/packaging
 
   deployment_tests:
@@ -442,7 +448,7 @@ jobs:
           command: .circleci/scripts/run-deployment-tests.sh
       - save_test_results
       - run_pytest:
-          pytest_options: -n auto
+          workers: auto
           tests_dir: ./tests/deployments/
 
   pylint_black:

--- a/.circleci/scripts/collect_tests.py
+++ b/.circleci/scripts/collect_tests.py
@@ -1,0 +1,17 @@
+import pytest
+import sys
+
+class CollectTests:
+    def __init__(self):
+        self.collected = set()
+
+    def pytest_collection_finish(self, session):
+        for item in session.items:
+            if item.location[0] not in self.collected:
+                print(item.location[0])
+            self.collected.add(item.location[0])
+
+
+markers = sys.argv[1]
+directory = sys.argv[2]
+pytest.main(['--collect-only', '-m', markers, '-p', 'no:terminal', directory], plugins=[CollectTests()])

--- a/.circleci/scripts/run-pytest.sh
+++ b/.circleci/scripts/run-pytest.sh
@@ -17,7 +17,7 @@ mkdir -p ~/testresults
 
 if [[ $CIRCLE_NODE_TOTAL -gt 1 && -n "$MARKERS" && $SPLIT -eq 1 ]]; then
     # Collect tests based on MARKERS and split them for parallelism
-    TESTS=$(pytest --collect-only -m "$MARKERS" $TESTS_DIR | grep '<Module.*>' | cut -d "'" -f2 | \
+    TESTS=$(python .circleci/scripts/collect_tests.py "$MARKERS" $TESTS_DIR | \
         circleci tests split --split-by=timings --total=$CIRCLE_NODE_TOTAL --index=$CIRCLE_NODE_INDEX)
     [ -n "$TESTS" ] || (echo "No test files found after splitting based on '$MARKERS' marker(s)!" && exit 1)
 else

--- a/.circleci/scripts/run-pytest.sh
+++ b/.circleci/scripts/run-pytest.sh
@@ -28,10 +28,18 @@ PYTEST_PATH="pytest"
 if [ $WITH_SUDO -eq 1 ]; then
     PYTEST_PATH="sudo -E $PYENV_ROOT/shims/pytest"
 fi
+FIRSTRUN_OPTIONS="--verbose --junitxml=~/testresults/results.xml --html=~/testresults/results.html --self-contained-html"
+RERUN_OPTIONS="--last-failed --verbose --junitxml=~/testresults/rerun-results.xml --html=~/testresults/rerun-results.html --self-contained-html"
+WORKERS=${WORKERS-}
+if [ -n "$WORKERS" ]; then
+    WORKERS="-n $WORKERS"
+fi
 
 set -x
 if [ -n "$MARKERS" ]; then
-    $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $TESTS
+    $PYTEST_PATH -m "$MARKERS" $WORKERS $PYTEST_OPTIONS $FIRSTRUN_OPTIONS $TESTS || \
+        $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $RERUN_OPTIONS $TESTS
 else
-    $PYTEST_PATH $PYTEST_OPTIONS $TESTS
+    $PYTEST_PATH $WORKERS $PYTEST_OPTIONS $FIRSTRUN_OPTIONS $TESTS || \
+        $PYTEST_PATH $PYTEST_OPTIONS $RERUN_OPTIONS $TESTS
 fi


### PR DESCRIPTION
Rerun all pytest failures in circleci to help reduce job failures due to environmental or file descriptor issues.