### PR TITLE
Update to kubernetes_workload property

### DIFF
--- a/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/dimensions.go
@@ -154,20 +154,28 @@ func (dh *DimensionHandler) handleAddPod(pod *v1.Pod) {
 		}
 	}
 
+	// Check if pod owner of type ReplicaSet is cached. Check owners reference on ReplicaSet to see if it was
+	// created by a Deployment. Sync properties accordingly
 	rsRef := k8sutil.FindOwnerWithKind(pod.OwnerReferences, "ReplicaSet")
 	if rsRef != nil {
 		if replicaSet := dh.replicaSetCache.Get(rsRef.UID); replicaSet != nil {
 			if deployRef := k8sutil.FindOwnerWithKind(replicaSet.OwnerReferences, "Deployment"); deployRef != nil {
 				dh.sendDimensionFunc(dimensionForPodDeployment(pod, deployRef.Name, deployRef.UID))
+			} else {
+				dh.sendDimensionFunc(dimensionForPodWorkload(pod, replicaSet.Name, "ReplicaSet"))
 			}
 		}
 	}
 
+	// Check if pod owner of type Job is cached. Check owners reference on Job to see if it was
+	// created by a CronJob. Sync properties accordingly
 	jobRef := k8sutil.FindOwnerWithKind(pod.OwnerReferences, "Job")
 	if jobRef != nil {
 		if job := dh.jobCache.Get(jobRef.UID); job != nil {
 			if cronJobRef := k8sutil.FindOwnerWithKind(job.OwnerReferences, "CronJob"); cronJobRef != nil {
 				dh.sendDimensionFunc(dimensionForPodCronJob(pod, cronJobRef.Name, cronJobRef.UID))
+			} else {
+				dh.sendDimensionFunc(dimensionForPodWorkload(pod, job.Name, "Job"))
 			}
 		}
 	}
@@ -178,7 +186,6 @@ func (dh *DimensionHandler) handleAddPod(pod *v1.Pod) {
 // and service UID properties to the pod.
 func (dh *DimensionHandler) handleAddService(service *v1.Service) {
 	dh.serviceCache.AddService(service)
-
 	for _, pod := range dh.podCache.GetForNamespace(service.Namespace) {
 		if k8sutil.SelectorMatchesPod(service.Spec.Selector, pod) {
 			dim := dimensionForPodServices(pod, []string{service.Name}, true)
@@ -208,20 +215,23 @@ func (dh *DimensionHandler) handleDeleteService(uid types.UID) error {
 	return nil
 }
 
-// handleAddReplicaSet adds a replicaset to the internal cache and
-// returns the datapoints and dim for the replicaset.
+// handleAddReplicaSet adds a replicaset to the internal cache
+// and emits dimensions related to replicaSets for pods. ReplicaSets should always be
+// created before Pods, but in case we receive the event out of order we can still
+// check pods in the namespace to sync their relevant properties.
+// A potential optimization would be to not check this, and assume we received events in order.
 func (dh *DimensionHandler) handleAddReplicaSet(rs *appsv1.ReplicaSet) {
 	dh.replicaSetCache.Add(rs)
-
 	deployRef := k8sutil.FindOwnerWithKind(rs.OwnerReferences, "Deployment")
-	if deployRef == nil {
-		return
-	}
 	for _, pod := range dh.podCache.GetForNamespace(rs.Namespace) {
 		if rsRef := k8sutil.FindOwnerWithUID(pod.OwnerReferences, rs.UID); rsRef == nil {
 			continue
 		}
-		dh.sendDimensionFunc(dimensionForPodDeployment(pod, deployRef.Name, deployRef.UID))
+		if deployRef == nil {
+			dh.sendDimensionFunc(dimensionForPodWorkload(pod, rs.Name, "ReplicaSet"))
+		} else {
+			dh.sendDimensionFunc(dimensionForPodDeployment(pod, deployRef.Name, deployRef.UID))
+		}
 	}
 }
 
@@ -231,15 +241,15 @@ func (dh *DimensionHandler) handleAddReplicaSet(rs *appsv1.ReplicaSet) {
 // Potential optimization would be to not check this and always assume they come in order.
 func (dh *DimensionHandler) handleAddJob(job *batchv1.Job) {
 	dh.jobCache.Add(job)
-
 	cronJobRef := k8sutil.FindOwnerWithKind(job.OwnerReferences, "CronJob")
-	if cronJobRef == nil {
-		return
-	}
 	for _, pod := range dh.podCache.GetForNamespace(job.Namespace) {
-		if cronJobRef := k8sutil.FindOwnerWithUID(pod.OwnerReferences, job.UID); cronJobRef == nil {
+		if jobRef := k8sutil.FindOwnerWithUID(pod.OwnerReferences, job.UID); jobRef == nil {
 			continue
 		}
-		dh.sendDimensionFunc(dimensionForPodCronJob(pod, cronJobRef.Name, cronJobRef.UID))
+		if cronJobRef == nil {
+			dh.sendDimensionFunc(dimensionForPodWorkload(pod, job.Name, "Job"))
+		} else {
+			dh.sendDimensionFunc(dimensionForPodCronJob(pod, cronJobRef.Name, cronJobRef.UID))
+		}
 	}
 }

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -1,6 +1,5 @@
 from functools import partial as p
 from pathlib import Path
-
 import pytest
 from kubernetes import client as k8s_client
 from tests.helpers.assertions import has_all_dim_props, has_datapoint, has_dim_prop, has_no_datapoint
@@ -233,36 +232,6 @@ def test_cronjobs(k8s_cluster):
 
 
 @pytest.mark.kubernetes
-def test_pods(k8s_cluster):
-    config = """
-    monitors:
-     - type: kubernetes-cluster
-    """
-    yamls = [TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml"]
-    with k8s_cluster.create_resources(yamls) as resources:
-
-        with k8s_cluster.run_agent(agent_yaml=config) as agent:
-            pods = k8s_client.CoreV1Api().list_namespaced_pod(
-                k8s_cluster.test_namespace, watch=False, label_selector="app=nginx"
-            )
-            for pod in pods.items:
-                assert wait_for(
-                    p(
-                        has_all_dim_props,
-                        agent.fake_services,
-                        dim_name="kubernetes_pod_uid",
-                        dim_value=pod.metadata.uid,
-                        props={
-                            "pod_creation_timestamp": pod.metadata.creation_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                            "deployment": resources[1].metadata.name,
-                            "kubernetes_workload_name": pod.metadata.owner_references[0].name,
-                            "kubernetes_workload": pod.metadata.owner_references[0].kind,
-                        },
-                    )
-                )
-
-
-@pytest.mark.kubernetes
 def test_deployments(k8s_cluster):
     config = """
     monitors:
@@ -287,6 +256,63 @@ def test_deployments(k8s_cluster):
                     },
                 )
             )
+
+
+@pytest.mark.kubernetes
+def test_deployment_workload_property(k8s_cluster):
+    config = """
+    monitors:
+     - type: kubernetes-cluster
+    """
+    yamls = [TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml"]
+    with k8s_cluster.create_resources(yamls) as resources:
+        with k8s_cluster.run_agent(agent_yaml=config) as agent:
+            pods = k8s_client.CoreV1Api().list_namespaced_pod(
+                k8s_cluster.test_namespace, watch=False, label_selector="app=nginx"
+            )
+            for pod in pods.items:
+                assert wait_for(
+                    p(
+                        has_all_dim_props,
+                        agent.fake_services,
+                        dim_name="kubernetes_pod_uid",
+                        dim_value=pod.metadata.uid,
+                        props={
+                            "pod_creation_timestamp": pod.metadata.creation_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "deployment": resources[1].metadata.name,
+                            "kubernetes_workload_name": resources[1].metadata.name,
+                            "kubernetes_workload": "Deployment",
+                        },
+                    )
+                )
+
+
+@pytest.mark.kubernetes
+def test_replicaset_workload_property(k8s_cluster):
+    config = """
+    monitors:
+     - type: kubernetes-cluster
+    """
+    yamls = [SCRIPT_DIR / "replicaSet.yaml"]
+    with k8s_cluster.create_resources(yamls) as resources:
+        with k8s_cluster.run_agent(agent_yaml=config) as agent:
+            pods = k8s_client.CoreV1Api().list_namespaced_pod(
+                k8s_cluster.test_namespace, watch=False, label_selector="app=nginx"
+            )
+            for pod in pods.items:
+                assert wait_for(
+                    p(
+                        has_all_dim_props,
+                        agent.fake_services,
+                        dim_name="kubernetes_pod_uid",
+                        dim_value=pod.metadata.uid,
+                        props={
+                            "pod_creation_timestamp": pod.metadata.creation_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "kubernetes_workload_name": resources[0].metadata.name,
+                            "kubernetes_workload": "ReplicaSet",
+                        },
+                    )
+                )
 
 
 CONTAINER_RESOURCE_METRICS = {

--- a/tests/monitors/kubernetes_cluster/replicaSet.yaml
+++ b/tests/monitors/kubernetes_cluster/replicaSet.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  # modify replicas according to your case
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9 


### PR DESCRIPTION
**Breaking changes from 4.x**:
Previously we synced the `kubernetes_workload` property to _always_ be the direct parent type. This change will set the `kubernetes_workload` to possibly be the super-parents type, as explained below:

- If a pod is created by a deployment, we should set the `kubernetes_workload` property to be `Deployment` instead of a `ReplicaSet`.
- If a pod is created by a ReplicaSet directly, and that ReplicaSet was *not* created by a Deployment, we should set `kubernetes_workload` to be `ReplicaSet`.

---

- Also, if a pod is created by a CronJob, we should set the `kubernetes_workload` property to be `CronJob` instead of `Job`.
- If a pod is created by a Job directly, and that Job was *not* created by a CronJob, we should set `kubernetes_workload` to be `Job`.








