### PR TITLE
Remove ESM apt repo from ubuntu 14.04 tests

### DIFF
--- a/tests/deployments/chef/images/Dockerfile.ubuntu1404
+++ b/tests/deployments/chef/images/Dockerfile.ubuntu1404
@@ -4,7 +4,8 @@ FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update &&\
+RUN rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list && \
+    apt update &&\
     apt install -y ca-certificates procps apt-transport-https curl
 
 WORKDIR /opt/cookbooks

--- a/tests/deployments/puppet/images/Dockerfile.ubuntu1404
+++ b/tests/deployments/puppet/images/Dockerfile.ubuntu1404
@@ -2,7 +2,8 @@ FROM ubuntu:14.04
 
 # See https://github.com/tianon/dockerfiles
 
-RUN apt update &&\
+RUN rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list && \
+    apt update &&\
     apt install -y ca-certificates procps wget apt-transport-https
 
 ARG PUPPET_RELEASE=""

--- a/tests/packaging/images/Dockerfile.ubuntu1404
+++ b/tests/packaging/images/Dockerfile.ubuntu1404
@@ -2,7 +2,8 @@ FROM ubuntu:14.04
 
 # See https://github.com/tianon/dockerfiles
 
-RUN apt update &&\
+RUN rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list && \
+    apt update &&\
     apt install -y ca-certificates procps wget apt-transport-https
 
 RUN rm /usr/sbin/policy-rc.d; \


### PR DESCRIPTION
The ubuntu:14.04 image was just updated to include the ESM apt repo, which requires a paid account.  Removing this repo ensures that we can still add/upgrade packages in our tests without issues.