### PR TITLE
Add support for sourcing envvar's from /etc/default/$name on sysv systems to support proxys

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,15 @@ Environment="HTTPS_PROXY=https://proxy.example.com:8081/"
 Then execute `systemctl daemon-reload` and `systemctl restart signalfx-agent.service`
 to restart the agent service with proxy support.
 
+### Sys-V based init.d systems: Debian * RHEL
+
+Create `/etc/default/signalfx-agent` with the following contents:
+
+```bash
+HTTP_PROXY="http://proxy.example.com:8080/"
+HTTPS_PROXY="https://proxy.example.com:8081/"
+```
+
 ## Diagnostics
 The agent serves diagnostic information on an HTTP server at the address
 configured by the `internalStatusHost` and `internalStatusPort` option.  As a

--- a/packaging/etc/init.d/signalfx-agent.debian
+++ b/packaging/etc/init.d/signalfx-agent.debian
@@ -25,6 +25,9 @@ name="signalfx-agent"
 pidfile="/var/run/$name.pid"
 logfile="/var/log/$name.log"
 
+# Read configuration variable file if it is present
+[ -r /etc/default/$name ] && . /etc/default/$name
+
 get_pid() {
     cat "$pidfile"
 }

--- a/packaging/etc/init.d/signalfx-agent.rhel
+++ b/packaging/etc/init.d/signalfx-agent.rhel
@@ -27,6 +27,9 @@ name="signalfx-agent"
 pidfile="/var/run/$name.pid"
 logfile="/var/log/$name.log"
 
+# Read configuration variable file if it is present
+[ -r /etc/default/$name ] && . /etc/default/$name
+
 get_pid() {
     cat "$pidfile"
 }


### PR DESCRIPTION
Address issues with configuring proxy envar's on systems running sysv init.d scripts.

- Check for /etc/default/$name and source if it exists (Fixes: #1138).
- Add example for setting up /etc/default/signalfx-agent for proxy support.
