### PR TITLE
Allow service name to be set via flag

### DIFF
--- a/cmd/agent/agentmain/main.go
+++ b/cmd/agent/agentmain/main.go
@@ -149,6 +149,8 @@ type flags struct {
 	service string
 	// serviceName is a string flag to control the name of the windows service (windows only) Default: signalfx-agent.
 	serviceName string
+	// serviceDisplayName is a string flag to control the display name of the windows service (windows only)
+	serviceDisplayName string
 	// logEvents is a bool flag for logging events to the Windows Application Event log.
 	// This flag is only intended to be used when the agent is launched as a Windows Service.
 	logEvents bool
@@ -171,6 +173,7 @@ func getFlags() *flags {
 	if runtime.GOOS == windowsOS {
 		set.StringVar(&flags.service, "service", "", "'start', 'stop', 'install' or 'uninstall' agent as a windows service.  You may specify an alternate config file path with the -config flag when installing the service.")
 		set.StringVar(&flags.serviceName, "serviceName", "signalfx-agent", "Name of the service to install.")
+		set.StringVar(&flags.serviceDisplayName, "serviceDisplayName", "SignalFx Smart Agent", "Display name of the service to install.")
 		set.BoolVar(&flags.logEvents, "logEvents", false, "copy log events from the agent to the Windows Application Event Log.  This is only used when the agent is deployed as a Windows service.  The agent will write to stdout under all other deployment scenarios.")
 	}
 

--- a/cmd/agent/agentmain/main.go
+++ b/cmd/agent/agentmain/main.go
@@ -147,6 +147,8 @@ type flags struct {
 	// service is a string flag used for starting, stopping, installing or
 	// uninstalling the agent as a windows service (windows only)
 	service string
+	// serviceName is a string flag to control the name of the windows service (windows only) Default: signalfx-agent.
+	serviceName string
 	// logEvents is a bool flag for logging events to the Windows Application Event log.
 	// This flag is only intended to be used when the agent is launched as a Windows Service.
 	logEvents bool
@@ -168,6 +170,7 @@ func getFlags() *flags {
 	// service is a windows only feature and should only be added to the flag set on windows
 	if runtime.GOOS == windowsOS {
 		set.StringVar(&flags.service, "service", "", "'start', 'stop', 'install' or 'uninstall' agent as a windows service.  You may specify an alternate config file path with the -config flag when installing the service.")
+		set.StringVar(&flags.serviceName, "serviceName", "signalfx-agent", "Name of the service to install.")
 		set.BoolVar(&flags.logEvents, "logEvents", false, "copy log events from the agent to the Windows Application Event Log.  This is only used when the agent is deployed as a Windows service.  The agent will write to stdout under all other deployment scenarios.")
 	}
 

--- a/cmd/agent/agentmain/windows.go
+++ b/cmd/agent/agentmain/windows.go
@@ -81,7 +81,7 @@ func runAgentPlatformSpecific(flags *flags, interruptCh chan os.Signal, exitCh c
 	initializeWMI()
 
 	config := &service.Config{
-		Name:        "signalfx-agent",
+		Name:        flags.serviceName,
 		DisplayName: "SignalFx Smart Agent",
 		Description: "Collects and publishes metric data to SignalFx",
 		Arguments:   []string{"-config", flags.configPath},

--- a/cmd/agent/agentmain/windows.go
+++ b/cmd/agent/agentmain/windows.go
@@ -82,7 +82,7 @@ func runAgentPlatformSpecific(flags *flags, interruptCh chan os.Signal, exitCh c
 
 	config := &service.Config{
 		Name:        flags.serviceName,
-		DisplayName: "SignalFx Smart Agent",
+		DisplayName: flags.serviceDisplayName,
 		Description: "Collects and publishes metric data to SignalFx",
 		Arguments:   []string{"-config", flags.configPath},
 	}


### PR DESCRIPTION
We would like to install a custom agent service alongside the official one and enable or disable them both independently. In order to do that we need to be able to control the service name it gets installed as. 