### PR TITLE
Make appmesh built-in metrics correct

### DIFF
--- a/docs/monitors/appmesh.md
+++ b/docs/monitors/appmesh.md
@@ -123,8 +123,11 @@ Metrics that are categorized as
  - `upstream_cx_total` (*cumulative*)<br>    Total connections
  - `upstream_cx_tx_bytes_buffered` (*gauge*)<br>    Send connection bytes currently buffered
  - `upstream_cx_tx_bytes_total` (*cumulative*)<br>    Total sent connection bytes
- - ***`upstream_rq_<_>`*** (*cumulative*)<br>    Specific HTTP response codes (e.g., 201, 302, etc.)
- - ***`upstream_rq_<_xx>`*** (*cumulative*)<br>    Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)
+ - `upstream_rq_2xx` (*cumulative*)<br>    Total number of HTTP response codes in the 200-299 range
+ - `upstream_rq_3xx` (*cumulative*)<br>    Total number of HTTP response codes in the 300-399 range
+ - ***`upstream_rq_4xx`*** (*cumulative*)<br>    Total number of HTTP response codes in the 400-499 range
+ - ***`upstream_rq_5xx`*** (*cumulative*)<br>    Total number of HTTP response codes in the 500-599 range
+ - `upstream_rq_<___>` (*cumulative*)<br>    Specific HTTP response codes (e.g., 201, 302, etc.)
  - `upstream_rq_active` (*gauge*)<br>    Total active requests
  - `upstream_rq_cancelled` (*cumulative*)<br>    Total requests cancelled before obtaining a connection pool connection
  - ***`upstream_rq_completed`*** (*cumulative*)<br>    Total upstream requests completed
@@ -136,7 +139,7 @@ Metrics that are categorized as
  - `upstream_rq_per_try_timeout` (*cumulative*)<br>    Total requests that hit the per try timeout
  - ***`upstream_rq_retry`*** (*cumulative*)<br>    Total request retries
  - `upstream_rq_retry_overflow` (*cumulative*)<br>    Total requests not retried due to circuit breaking
- - ***`upstream_rq_retry_success`*** (*cumulative*)<br>    Total request retry successes
+ - `upstream_rq_retry_success` (*cumulative*)<br>    Total request retry successes
  - `upstream_rq_rx_reset` (*cumulative*)<br>    Total requests that were reset remotely
  - ***`upstream_rq_time`*** (*gauge*)<br>    Request time milliseconds
  - `upstream_rq_timeout` (*cumulative*)<br>    Total requests that timed out waiting for a response

--- a/internal/monitors/appmesh/metadata.yaml
+++ b/internal/monitors/appmesh/metadata.yaml
@@ -256,7 +256,7 @@ monitors:
       type: cumulative
     upstream_rq_retry_success:
       description: Total request retry successes
-      default: true
+      default: false
       type: cumulative
     upstream_rq_retry_overflow:
       description: Total requests not retried due to circuit breaking
@@ -266,13 +266,25 @@ monitors:
       description: Total upstream requests completed
       default: true
       type: cumulative
-    upstream_rq_<_xx>:
-      description: Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)
+    upstream_rq_2xx:
+      description: Total number of HTTP response codes in the 200-299 range
+      default: false
+      type: cumulative
+    upstream_rq_3xx:
+      description: Total number of HTTP response codes in the 300-399 range
+      default: false
+      type: cumulative
+    upstream_rq_4xx:
+      description: Total number of HTTP response codes in the 400-499 range
       default: true
       type: cumulative
-    upstream_rq_<_>:
-      description: Specific HTTP response codes (e.g., 201, 302, etc.)
+    upstream_rq_5xx:
+      description: Total number of HTTP response codes in the 500-599 range
       default: true
+      type: cumulative
+    upstream_rq_<___>:
+      description: Specific HTTP response codes (e.g., 201, 302, etc.)
+      default: false
       type: cumulative
     upstream_rq_time:
       description: Request time milliseconds

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -292,8 +292,11 @@
             "upstream_cx_total",
             "upstream_cx_tx_bytes_buffered",
             "upstream_cx_tx_bytes_total",
-            "upstream_rq_\u003c_\u003e",
-            "upstream_rq_\u003c_xx\u003e",
+            "upstream_rq_2xx",
+            "upstream_rq_3xx",
+            "upstream_rq_4xx",
+            "upstream_rq_5xx",
+            "upstream_rq_\u003c___\u003e",
             "upstream_rq_active",
             "upstream_rq_cancelled",
             "upstream_rq_completed",
@@ -597,17 +600,35 @@
           "group": null,
           "default": false
         },
-        "upstream_rq_\u003c_\u003e": {
+        "upstream_rq_2xx": {
           "type": "cumulative",
-          "description": "Specific HTTP response codes (e.g., 201, 302, etc.)",
+          "description": "Total number of HTTP response codes in the 200-299 range",
+          "group": null,
+          "default": false
+        },
+        "upstream_rq_3xx": {
+          "type": "cumulative",
+          "description": "Total number of HTTP response codes in the 300-399 range",
+          "group": null,
+          "default": false
+        },
+        "upstream_rq_4xx": {
+          "type": "cumulative",
+          "description": "Total number of HTTP response codes in the 400-499 range",
           "group": null,
           "default": true
         },
-        "upstream_rq_\u003c_xx\u003e": {
+        "upstream_rq_5xx": {
           "type": "cumulative",
-          "description": "Aggregate HTTP response codes (e.g., 2xx, 3xx, etc.)",
+          "description": "Total number of HTTP response codes in the 500-599 range",
           "group": null,
           "default": true
+        },
+        "upstream_rq_\u003c___\u003e": {
+          "type": "cumulative",
+          "description": "Specific HTTP response codes (e.g., 201, 302, etc.)",
+          "group": null,
+          "default": false
         },
         "upstream_rq_active": {
           "type": "gauge",
@@ -679,7 +700,7 @@
           "type": "cumulative",
           "description": "Total request retry successes",
           "group": null,
-          "default": true
+          "default": false
         },
         "upstream_rq_rx_reset": {
           "type": "cumulative",


### PR DESCRIPTION
This involves splitting out the upstream_rq_xxx metrics into specific metrics
and removing the wildcard one.