### PR TITLE
re-enable jaeger grpc tests on windows

### DIFF
--- a/pkg/monitors/jaegergrpc/monitor.go
+++ b/pkg/monitors/jaegergrpc/monitor.go
@@ -35,6 +35,7 @@ type TLSCreds struct {
 	KeyFile string `yaml:"keyFile"`
 }
 
+// Credentials returns a grpc credentials transport
 func (tls *TLSCreds) Credentials() (credentials.TransportCredentials, error) {
 	var creds credentials.TransportCredentials
 	var err error

--- a/pkg/monitors/jaegergrpc/monitor_test.go
+++ b/pkg/monitors/jaegergrpc/monitor_test.go
@@ -433,9 +433,6 @@ func TestMonitor_Configure(t *testing.T) {
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			if runtime.GOOS == "windows" {
-				return
-			}
 			var err error
 
 			// test monitor with test output
@@ -456,6 +453,7 @@ func TestMonitor_Configure(t *testing.T) {
 					address = m.ln.Addr().String()
 				}
 				m.listenerLock.Unlock()
+				runtime.Gosched()
 			}
 
 			// build the grpc client


### PR DESCRIPTION
The for loop in the jaeger-grpc monitor test was constantly running and starving the actual monitor's routine from acquiring the listener mutex.  Explicitly adding a runtime.Gosched() in the test's for loop helps prevent the starvation scenario from happening during tests.