### PR TITLE
Make prometheus-exporter timeout user-configurable

### DIFF
--- a/docs/monitors/coredns.md
+++ b/docs/monitors/coredns.md
@@ -50,6 +50,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/coredns.md
+++ b/docs/monitors/coredns.md
@@ -50,7 +50,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/etcd.md
+++ b/docs/monitors/etcd.md
@@ -61,7 +61,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/etcd.md
+++ b/docs/monitors/etcd.md
@@ -61,6 +61,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-gitaly.md
+++ b/docs/monitors/gitlab-gitaly.md
@@ -39,7 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-gitaly.md
+++ b/docs/monitors/gitlab-gitaly.md
@@ -39,6 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-runner.md
+++ b/docs/monitors/gitlab-runner.md
@@ -50,6 +50,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-runner.md
+++ b/docs/monitors/gitlab-runner.md
@@ -50,7 +50,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-sidekiq.md
+++ b/docs/monitors/gitlab-sidekiq.md
@@ -39,7 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-sidekiq.md
+++ b/docs/monitors/gitlab-sidekiq.md
@@ -39,6 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-unicorn.md
+++ b/docs/monitors/gitlab-unicorn.md
@@ -58,7 +58,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-unicorn.md
+++ b/docs/monitors/gitlab-unicorn.md
@@ -58,6 +58,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-workhorse.md
+++ b/docs/monitors/gitlab-workhorse.md
@@ -53,7 +53,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab-workhorse.md
+++ b/docs/monitors/gitlab-workhorse.md
@@ -53,6 +53,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab.md
+++ b/docs/monitors/gitlab.md
@@ -177,7 +177,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/gitlab.md
+++ b/docs/monitors/gitlab.md
@@ -177,6 +177,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kube-controller-manager.md
+++ b/docs/monitors/kube-controller-manager.md
@@ -56,6 +56,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kube-controller-manager.md
+++ b/docs/monitors/kube-controller-manager.md
@@ -56,7 +56,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-apiserver.md
+++ b/docs/monitors/kubernetes-apiserver.md
@@ -51,6 +51,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-apiserver.md
+++ b/docs/monitors/kubernetes-apiserver.md
@@ -51,7 +51,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-proxy.md
+++ b/docs/monitors/kubernetes-proxy.md
@@ -54,6 +54,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-proxy.md
+++ b/docs/monitors/kubernetes-proxy.md
@@ -54,7 +54,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-scheduler.md
+++ b/docs/monitors/kubernetes-scheduler.md
@@ -39,7 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/kubernetes-scheduler.md
+++ b/docs/monitors/kubernetes-scheduler.md
@@ -39,6 +39,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-exporter.md
+++ b/docs/monitors/prometheus-exporter.md
@@ -105,6 +105,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-exporter.md
+++ b/docs/monitors/prometheus-exporter.md
@@ -105,7 +105,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-go.md
+++ b/docs/monitors/prometheus-go.md
@@ -45,7 +45,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-go.md
+++ b/docs/monitors/prometheus-go.md
@@ -45,6 +45,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-nginx-vts.md
+++ b/docs/monitors/prometheus-nginx-vts.md
@@ -43,6 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-nginx-vts.md
+++ b/docs/monitors/prometheus-nginx-vts.md
@@ -43,7 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-node.md
+++ b/docs/monitors/prometheus-node.md
@@ -43,6 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-node.md
+++ b/docs/monitors/prometheus-node.md
@@ -43,7 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-postgres.md
+++ b/docs/monitors/prometheus-postgres.md
@@ -43,6 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-postgres.md
+++ b/docs/monitors/prometheus-postgres.md
@@ -43,7 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-prometheus.md
+++ b/docs/monitors/prometheus-prometheus.md
@@ -43,6 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-prometheus.md
+++ b/docs/monitors/prometheus-prometheus.md
@@ -43,7 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-redis.md
+++ b/docs/monitors/prometheus-redis.md
@@ -43,6 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/prometheus-redis.md
+++ b/docs/monitors/prometheus-redis.md
@@ -43,7 +43,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/traefik.md
+++ b/docs/monitors/traefik.md
@@ -91,7 +91,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
-| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/docs/monitors/traefik.md
+++ b/docs/monitors/traefik.md
@@ -91,6 +91,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
+| `httpTimeout` | no | `int64` | Number of seconds before timing out while requesting data from target host. (**default:** `10s`) |
 | `useServiceAccount` | no | `bool` | Use pod service account to authenticate. (**default:** `false`) |
 | `metricPath` | no | `string` | Path to the metrics endpoint on the exporter server, usually `/metrics` (the default). (**default:** `/metrics`) |
 | `sendAllMetrics` | no | `bool` | Send all the metrics that come out of the Prometheus exporter without any filtering.  This option has no effect when using the prometheus exporter monitor directly since there is no built-in filtering, only when embedding it in other monitors. (**default:** `false`) |

--- a/internal/monitors/prometheusexporter/prometheus.go
+++ b/internal/monitors/prometheusexporter/prometheus.go
@@ -56,7 +56,8 @@ type Config struct {
 	// Path to the client TLS key to use for TLS required connections
 	ClientKeyPath string `yaml:"clientKeyPath"`
 
-	// Number of seconds before timing out while requesting data from target host.
+	// HTTP timeout duration for both read and writes. This should be a
+	// duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
 	HTTPTimeout time.Duration `yaml:"httpTimeout" default:"10s"`
 
 	// Use pod service account to authenticate.

--- a/internal/monitors/prometheusexporter/prometheus.go
+++ b/internal/monitors/prometheusexporter/prometheus.go
@@ -56,6 +56,9 @@ type Config struct {
 	// Path to the client TLS key to use for TLS required connections
 	ClientKeyPath string `yaml:"clientKeyPath"`
 
+	// Number of seconds before timing out while requesting data from target host.
+	HTTPTimeout time.Duration `yaml:"httpTimeout" default:"10s"`
+
 	// Use pod service account to authenticate.
 	UseServiceAccount bool `yaml:"useServiceAccount"`
 
@@ -124,7 +127,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: conf.HTTPTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: tlsConfig,
 		},

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -18930,6 +18930,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -23415,6 +23423,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -24471,6 +24487,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -24684,6 +24708,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -24880,6 +24912,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -25135,6 +25175,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -25470,6 +25518,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -25771,6 +25827,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -30429,6 +30493,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -32903,6 +32975,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -34098,6 +34178,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -35043,6 +35131,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -37170,6 +37266,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -37551,6 +37655,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -37796,6 +37908,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -39024,6 +39144,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -40836,6 +40964,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -41952,6 +42088,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "useServiceAccount",
             "doc": "Use pod service account to authenticate.",
             "default": false,
@@ -42484,6 +42628,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {
@@ -45741,6 +45893,14 @@
             "default": "",
             "required": false,
             "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "httpTimeout",
+            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
             "elementKind": ""
           },
           {

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -18931,7 +18931,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -23424,7 +23424,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -24488,7 +24488,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -24709,7 +24709,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -24916,7 +24916,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -25179,7 +25179,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -25519,7 +25519,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -25831,7 +25831,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -30494,7 +30494,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -32976,7 +32976,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -34179,7 +34179,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -35135,7 +35135,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -37267,7 +37267,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -37656,7 +37656,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -37912,7 +37912,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -39148,7 +39148,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -40965,7 +40965,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -42089,7 +42089,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -42632,7 +42632,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",
@@ -45897,7 +45897,7 @@
           },
           {
             "yamlName": "httpTimeout",
-            "doc": "Number of seconds before timing out while requesting data from target host.",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
             "default": "10s",
             "required": false,
             "type": "int64",


### PR DESCRIPTION
Keeps original default of 10s while allowing user to override.