### PR TITLE
Add is_ipv6 flag to host observer

### DIFF
--- a/docs/observers/host.md
+++ b/docs/observers/host.md
@@ -33,6 +33,7 @@ can be used in discovery rules.
 | `command` | `string` | The full command used to invoke this process, including the executable itself at the beginning. |
 | `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
+| `is_ipv6` | `string` | Will be `true` if the endpoint is IPv6. |
 | `network_port` | `string` | An alias for `port` |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |

--- a/internal/observers/host/host.go
+++ b/internal/observers/host/host.go
@@ -34,6 +34,8 @@ const (
 // ENDPOINT_VAR(command): The full command used to invoke this process,
 // including the executable itself at the beginning.
 
+// ENDPOINT_VAR(is_ipv6): Will be `true` if the endpoint is IPv6.
+
 // Observer that watches the current host
 type Observer struct {
 	serviceCallbacks *observers.ServiceCallbacks
@@ -156,7 +158,11 @@ func (o *Observer) discover() []services.Endpoint {
 			se.Host = ip
 			if c.Family == syscall.AF_INET6 {
 				se.Host = "[" + se.Host + "]"
+				se.AddExtraField("is_ipv6", true)
+			} else {
+				se.AddExtraField("is_ipv6", false)
 			}
+
 			se.Port = uint16(c.Laddr.Port)
 			se.PortType = portTypeToProtocol(c.Type)
 			se.Target = services.TargetTypeHostPort

--- a/internal/observers/host/host_test.go
+++ b/internal/observers/host/host_test.go
@@ -125,6 +125,11 @@ func Test_HostObserver(t *testing.T) {
 				require.EqualValues(t, e.Port, portNum)
 				require.Equal(t, filepath.Base(exe), e.Name)
 				require.Equal(t, e.PortType, services.TCP)
+				if host[0] == ':' {
+					require.Equal(t, e.DerivedFields()["is_ipv6"], true)
+				} else {
+					require.Equal(t, e.DerivedFields()["is_ipv6"], false)
+				}
 			}
 		})
 
@@ -141,6 +146,11 @@ func Test_HostObserver(t *testing.T) {
 				require.EqualValues(t, e.Port, portNum)
 				require.Equal(t, filepath.Base(exe), e.Name)
 				require.Equal(t, services.UDP, e.PortType)
+				if host[0] == ':' {
+					require.Equal(t, e.DerivedFields()["is_ipv6"], true)
+				} else {
+					require.Equal(t, e.DerivedFields()["is_ipv6"], false)
+				}
 			}
 		})
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -46750,6 +46750,12 @@
           "description": "The IP address of the endpoint if the `host` is in the from of an IPv4 address"
         },
         {
+          "name": "is_ipv6",
+          "type": "string",
+          "elementKind": "",
+          "description": "Will be `true` if the endpoint is IPv6."
+        },
+        {
           "name": "network_port",
           "type": "string",
           "elementKind": "",


### PR DESCRIPTION
This allows the user to distinguish between ipv4 and v6 endpoints in the
discovery rules.