### PR TITLE
Remove default puppet ingest/api urls

### DIFF
--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -14,6 +14,7 @@ class accepts the following parameters:
     ```ruby
     $config = {
       signalFxAccessToken: "MY_TOKEN",
+      signalFxRealm: "us1",
       enableBuiltInFiltering: true,
       monitors: [
         {type: "collectd/cpu"},

--- a/deployments/puppet/data/default.yaml
+++ b/deployments/puppet/data/default.yaml
@@ -1,8 +1,5 @@
 ---
 signalfx_agent::config:
-  signalFxAccessToken: "MY_TOKEN"
-  ingestUrl: https://ingest.signalfx.com
-  apiUrl: https://api.signalfx.com
   hostname: "%{facts.fqdn}"
   intervalSeconds: 10
   logging:


### PR DESCRIPTION
Remove any references to default ingest/api urls.  The user should specify these without us providing any defaults.

Fixes #1133.