### PR TITLE
Fixed expvar monitor crashing for empty map value and metric name mangling for wildcard in JSON path

### DIFF
--- a/internal/monitors/expvar/common.go
+++ b/internal/monitors/expvar/common.go
@@ -3,10 +3,7 @@ package expvar
 import (
 	"errors"
 	"regexp"
-	"strconv"
 	"strings"
-
-	"github.com/signalfx/golib/v3/datapoint"
 )
 
 var capRegexp = regexp.MustCompile("(^[^A-Z]*|[A-Z]*)([A-Z][^A-Z]+|$)")
@@ -37,18 +34,6 @@ func joinWords(slice []string, sep string) string {
 		}
 	}
 	return strings.Join(words, sep)
-}
-
-// getMostRecentGCPauseIndex logic is derived from https://golang.org/pkg/runtime/ in the PauseNs section of the 'type MemStats' section
-func getMostRecentGCPauseIndex(dpsMap map[string][]*datapoint.Datapoint) int64 {
-	dps := dpsMap[memstatsNumGCMetricPath]
-	mostRecentGCPauseIndex := int64(-1)
-	if len(dps) > 0 && dps[0].Value != nil {
-		if numGC, err := strconv.ParseInt(dps[0].Value.String(), 10, 0); err == nil {
-			mostRecentGCPauseIndex = (numGC + 255) % 256
-		}
-	}
-	return mostRecentGCPauseIndex
 }
 
 var slashLastRegexp = regexp.MustCompile(`[^\/]*$`)

--- a/internal/monitors/expvar/config.go
+++ b/internal/monitors/expvar/config.go
@@ -2,6 +2,7 @@ package expvar
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/signalfx/signalfx-agent/internal/utils"
@@ -44,6 +45,19 @@ func (c *Config) GetExtraMetrics() []string {
 		return []string{"*"}
 	}
 	return nil
+}
+
+func (c *Config) getURL() url.URL {
+	return url.URL{
+		Scheme: func() string {
+			if c.UseHTTPS {
+				return "https"
+			}
+			return "http"
+		}(),
+		Host: fmt.Sprintf("%s:%d", c.Host, c.Port),
+		Path: c.Path,
+	}
 }
 
 var _ config.ExtraMetrics = &Config{}

--- a/internal/monitors/expvar/expvar.go
+++ b/internal/monitors/expvar/expvar.go
@@ -3,7 +3,6 @@ package expvar
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -26,31 +25,27 @@ const (
 	memstatsBySizeSizeMetricPath    = "memstats.BySize.\\.*.Size"
 	memstatsBySizeMallocsMetricPath = "memstats.BySize.\\.*.Mallocs"
 	memstatsBySizeFreesMetricPath   = "memstats.BySize.\\.*.Frees"
-	memstatsBySizeDimensionPath     = "memstats.BySize"
+	memstatsBySizeDimensionPath     = "memstats_by_size_index"
 )
 
 func init() {
-	monitors.Register(&monitorMetadata, func() interface{} {
-		return &Monitor{
-			keysFromPaths:    map[string][]string{},
-			keysFromDimPaths: map[string][]string{},
-			allMetricConfigs: nil,
-		}
-	}, &Config{})
+	monitors.Register(&monitorMetadata, func() interface{} { return &Monitor{} }, &Config{})
 }
 
 // Monitor for expvar metrics
 type Monitor struct {
-	Output           types.FilteringOutput
-	cancel           context.CancelFunc
-	ctx              context.Context
-	client           *http.Client
-	url              *url.URL
-	runInterval      time.Duration
-	keysFromPaths    map[string][]string
-	keysFromDimPaths map[string][]string
-	allMetricConfigs []*MetricConfig
-	logger           log.FieldLogger
+	Output types.FilteringOutput
+	cancel context.CancelFunc
+	ctx    context.Context
+	client *http.Client
+	logger log.FieldLogger
+}
+
+type metricVal struct {
+	metric              string
+	keys                []string
+	value               datapoint.Value
+	arrayIndexDimension map[string]string
 }
 
 // Configure monitor
@@ -59,23 +54,6 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 	if m.Output.HasAnyExtraMetrics() {
 		conf.EnhancedMetrics = true
 	}
-	m.allMetricConfigs = conf.getAllMetricConfigs()
-	for _, mConf := range m.allMetricConfigs {
-		if m.keysFromPaths[mConf.Name], err = utils.SplitString(mConf.JSONPath, []rune(mConf.PathSeparator)[0], escape); err != nil {
-			return err
-		}
-	}
-	m.url = &url.URL{
-		Scheme: func() string {
-			if conf.UseHTTPS {
-				return "https"
-			}
-			return "http"
-		}(),
-		Host: fmt.Sprintf("%s:%d", conf.Host, conf.Port),
-		Path: conf.Path,
-	}
-	m.runInterval = time.Duration(conf.IntervalSeconds) * time.Second
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 	m.client = &http.Client{
 		Transport: &http.Transport{
@@ -83,36 +61,79 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 		},
 		Timeout: 300 * time.Millisecond,
 	}
+
+	url := conf.getURL()
+	runInterval := time.Duration(conf.IntervalSeconds) * time.Second
+	allMetricConfigs := conf.getAllMetricConfigs()
+
 	utils.RunOnInterval(m.ctx, func() {
-		dpsMap, err := m.fetchMetrics()
+		obj, err := m.fetchObj(url)
 		if err != nil {
-			m.logger.WithError(err).Error("could not get expvar metrics")
+			m.logger.WithError(err).Error("Getting expvar json object failed")
 			return
 		}
-		mostRecentGCPauseIndex := getMostRecentGCPauseIndex(dpsMap)
-		now := time.Now()
-		for metricPath, dps := range dpsMap {
-			// This is the filtering in place trick from https://github.com/golang/go/wiki/SliceTricks#filter-in-place
-			n := 0
-			for i := range dps {
-				shouldSend, err := m.preprocessDatapoint(dps[i], metricPath, mostRecentGCPauseIndex, &now)
-				if err != nil {
-					m.logger.Error(err)
-					continue
-				}
-				if shouldSend {
-					dps[n] = dps[i]
-					n++
+		applicationName, err := getApplicationName(obj)
+		if err != nil {
+			m.logger.Warn(err)
+		}
+		valsMap := make(map[string][]*metricVal)
+		mostRecentGCPauseIndex := int64(-1)
+		// Getting the most recent GC pause index using logic from https://golang.org/pkg/runtime/ in the PauseNs section of the 'type MemStats' section
+		for _, mConf := range allMetricConfigs {
+			vals := m.getValuesInPath(obj, mConf.JSONPath, mConf.PathSeparator)
+			valsMap[mConf.JSONPath] = vals
+			if mConf.JSONPath == memstatsNumGCMetricPath {
+				if len(vals) > 0 && vals[0].value != nil {
+					if numGC, err := strconv.ParseInt(vals[0].value.String(), 10, 0); err == nil {
+						mostRecentGCPauseIndex = (numGC + 255) % 256
+					}
 				}
 			}
-			m.Output.SendDatapoints(dps[:n]...)
 		}
-	}, m.runInterval)
+		// Using the most recent GC pause index to get the most recent gc pause values in arrays PauseNs and PauseEnd and discarding the rest.
+		for k, vals := range valsMap {
+			if k == memstatsPauseNsMetricPath || k == memstatsPauseEndMetricPath {
+				newVals := make([]*metricVal, 0)
+				for _, val := range vals {
+					indexStr := val.arrayIndexDimension[joinWords(append(snakeCaseSlice(val.keys), "array_index"), "_")]
+					index, err := strconv.ParseInt(indexStr, 10, 0)
+					if err != nil {
+						m.logger.Errorf("Error while getting the most recent GC pause. %+v", err)
+						continue
+					}
+					if index == mostRecentGCPauseIndex {
+						if val.metric = memstatsMostRecentGcPauseNs; k == memstatsPauseEndMetricPath {
+							val.metric = memstatsMostRecentGcPauseEnd
+						}
+						newVals = append(newVals, val)
+					}
+				}
+				valsMap[k] = newVals
+			}
+		}
+		dps := make([]*datapoint.Datapoint, 0)
+		now := time.Now()
+		for _, mConf := range allMetricConfigs {
+			for _, metricVal := range valsMap[mConf.JSONPath] {
+				dp := m.newDp(metricVal, mConf.JSONPath, mConf.metricType(), now)
+				if applicationName != "" {
+					dp.Dimensions["application_name"] = applicationName
+				}
+				for _, dConf := range mConf.DimensionConfigs {
+					if strings.TrimSpace(dConf.Name) != "" && strings.TrimSpace(dConf.Value) != "" {
+						dp.Dimensions[dConf.Name] = dConf.Value
+					}
+				}
+				dps = append(dps, dp)
+			}
+		}
+		m.Output.SendDatapoints(dps...)
+	}, runInterval)
 	return nil
 }
 
-func (m *Monitor) fetchMetrics() (map[string][]*datapoint.Datapoint, error) {
-	resp, err := m.client.Get(m.url.String())
+func (m *Monitor) fetchObj(url url.URL) (map[string]interface{}, error) {
+	resp, err := m.client.Get(url.String())
 	if err != nil {
 		return nil, err
 	}
@@ -128,175 +149,105 @@ func (m *Monitor) fetchMetrics() (map[string][]*datapoint.Datapoint, error) {
 	if err != nil {
 		return nil, err
 	}
-	applicationName, err := getApplicationName(jsonObj)
+	return jsonObj, nil
+}
+
+// getValuesInPath gets values in path "path" of "obj"
+func (m *Monitor) getValuesInPath(obj map[string]interface{}, path string, pathSeparator string) []*metricVal {
+	// Splitting configured path into components. The path and thus its components contain regular expressions
+	pathComps, err := utils.SplitString(path, []rune(pathSeparator)[0], escape)
 	if err != nil {
-		m.logger.Warn(err)
+		m.logger.Error(err)
+		return nil
 	}
-	dps := make(map[string][]*datapoint.Datapoint)
-	for _, mConf := range m.allMetricConfigs {
-		dps[mConf.JSONPath] = make([]*datapoint.Datapoint, 0)
-		for _, jsonKey := range m.findMatchingMapKeys(m.keysFromPaths[mConf.Name][0], jsonObj) {
-			dp := datapoint.Datapoint{Dimensions: map[string]string{}}
-			if applicationName != "" {
-				dp.Dimensions["application_name"] = applicationName
-			}
-			m.addDps(dps, &dp, []string{jsonKey}, 0, jsonObj[jsonKey], mConf)
-		}
-	}
-	return dps, nil
+	return m.getValuesInPathHelper(obj, pathComps)
 }
 
-func (m *Monitor) findMatchingMapKeys(regex string, aMap map[string]interface{}) []string {
-	if aMap[regex] != nil {
-		return []string{regex}
-	}
-	var keys []string
-	for key := range aMap {
-		matched, err := regexp.MatchString(regex, key)
-		if err != nil {
-			m.logger.Error(err)
-			continue
-		}
-		if matched {
-			keys = append(keys, key)
-		}
-	}
-	return keys
-}
-
-// addDps sets metric values and dimensions by traversing jsonValue recursively using keys derived by regex matching
-// configured JSON paths. When addDps encounters and array type JSON value it clones the datapoint argument and adds
-// dimension to hold the array index.
-func (m *Monitor) addDps(dps map[string][]*datapoint.Datapoint, dp *datapoint.Datapoint, keys []string, keyFromPathIndex int, value interface{}, conf *MetricConfig) {
-	keysFromPath, pathKeysLen, nextKeyFromPathIndex := m.keysFromPaths[conf.Name], len(m.keysFromPaths[conf.Name]), keyFromPathIndex+1
-	atPathEnd := nextKeyFromPathIndex == pathKeysLen
-	switch value := value.(type) {
+// getValuesInPathHelper gets values in "obj" by traversing "obj" depth-wise using path components "pathComps" as keys.
+func (m *Monitor) getValuesInPathHelper(obj interface{}, pathComps []string) (values []*metricVal) {
+	switch value := obj.(type) {
 	case map[string]interface{}:
-		if atPathEnd {
-			m.logger.Debugf("Expecting numeric value in path %s but found %+v. Configured path regex %s", joinWords(snakeCaseSlice(keys), conf.PathSeparator), value, conf.JSONPath)
+		if len(pathComps) == 0 {
+			m.logger.Debugf("no key(s) for embedded object %+v", value)
 			return
 		}
-		if len(value) == 0 {
-			m.logger.Debugf("Empty object at %s before end of path. Configured path regex %s", joinWords(snakeCaseSlice(keys), conf.PathSeparator), conf.JSONPath)
-			return
-		}
-		dpCopy, dims := dp, dp.Dimensions
-		nextKeyFromPath := keysFromPath[nextKeyFromPathIndex]
-		for i, nextKey := range m.findMatchingMapKeys(nextKeyFromPath, value) {
-			if i > 0 {
-				dpCopy = &datapoint.Datapoint{Dimensions: utils.CloneStringMap(dims)}
-			}
-			for _, dConf := range conf.DimensionConfigs {
-				if keysFromDimPath := m.keysFromDimPaths[dConf.Name]; len(keysFromDimPath) != 0 && len(keysFromDimPath) == nextKeyFromPathIndex {
-					dpCopy.Dimensions[dConf.Name] = nextKey
-				}
-			}
-			keys := append(keys, nextKey)
-			m.addDps(dps, dpCopy, append(keys[:0:0], keys...), nextKeyFromPathIndex, value[nextKey], conf)
-		}
-	case []interface{}:
-		if atPathEnd {
-			m.logger.Debugf("Expecting numeric value in path %s but found %+v. Configured path regex %s", joinWords(snakeCaseSlice(keys), conf.PathSeparator), value, conf.JSONPath)
-			return
-		}
-		if len(value) == 0 {
-			m.logger.Debugf("Empty object at %s before end of path. Configured path regex %s", joinWords(snakeCaseSlice(keys), conf.PathSeparator), conf.JSONPath)
-			return
-		}
-		array, arrayIndexFromPath := value, keysFromPath[nextKeyFromPathIndex]
-		arrayIndexFromPathCompiled, err := regexp.Compile(arrayIndexFromPath)
+		pathComp, err := regexp.Compile(pathComps[0])
 		if err != nil {
 			m.logger.Error(err)
 			return
 		}
-		dpCopy, dims := dp, dp.Dimensions
-		for arrayIndex, arrayValue := range array {
-			arrayIndexStr := strconv.Itoa(arrayIndex)
-			if arrayIndexFromPathCompiled.MatchString(arrayIndexStr) {
-				if arrayIndex > 0 {
-					dpCopy = &datapoint.Datapoint{Dimensions: utils.CloneStringMap(dims)}
-				}
-				m.addArrayIndexDim(dpCopy.Dimensions, arrayIndexStr, keys, keyFromPathIndex, conf)
-				m.addDps(dps, dpCopy, append(keys[:0:0], keys...), nextKeyFromPathIndex, arrayValue, conf)
-			}
-		}
-	default:
-		m.addDp(dps, dp, value, keys, atPathEnd, conf)
-	}
-}
-
-func (m *Monitor) addDp(dps map[string][]*datapoint.Datapoint, dp *datapoint.Datapoint, value interface{}, keys []string, atPathEnd bool, conf *MetricConfig) {
-	if !atPathEnd {
-		m.logger.Debugf("Expecting object or array at %s before end of path. Found value %+v instead. Configured path regex %s", joinWords(snakeCaseSlice(keys), conf.PathSeparator), value, conf.JSONPath)
-		return
-	}
-	if strings.TrimSpace(conf.Name) != "" {
-		dp.Metric = conf.Name
-	}
-	if dp.Metric == "" {
-		dp.Metric = joinWords(snakeCaseSlice(keys), ".")
-	}
-	dp.MetricType = conf.metricType()
-	for _, dConf := range conf.DimensionConfigs {
-		if strings.TrimSpace(dConf.Name) != "" && strings.TrimSpace(dConf.Value) != "" {
-			dp.Dimensions[dConf.Name] = dConf.Value
-		}
-	}
-	var err error
-	if dp.Value, err = datapoint.CastMetricValueWithBool(value); err == nil {
-		dps[conf.JSONPath] = append(dps[conf.JSONPath], dp)
-	} else {
-		m.logger.Debugf("Failed to set value for metric %s with JSON path %s because of type conversion error due to %+v", conf.Name, conf.JSONPath, err)
-		m.logger.WithError(err).Error("Unable to set metric value")
-	}
-}
-
-func (m *Monitor) addArrayIndexDim(dims map[string]string, arrayIndex string, keys []string, keyFromPathIndex int, metricConfig *MetricConfig) {
-	nextKeyIndex := keyFromPathIndex + 1
-	for _, conf := range metricConfig.DimensionConfigs {
-		if keysFromDimPath := m.keysFromDimPaths[conf.Name]; len(keysFromDimPath) == nextKeyIndex {
-			matched, err := regexp.MatchString(keysFromDimPath[keyFromPathIndex], keys[keyFromPathIndex])
-			if err != nil {
-				m.logger.Error(err)
+		for key := range value {
+			if !pathComp.MatchString(key) {
 				continue
 			}
-			if matched {
-				dims[conf.Name] = arrayIndex
+			var nextPathComps []string
+			if len(pathComps) > 1 {
+				nextPathComps = pathComps[1:]
 			}
+			newValues := m.getValuesInPathHelper(value[key], nextPathComps)
+			for _, newValue := range newValues {
+				newValue.keys = append([]string{key}, newValue.keys...)
+				dims := make(map[string]string)
+				for k, v := range newValue.arrayIndexDimension {
+					dims[joinWords(append(snakeCaseSlice([]string{key}), k), "_")] = v
+				}
+				newValue.arrayIndexDimension = dims
+			}
+			values = append(values, newValues...)
+		}
+		return values
+	case []interface{}:
+		pathComp, err := regexp.Compile(pathComps[0])
+		if err != nil {
+			m.logger.Error(err)
 			return
 		}
+		for i := range value {
+			index := strconv.Itoa(i)
+			if !pathComp.MatchString(index) {
+				continue
+			}
+			var nextPathComps []string
+			if len(pathComps) > 1 {
+				nextPathComps = pathComps[1:]
+			}
+			newValues := m.getValuesInPathHelper(value[i], nextPathComps)
+			for _, newValue := range newValues {
+				newValue.arrayIndexDimension = make(map[string]string)
+				newValue.arrayIndexDimension["array_index"] = index
+			}
+			values = append(values, newValues...)
+		}
+		return values
+	default:
+		metricValue, err := datapoint.CastMetricValueWithBool(value)
+		if err != nil {
+			m.logger.Error(err)
+		}
+		return []*metricVal{{value: metricValue}}
 	}
-	if metricConfig.JSONPath == memstatsPauseNsMetricPath || metricConfig.JSONPath == memstatsPauseEndMetricPath {
-		dims[metricConfig.JSONPath] = arrayIndex
-		return
-	}
-	dims[joinWords(append(snakeCaseSlice(keys[:nextKeyIndex]), "index"), "_")] = arrayIndex
 }
 
-func (m *Monitor) preprocessDatapoint(dp *datapoint.Datapoint, metricPath string, mostRecentGCPauseIndex int64, now *time.Time) (bool, error) {
-	if metricPath == memstatsPauseNsMetricPath || metricPath == memstatsPauseEndMetricPath {
-		index, err := strconv.ParseInt(dp.Dimensions[metricPath], 10, 0)
-		if err == nil && index == mostRecentGCPauseIndex {
-			dp.Metric = memstatsMostRecentGcPauseNs
-			if metricPath == memstatsPauseEndMetricPath {
-				dp.Metric = memstatsMostRecentGcPauseEnd
-			}
-			// For index dimension key is equal to metric path for default metrics memstats.PauseNs and memstats.PauseEnd
-			delete(dp.Dimensions, metricPath)
-		} else {
-			if err != nil {
-				err = fmt.Errorf("failed to set metric GC pause. %+v", err)
-			}
-			return false, err
-		}
+func (m *Monitor) newDp(val *metricVal, path string, metricType datapoint.MetricType, now time.Time) *datapoint.Datapoint {
+	dp := datapoint.Datapoint{
+		Metric:     strings.TrimSpace(val.metric),
+		MetricType: metricType,
+		Value:      val.value,
+		Timestamp:  now,
+	}
+	if dp.Metric == "" {
+		dp.Metric = joinWords(snakeCaseSlice(val.keys), ".")
+	}
+	dp.Dimensions = make(map[string]string)
+	for k, v := range val.arrayIndexDimension {
+		dp.Dimensions[k] = v
 	}
 	// Renaming auto created dimension 'memstats.BySize' that stores array index to 'class'
-	if metricPath == memstatsBySizeSizeMetricPath || metricPath == memstatsBySizeMallocsMetricPath || metricPath == memstatsBySizeFreesMetricPath {
+	if path == memstatsBySizeSizeMetricPath || path == memstatsBySizeMallocsMetricPath || path == memstatsBySizeFreesMetricPath {
 		dp.Dimensions["class"] = dp.Dimensions[memstatsBySizeDimensionPath]
 		delete(dp.Dimensions, memstatsBySizeDimensionPath)
 	}
-	dp.Timestamp = *now
-	return true, nil
+	return &dp
 }
 
 // Shutdown stops the metric sync

--- a/test-services/expvar/server.go
+++ b/test-services/expvar/server.go
@@ -8,15 +8,6 @@ import (
 )
 
 func init() {
-	expvar.Publish("queues", expvar.Func(func() interface{} {
-		return map[string]interface{}{
-			"count": 5,
-			"lengths": []int64{
-				4, 2, 1, 0, 5,
-			},
-		}
-	}))
-
 	expvar.Publish("memory", expvar.Func(func() interface{} {
 		return map[string]interface{}{
 			"Allocations": []map[string]int64{
@@ -30,8 +21,19 @@ func init() {
 }
 
 func main() {
-	var kafkaExJaegerTransactionOk = expvar.NewInt("kafka.ex-jaeger-transaction.ok")
-	kafkaExJaegerTransactionOk.Add(11)
+	expvar.Publish("queues", expvar.Func(func() interface{} {
+		return map[string]interface{}{
+			"count": 5,
+			"lengths": []int64{
+				4, 2, 1, 0, 5,
+			},
+		}
+	}))
+	expvar.NewInt("kafka.ex-jaeger-transaction.ok").Add(11)
+	expvar.NewInt("willplayad.in_flight").Set(0)
+	expvar.Publish("willplayad.response.noserv", expvar.Func(func() interface{} { return struct{}{} }))
+	expvar.NewInt("willplayad.response.serv").Set(0)
+	expvar.NewInt("willplayad.start").Set(0)
 
 	sock, err := net.Listen("tcp", "0.0.0.0:8080") //nolint: gosec
 	if err != nil {

--- a/tests/monitors/expvar/expvar_test.py
+++ b/tests/monitors/expvar/expvar_test.py
@@ -222,3 +222,35 @@ def test_expvar_2_one_or_more_character_regex_json_path():
             """,
             expected,
         )
+
+
+def test_expvar_empty_object_for_metric_value():
+    """
+    Given the JSON object below
+    {
+        "willplayad.in_flight": 0,
+        "willplayad.response.noserv": {},
+        "willplayad.response.serv": 0,
+        "willplayad.start": 0
+    }
+    """
+    expected = METADATA.default_metrics | {
+        "willplayad.in_flight",
+        # "willplayad.response.noserv",
+        "willplayad.response.serv",
+        "willplayad.start",
+    }
+    with run_expvar() as expvar_container_ip:
+        run_agent_verify(
+            f"""
+            monitors:
+            - type: expvar
+              host: {expvar_container_ip}
+              port: 8080
+              metrics:
+              - JSONPath: 'willplay*'
+                pathSeparator: /
+                type: gauge
+            """,
+            expected,
+        )


### PR DESCRIPTION
Fixed the following issues with the expvar monitor reported by a customer:
1. Using a JSONPath with willplayads.* results in a single metric with the names smushed together instead of separate metrics.
2. Having a map value be `{}` causes the monitor to crash.