### PR TITLE
Allow the agent to be cross-compiled with code gen

### DIFF
--- a/internal/monitors/zcodegen/codegen.go
+++ b/internal/monitors/zcodegen/codegen.go
@@ -5,5 +5,5 @@
 // module is generated.
 package codegen
 
-//go:generate go build -o monitorcodegen ../../../cmd/monitorcodegen
+//go:generate sh -c "GOOS=`go env GOHOSTOS` go build -o monitorcodegen ../../../cmd/monitorcodegen"
 //go:generate ./monitorcodegen


### PR DESCRIPTION
This makes sure the monitorcodegen binary is built for the host OS and not the
cross-compile target OS.