### PR TITLE
Allow setting event endpoint separate from datapoints and traces

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -38,7 +38,8 @@ if not set.
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
 | `signalFxAccessToken` | no | string | The access token for the org that should receive the metrics emitted by the agent. |
-| `ingestUrl` | no | string | The URL of SignalFx ingest server.  Should be overridden if using the SignalFx Gateway.  If not set, this will be determined by the `signalFxRealm` option below.  If you want to send trace spans to a different location, set the `traceEndpointUrl` option. |
+| `ingestUrl` | no | string | The URL of SignalFx ingest server.  Should be overridden if using the SignalFx Gateway.  If not set, this will be determined by the `signalFxRealm` option below.  If you want to send trace spans to a different location, set the `traceEndpointUrl` option.  If you want to send events to a different location, set the `eventEndpointUrl` option. |
+| `eventEndpointUrl` | no | string | The full URL (including path) to the event ingest server.  If this is not set, all events will be sent to the same place as `ingestUrl` above. |
 | `traceEndpointUrl` | no | string | The full URL (including path) to the trace ingest server.  If this is not set, all trace spans will be sent to the same place as `ingestUrl` above. |
 | `apiUrl` | no | string | The SignalFx API base URL.  If not set, this will determined by the `signalFxRealm` option below. |
 | `signalFxRealm` | no | string | The SignalFx Realm that the organization you want to send to is a part of.  This defaults to the original realm (`us0`) but if you are setting up the agent for the first time, you quite likely need to change this. (**default:** `"us0"`) |
@@ -375,6 +376,7 @@ where applicable:
 ```yaml
   signalFxAccessToken: 
   ingestUrl: 
+  eventEndpointUrl: 
   traceEndpointUrl: 
   apiUrl: 
   signalFxRealm: "us0"

--- a/pkg/core/config/writer.go
+++ b/pkg/core/config/writer.go
@@ -104,6 +104,7 @@ type WriterConfig struct {
 	HostIDDims          map[string]string      `yaml:"-"`
 	IngestURL           string                 `yaml:"-"`
 	APIURL              string                 `yaml:"-"`
+	EventEndpointURL    string                 `yaml:"-"`
 	TraceEndpointURL    string                 `yaml:"-"`
 	SignalFxAccessToken string                 `yaml:"-"`
 	GlobalDimensions    map[string]string      `yaml:"-"`
@@ -136,6 +137,18 @@ func (wc *WriterConfig) ParsedAPIURL() *url.URL {
 		panic("apiUrl was supposed to be validated already")
 	}
 	return apiURL
+}
+
+// ParsedEventEndpointURL parses and returns the event endpoint server URL
+func (wc *WriterConfig) ParsedEventEndpointURL() *url.URL {
+	if wc.EventEndpointURL != "" {
+		eventEndpointURL, err := url.Parse(wc.EventEndpointURL)
+		if err != nil {
+			panic("eventEndpointUrl was supposed to be validated already")
+		}
+		return eventEndpointURL
+	}
+	return nil
 }
 
 // ParsedTraceEndpointURL parses and returns the trace endpoint server URL

--- a/pkg/core/writer/writer.go
+++ b/pkg/core/writer/writer.go
@@ -154,13 +154,17 @@ func New(conf *config.WriterConfig, dpChan chan []*datapoint.Datapoint, eventCha
 	}
 	sw.client.DatapointEndpoint = dpEndpointURL.String()
 
-	eventEndpointURL, err := conf.ParsedIngestURL().Parse("v2/event")
-	if err != nil {
-		log.WithFields(log.Fields{
-			"error":     err,
-			"ingestURL": conf.ParsedIngestURL().String(),
-		}).Error("Could not construct event ingest URL")
-		return nil, err
+	eventEndpointURL := conf.ParsedEventEndpointURL()
+	if eventEndpointURL == nil {
+		var err error
+		eventEndpointURL, err = conf.ParsedIngestURL().Parse("v2/event")
+		if err != nil {
+			log.WithFields(log.Fields{
+				"error":     err,
+				"ingestURL": conf.ParsedIngestURL().String(),
+			}).Error("Could not construct event ingest URL")
+			return nil, err
+		}
 	}
 	sw.client.EventEndpoint = eventEndpointURL.String()
 
@@ -216,6 +220,7 @@ func New(conf *config.WriterConfig, dpChan chan []*datapoint.Datapoint, eventCha
 	sw.spanWriter.Start(ctx)
 
 	log.Infof("Sending datapoints to %s", sw.client.DatapointEndpoint)
+	log.Infof("Sending events to %s", sw.client.EventEndpoint)
 	log.Infof("Sending trace spans to %s", sw.client.TraceEndpoint)
 
 	return sw, nil

--- a/pkg/core/writer/writer_test.go
+++ b/pkg/core/writer/writer_test.go
@@ -1,0 +1,39 @@
+package writer
+
+import (
+	"testing"
+	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/stretchr/testify/require"
+)
+
+var essentialWriterConfig = config.WriterConfig{
+	PropertiesHistorySize:               100,
+	PropertiesSendDelaySeconds:          1,
+	TraceExportFormat:                   "zipkin",
+	TraceHostCorrelationMetricsInterval: 1 * time.Second,
+	StaleServiceTimeout:                 1 * time.Second,
+	EventSendIntervalSeconds:            1,
+}
+
+func TestWriterSetup(t *testing.T) {
+	t.Run("Overrides event URL", func(t *testing.T) {
+		t.Parallel()
+		conf := essentialWriterConfig
+		conf.EventEndpointURL = "http://example.com/v2/event"
+		writer, err := New(&conf, nil, nil, nil, nil, nil)
+
+		require.Nil(t, err)
+		require.Equal(t, "http://example.com/v2/event", writer.client.EventEndpoint)
+	})
+
+	t.Run("Sets default event URL", func(t *testing.T) {
+		t.Parallel()
+		conf := essentialWriterConfig
+		conf.IngestURL = "http://example.com"
+		writer, err := New(&conf, nil, nil, nil, nil, nil)
+		require.Nil(t, err)
+		require.Equal(t, "http://example.com/v2/event", writer.client.EventEndpoint)
+	})
+}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -47881,7 +47881,15 @@
       },
       {
         "yamlName": "ingestUrl",
-        "doc": "The URL of SignalFx ingest server.  Should be overridden if using the SignalFx Gateway.  If not set, this will be determined by the `signalFxRealm` option below.  If you want to send trace spans to a different location, set the `traceEndpointUrl` option.",
+        "doc": "The URL of SignalFx ingest server.  Should be overridden if using the SignalFx Gateway.  If not set, this will be determined by the `signalFxRealm` option below.  If you want to send trace spans to a different location, set the `traceEndpointUrl` option.  If you want to send events to a different location, set the `eventEndpointUrl` option.",
+        "default": "",
+        "required": false,
+        "type": "string",
+        "elementKind": ""
+      },
+      {
+        "yamlName": "eventEndpointUrl",
+        "doc": "The full URL (including path) to the event ingest server.  If this is not set, all events will be sent to the same place as `ingestUrl` above.",
         "default": "",
         "required": false,
         "type": "string",


### PR DESCRIPTION
This might be useful for a setup in which both the agent and OpenTelemetry
Collector are used together.