### PR TITLE
Attempt to fix EBADF errors in pytest

### DIFF
--- a/.azure-pipelines/templates/run-pytest.yml
+++ b/.azure-pipelines/templates/run-pytest.yml
@@ -25,7 +25,7 @@ steps:
   displayName: 'Install conda'
   condition: and(ne(variables.hasChanges, 'false'), ne(variables.hasChanges, False))
 - powershell: |
-    conda install --yes python=3.6.7 pip=10.0.1
+    conda install --yes python=3.8.0 pip=10.0.1
     python --version
     pip --version
     pip install -q -r tests\requirements.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,15 @@ commands:
             docker load -i /tmp/workspace/image.tar
 
   install_pytest:
-    description: Install pytest and dependencies with pyenv 3.6.3.
+    description: Install pytest and dependencies with pyenv 3.8.0.
     steps:
       - restore_cache:
           key: v1-pytest-{{ checksum "tests/requirements.txt" }}
       - run:
           name: Install pytest and dependencies
           command: |
-            pyenv install --skip-existing 3.6.3
-            pyenv global 3.6.3
+            pyenv install --skip-existing 3.8.0
+            pyenv global 3.8.0
             if which pip; then
                 pip install --upgrade 'pip==10.0.1'
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,15 +44,20 @@ commands:
             docker load -i /tmp/workspace/image.tar
 
   install_pytest:
-    description: Install pytest and dependencies with pyenv 3.8.0.
+    description: Install pytest and dependencies with pyenv.
+    parameters:
+      python_version:
+        type: string
+        default: "3.8.0"
     steps:
       - restore_cache:
-          key: v1-pytest-{{ checksum "tests/requirements.txt" }}
+          key: v1-pytest-<< parameters.python_version >>-{{ checksum "tests/requirements.txt" }}
       - run:
           name: Install pytest and dependencies
           command: |
-            pyenv install --skip-existing 3.8.0
-            pyenv global 3.8.0
+            cd $PYENV_ROOT && git pull && cd -
+            pyenv install --skip-existing << parameters.python_version >>
+            pyenv global << parameters.python_version >>
             if which pip; then
                 pip install --upgrade 'pip==10.0.1'
             else
@@ -67,7 +72,7 @@ commands:
             wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
             sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
       - save_cache:
-          key: v1-pytest-{{ checksum "tests/requirements.txt" }}
+          key: v1-pytest-<< parameters.python_version >>-{{ checksum "tests/requirements.txt" }}
           paths:
             - /opt/circleci/.pyenv
 

--- a/.circleci/scripts/collect_tests.py
+++ b/.circleci/scripts/collect_tests.py
@@ -1,0 +1,17 @@
+import pytest
+import sys
+
+class CollectTests:
+    def __init__(self):
+        self.collected = set()
+
+    def pytest_collection_finish(self, session):
+        for item in session.items:
+            if item.location[0] not in self.collected:
+                print(item.location[0])
+            self.collected.add(item.location[0])
+
+
+markers = sys.argv[1]
+directory = sys.argv[2]
+pytest.main(['--collect-only', '-m', markers, '-p', 'no:terminal', directory], plugins=[CollectTests()])

--- a/.circleci/scripts/run-pytest.sh
+++ b/.circleci/scripts/run-pytest.sh
@@ -31,7 +31,9 @@ fi
 
 set -x
 if [ -n "$MARKERS" ]; then
-    $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $TESTS
+    for i in $(seq 1 20); do
+        $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $TESTS
+    done
 else
     $PYTEST_PATH $PYTEST_OPTIONS $TESTS
 fi

--- a/.circleci/scripts/run-pytest.sh
+++ b/.circleci/scripts/run-pytest.sh
@@ -17,7 +17,7 @@ mkdir -p ~/testresults
 
 if [[ $CIRCLE_NODE_TOTAL -gt 1 && -n "$MARKERS" && $SPLIT -eq 1 ]]; then
     # Collect tests based on MARKERS and split them for parallelism
-    TESTS=$(pytest --collect-only -m "$MARKERS" $TESTS_DIR | grep '<Module.*>' | cut -d "'" -f2 | \
+    TESTS=$(python .circleci/scripts/collect_tests.py "$MARKERS" $TESTS_DIR | \
         circleci tests split --split-by=timings --total=$CIRCLE_NODE_TOTAL --index=$CIRCLE_NODE_INDEX)
     [ -n "$TESTS" ] || (echo "No test files found after splitting based on '$MARKERS' marker(s)!" && exit 1)
 else

--- a/.circleci/scripts/run-pytest.sh
+++ b/.circleci/scripts/run-pytest.sh
@@ -31,9 +31,7 @@ fi
 
 set -x
 if [ -n "$MARKERS" ]; then
-    for i in $(seq 1 20); do
-        $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $TESTS
-    done
+  $PYTEST_PATH -m "$MARKERS" $PYTEST_OPTIONS $TESTS
 else
     $PYTEST_PATH $PYTEST_OPTIONS $TESTS
 fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -94,3 +94,4 @@ markers =
     windowsiis: Windows IIS monitor
     windowslegacy
     zookeeper
+junit_family=legacy

--- a/tests/basic/datapoint_tap_test.py
+++ b/tests/basic/datapoint_tap_test.py
@@ -24,7 +24,8 @@ def test_basic_service_discovery():
                     "nginx_connections*",
                     "-dims",
                     "{plugin: nginx}",
-                ]
+                ],
+                close_fds=False,
             ) as [get_output, _]:
 
                 def shows_datapoints():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,7 @@ NON_INTEGRATION_MARKERS = {"packaging", "installer", "kubernetes", "windows_only
 
 def pytest_collection_modifyitems(items):
     for item in items:
-        if isinstance(item, item.Function):
+        if isinstance(item, pytest.Function):
             if "k8s_cluster" in item.fixturenames:
                 item.add_marker("kubernetes")
             markers = {marker.name for marker in item.iter_markers()}

--- a/tests/deployments/chef/chef_test.py
+++ b/tests/deployments/chef/chef_test.py
@@ -177,7 +177,7 @@ def run_win_chef_client(backend, agent_version, stage):
             cmd = CHEF_CMD.format(attributes_path)
         print('running "%s" ...' % cmd)
         proc = subprocess.run(
-            cmd, cwd=r"C:\chef\cookbooks", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True
+            cmd, cwd=r"C:\chef\cookbooks", stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True, close_fds=False
         )
         output = proc.stdout.decode("utf-8")
         assert proc.returncode == 0, output

--- a/tests/helpers/agent.py
+++ b/tests/helpers/agent.py
@@ -104,7 +104,7 @@ class Agent:
         self.write_config()
 
         with run_subprocess(
-            [AGENT_BIN, "-config", self.config_path] + (["-debug"] if self.debug else []), env=self.env
+            [AGENT_BIN, "-config", self.config_path] + (["-debug"] if self.debug else []), env=self.env, close_fds=False
         ) as [get_output, pid]:
             self.pid = pid
             self.get_output = get_output

--- a/tests/helpers/agent.py
+++ b/tests/helpers/agent.py
@@ -64,9 +64,9 @@ class Agent:
         self.config["configSources"]["file"]["pollRateSeconds"] = 1
 
     def write_config(self):
-        with open(self.config_path, "w") as fd:
+        with open(self.config_path, "wb+") as fd:
             print("CONFIG: %s\n%s" % (self.config_path, self.config))
-            fd.write(self.get_final_config_yaml())
+            fd.write(self.get_final_config_yaml().encode("utf-8"))
 
     def get_final_config_yaml(self):
         self.fill_in_config()
@@ -90,6 +90,7 @@ class Agent:
             [str(AGENT_BIN), "status", "-config", self.config_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            close_fds=False,
             encoding="utf-8",
         )
         return status_proc.stdout

--- a/tests/helpers/agent.py
+++ b/tests/helpers/agent.py
@@ -10,7 +10,7 @@ from . import fake_backend
 from .formatting import print_dp_or_event
 from .internalmetrics import InternalMetricsClient
 from .profiling import PProfClient
-from .util import get_unique_localhost, print_lines, run_subprocess
+from .util import get_unique_localhost, print_lines, retry_on_ebadf, run_subprocess
 
 
 # pylint: disable=too-many-arguments,too-many-instance-attributes
@@ -63,6 +63,7 @@ class Agent:
         self.config["configSources"]["file"] = self.config["configSources"].get("file", {})
         self.config["configSources"]["file"]["pollRateSeconds"] = 1
 
+    @retry_on_ebadf
     def write_config(self):
         with open(self.config_path, "wb+") as fd:
             print("CONFIG: %s\n%s" % (self.config_path, self.config))

--- a/tests/helpers/kubernetes/cluster.py
+++ b/tests/helpers/kubernetes/cluster.py
@@ -68,7 +68,7 @@ class Cluster:
 
         args += shlex.split(command)
 
-        proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8")
+        proc = subprocess.run(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, encoding="utf-8", close_fds=False)
         assert proc.returncode == 0, f"{args}:\n{proc.stdout}"
         return proc.stdout
 

--- a/tests/helpers/kubernetes/tunnel.py
+++ b/tests/helpers/kubernetes/tunnel.py
@@ -53,7 +53,11 @@ def start_tunneling_fake_service(local_host, local_port, namespace, kube_config_
     )
 
     proc = subprocess.Popen(
-        ["/bin/bash", f"{SCRIPT_DIR}/tunnel/client.sh"], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        ["/bin/bash", f"{SCRIPT_DIR}/tunnel/client.sh"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        close_fds=False,
     )
 
     get_output = pull_from_reader_in_background(proc.stdout)

--- a/tests/helpers/profiling.py
+++ b/tests/helpers/profiling.py
@@ -45,7 +45,8 @@ class PProfClient:
             + f"{self._base_url}/debug/pprof/{profile_type}"
         )
 
-        profile_text = subprocess.check_output(command, shell=True)
+        # pylint: disable=unexpected-keyword-arg
+        profile_text = subprocess.check_output(command, shell=True, close_fds=False)
         return self._parse_profile(profile_text)
 
     @staticmethod

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -156,9 +156,11 @@ def get_unique_localhost():
 
 
 @contextmanager
-def run_subprocess(command: List[str], env: Dict[Any, Any] = None):
+def run_subprocess(command: List[str], env: Dict[Any, Any] = None, **kwargs):
     # subprocess on Windows has a bug where it doesn't like Path.
-    proc = subprocess.Popen([str(c) for c in command], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    proc = subprocess.Popen(
+        [str(c) for c in command], env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, **kwargs
+    )
 
     get_output = pull_from_reader_in_background(proc.stdout)
 

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -125,6 +125,7 @@ def socat_https_proxy(container, target_host, target_port, source_host, bind_add
         [socat_bin, "-v", "UNIX-LISTEN:%s,fork" % socket_path, "TCP4:%s:%d" % (target_host, target_port)],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+        close_fds=False,
     )
 
     get_local_out = pull_from_reader_in_background(proc.stdout)
@@ -208,7 +209,7 @@ def run_win_command(cmd, returncodes=None, shell=True, **kwargs):
     if returncodes is None:
         returncodes = [0]
     print('running "%s" ...' % cmd)
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell, **kwargs)
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell, close_fds=False, **kwargs)
     output = proc.stdout.decode("utf-8")
     if returncodes:
         assert proc.returncode in returncodes, output

--- a/tests/pylintrc
+++ b/tests/pylintrc
@@ -421,7 +421,8 @@ good-names=e,
            do_PUT,
            _,
            logger,
-           runner
+           runner,
+           T
 
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -13,7 +13,7 @@ pytest-rerunfailures==4.1
 pytest-xdist==1.30.0
 pytest==5.3.1
 redis==2.10.6
-requests==2.21.0
+requests==2.22.0
 sanic==18.12.0
 semver==2.8.0
 signalfx==1.0.19

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==5.1
 black==18.9b0
-docker==3.5.0
+docker==4.1.0
 hvac==0.7.2
 kubernetes==9.0.0
 mysql-connector-python==8.0.16

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,8 +10,8 @@ psutil==5.6.1
 pylint==2.3.0
 pytest-html==1.22
 pytest-rerunfailures==4.1
-pytest-xdist==1.22.0
-pytest==3.6.0
+pytest-xdist==1.30.0
+pytest==5.3.1
 redis==2.10.6
 requests==2.21.0
 sanic==18.12.0


### PR DESCRIPTION
 - Upgrade Python to latest
 - Upgrade pytest and pytest-xdist
 - Don't close file descriptors for stdin/out/err when running agent as a subprocess
 - Write the config file in binary mode
 - Add decorator to catch and retry EBADF for certain functions.