### PR TITLE
CPU Monitor GA

### DIFF
--- a/docs/monitors/cpu.md
+++ b/docs/monitors/cpu.md
@@ -48,6 +48,11 @@ Metrics that are categorized as
 
 
  - ***`cpu.utilization`*** (*gauge*)<br>    Percent of CPU used on this host. This metric is emitted with a plugin dimension set to "signalfx-metadata".
+
+#### Group per_core
+All of the following metrics are part of the `per_core` metric group. All of
+the non-default metrics below can be turned on by adding `per_core` to the
+monitor config option `extraGroups`:
  - `cpu.utilization_per_core` (*gauge*)<br>    Percent of CPU used on each core. This metric is emitted with the plugin dimension set to "signalfx-metadata"
 
 ### Non-default metrics (version 4.7.0+)

--- a/pkg/monitors/cpu/genmetadata.go
+++ b/pkg/monitors/cpu/genmetadata.go
@@ -9,7 +9,13 @@ import (
 
 const monitorType = "cpu"
 
-var groupSet = map[string]bool{}
+const (
+	groupPerCore = "per_core"
+)
+
+var groupSet = map[string]bool{
+	groupPerCore: true,
+}
 
 const (
 	cpuUtilization        = "cpu.utilization"
@@ -18,14 +24,18 @@ const (
 
 var metricSet = map[string]monitors.MetricInfo{
 	cpuUtilization:        {Type: datapoint.Gauge},
-	cpuUtilizationPerCore: {Type: datapoint.Gauge},
+	cpuUtilizationPerCore: {Type: datapoint.Gauge, Group: groupPerCore},
 }
 
 var defaultMetrics = map[string]bool{
 	cpuUtilization: true,
 }
 
-var groupMetricsMap = map[string][]string{}
+var groupMetricsMap = map[string][]string{
+	groupPerCore: []string{
+		cpuUtilizationPerCore,
+	},
+}
 
 var monitorMetadata = monitors.Metadata{
 	MonitorType:       "cpu",

--- a/pkg/monitors/cpu/metadata.yaml
+++ b/pkg/monitors/cpu/metadata.yaml
@@ -23,5 +23,9 @@ monitors:
         plugin dimension set to "signalfx-metadata"
       default: false
       type: gauge
+      group: per_core
   monitorType: cpu
   properties:
+  groups:
+    per_core:
+      description: Per-core CPU metrics

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -18155,7 +18155,12 @@
         "": {
           "description": "",
           "metrics": [
-            "cpu.utilization",
+            "cpu.utilization"
+          ]
+        },
+        "per_core": {
+          "description": "Per-core CPU metrics",
+          "metrics": [
             "cpu.utilization_per_core"
           ]
         }
@@ -18170,7 +18175,7 @@
         "cpu.utilization_per_core": {
           "type": "gauge",
           "description": "Percent of CPU used on each core. This metric is emitted with the plugin dimension set to \"signalfx-metadata\"",
-          "group": null,
+          "group": "per_core",
           "default": false
         }
       },

--- a/tests/monitors/cpu/cpu_test.py
+++ b/tests/monitors/cpu/cpu_test.py
@@ -3,9 +3,9 @@ Tests for the cpu monitor
 """
 
 import pytest
-
+from tests.helpers.assertions import has_datapoint
 from tests.helpers.metadata import Metadata
-from tests.helpers.verify import run_agent_verify_default_metrics, run_agent_verify_all_metrics
+from tests.helpers.verify import run_agent_verify_all_metrics, run_agent_verify_default_metrics
 
 pytestmark = [pytest.mark.windows, pytest.mark.cpu, pytest.mark.monitor_without_endpoints]
 
@@ -23,7 +23,7 @@ def test_cpu_default():
 
 
 def test_cpu_all():
-    run_agent_verify_all_metrics(
+    agent = run_agent_verify_all_metrics(
         """
         monitors:
         - type: cpu
@@ -31,3 +31,5 @@ def test_cpu_all():
         """,
         METADATA,
     )
+
+    assert has_datapoint(agent.fake_services, metric_name="cpu.utilization_per_core", dimensions={"cpu": "0"})


### PR DESCRIPTION
 - Corrected CPU total calculation to remove double-counted guest
 values.
 - Removed beta warning for Linux
 - Make sure all comparisons of utilizations are done with floats

Breaking Changes:
 - The dimension for `core` is now called `cpu` and the value is simply
 the CPU number.  The term `core` was not terribly accurate given
 hyperthreading and virtual CPUs.
 - Removed the `plugin` dimension from this monitor as it is no longer
 needed.