### PR TITLE
Make net-io monitor default on Linux

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -37,7 +37,7 @@ This role sources the following variables:
         - type: collectd/cpufreq
         - type: filesystems
         - type: collectd/disk
-        - type: collectd/interface
+        - type: net-io
         - type: collectd/load
         - type: memory
         - type: collectd/vmem

--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -6,7 +6,7 @@ sfx_agent_config:
     - type: collectd/cpufreq
     - type: filesystems
     - type: collectd/disk
-    - type: collectd/interface
+    - type: net-io
     - type: collectd/load
     - type: memory
     - type: collectd/signalfx-metadata

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -52,7 +52,7 @@ node['signalfx_agent']['conf'] = {
     {type: "collectd/cpufreq"},
     {type: "filesystems"},
     {type: "collectd/disk"},
-    {type: "collectd/interface"},
+    {type: "net-io"},
     {type: "collectd/load"},
     {type: "memory"},
     {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},

--- a/deployments/chef/example_attrs.json
+++ b/deployments/chef/example_attrs.json
@@ -11,7 +11,7 @@
       {"type": "collectd/cpufreq"},
       {"type": "filesystems"},
       {"type": "collectd/disk"},
-      {"type": "collectd/interface"},
+      {"type": "net-io"},
       {"type": "collectd/load"},
       {"type": "memory"},
       {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},

--- a/deployments/docker/agent.yaml
+++ b/deployments/docker/agent.yaml
@@ -26,7 +26,7 @@ monitors:
   - type: filesystems
     hostFSPath: /hostfs
   - type: collectd/disk
-  - type: collectd/interface
+  - type: net-io
   - type: collectd/load
   - type: memory
   - type: collectd/vmem

--- a/deployments/ecs/agent.yaml
+++ b/deployments/ecs/agent.yaml
@@ -40,7 +40,7 @@ monitors:
   - type: filesystems
     hostFSPath: /hostfs
   - type: collectd/disk
-  - type: collectd/interface
+  - type: net-io
   - type: collectd/load
   - type: memory
   - type: collectd/signalfx-metadata

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -20,7 +20,7 @@ observers:
 monitors:
   - type: collectd/cpu
   - type: collectd/disk
-  - type: collectd/interface
+  - type: net-io
   - type: collectd/load
   - type: memory
   - type: collectd/protocols

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -34,7 +34,7 @@ data:
     - type: filesystems
       hostFSPath: /hostfs
     - type: collectd/disk
-    - type: collectd/interface
+    - type: net-io
     - type: collectd/load
     - type: memory
     - type: collectd/protocols

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -58,7 +58,7 @@ data:
     - type: filesystems
       hostFSPath: {{ .Values.hostFSPath }}
     - type: collectd/disk
-    - type: collectd/interface
+    - type: net-io
     - type: collectd/load
     - type: memory
     - type: collectd/protocols

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -21,7 +21,7 @@ class accepts the following parameters:
         {type: "collectd/cpufreq"},
         {type: "filesystems"},
         {type: "collectd/disk"},
-        {type: "collectd/interface"},
+        {type: "net-io"},
         {type: "collectd/load"},
         {type: "memory"},
         {type: "collectd/protocols"},

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -48,7 +48,7 @@ signalfx-agent:
       - type: collectd/cpufreq
       - type: filesystems
       - type: collectd/disk
-      - type: collectd/interface
+      - type: net-io
       - type: collectd/load
       - type: memory
       - type: collectd/vmem

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -10,7 +10,7 @@ signalfx-agent:
       - type: collectd/cpufreq
       - type: filesystems
       - type: collectd/disk
-      - type: collectd/interface
+      - type: net-io
       - type: collectd/load
       - type: memory
       - type: collectd/signalfx-metadata

--- a/docs/monitors/collectd-interface.md
+++ b/docs/monitors/collectd-interface.md
@@ -14,6 +14,12 @@ Collectd stats about network interfaces on the
 system by using the [collectd interface
 plugin](https://collectd.org/wiki/index.php/Plugin:Interface).
 
+**This monitor is deprecated in favor of the `net-io` monitor. Please
+switch to that monitor as this monitor will be removed in a future release
+of the agent.**  Note that the `net-io` monitor uses the `interface`
+dimension to identify the network card instead of the `plugin_instance`
+dimension, but otherwise the metrics are the same.
+
 
 ## Configuration
 

--- a/docs/monitors/net-io.md
+++ b/docs/monitors/net-io.md
@@ -51,13 +51,15 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
+ - `if_dropped.rx` (*cumulative*)<br>    Count of received packets dropped by the interface
+ - `if_dropped.tx` (*cumulative*)<br>    Count of transmitted packets dropped by the interface
  - ***`if_errors.rx`*** (*cumulative*)<br>    Count of receive errors on the interface
  - ***`if_errors.tx`*** (*cumulative*)<br>    Count of transmit errors on the interface
  - ***`if_octets.rx`*** (*cumulative*)<br>    Count of bytes (octets) received on the interface
  - ***`if_octets.tx`*** (*cumulative*)<br>    Count of bytes (octets) transmitted by the interface
  - `if_packets.rx` (*cumulative*)<br>    Count of packets received on the interface
  - `if_packets.tx` (*cumulative*)<br>    Count of packets transmitted by the interface
- - ***`network.total`*** (*cumulative*)<br>    Total amount of inbound and outbound network traffic on this host, in bytes.  This metric reports with plugin dimension set to "signalfx-metadata".
+ - ***`network.total`*** (*cumulative*)<br>    Total amount of inbound and outbound network traffic on this host, in bytes.
 
 ### Non-default metrics (version 4.7.0+)
 
@@ -85,6 +87,15 @@ that whitelist, then you need to add an item to the top-level
 `metricsToInclude` config option to override that whitelist (see [Inclusion
 filtering](../legacy-filtering.md#inclusion-filtering).  Or you can just
 copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
+
+## Dimensions
+
+The following dimensions may occur on metrics emitted by this monitor.  Some
+dimensions may be specific to certain metrics.
+
+| Name | Description |
+| ---  | ---         |
+| `interface` | The name of the network interface (e.g. `eth0`) |
 
 
 

--- a/packaging/etc/agent.yaml
+++ b/packaging/etc/agent.yaml
@@ -23,7 +23,7 @@ monitors:
   - type: collectd/cpufreq
   - type: filesystems
   - type: collectd/disk
-  - type: collectd/interface
+  - type: net-io
   - type: collectd/load
   - type: memory
   - type: collectd/signalfx-metadata

--- a/pkg/monitors/collectd/netinterface/metadata.yaml
+++ b/pkg/monitors/collectd/netinterface/metadata.yaml
@@ -4,6 +4,12 @@ monitors:
     Collectd stats about network interfaces on the
     system by using the [collectd interface
     plugin](https://collectd.org/wiki/index.php/Plugin:Interface).
+
+    **This monitor is deprecated in favor of the `net-io` monitor. Please
+    switch to that monitor as this monitor will be removed in a future release
+    of the agent.**  Note that the `net-io` monitor uses the `interface`
+    dimension to identify the network card instead of the `plugin_instance`
+    dimension, but otherwise the metrics are the same.
   metrics:
     if_errors.rx:
       description: Count of receive errors on the interface

--- a/pkg/monitors/netio/genmetadata.go
+++ b/pkg/monitors/netio/genmetadata.go
@@ -12,6 +12,8 @@ const monitorType = "net-io"
 var groupSet = map[string]bool{}
 
 const (
+	ifDroppedRx  = "if_dropped.rx"
+	ifDroppedTx  = "if_dropped.tx"
 	ifErrorsRx   = "if_errors.rx"
 	ifErrorsTx   = "if_errors.tx"
 	ifOctetsRx   = "if_octets.rx"
@@ -22,6 +24,8 @@ const (
 )
 
 var metricSet = map[string]monitors.MetricInfo{
+	ifDroppedRx:  {Type: datapoint.Counter},
+	ifDroppedTx:  {Type: datapoint.Counter},
 	ifErrorsRx:   {Type: datapoint.Counter},
 	ifErrorsTx:   {Type: datapoint.Counter},
 	ifOctetsRx:   {Type: datapoint.Counter},

--- a/pkg/monitors/netio/metadata.yaml
+++ b/pkg/monitors/netio/metadata.yaml
@@ -1,5 +1,7 @@
 monitors:
 - dimensions:
+    interface:
+      description: The name of the network interface (e.g. `eth0`)
   doc: |
     This monitor reports I/O metrics about network interfaces.
 
@@ -37,9 +39,16 @@ monitors:
       description: Count of packets transmitted by the interface
       default: false
       type: cumulative
+    if_dropped.rx:
+      description: Count of received packets dropped by the interface
+      default: false
+      type: cumulative
+    if_dropped.tx:
+      description: Count of transmitted packets dropped by the interface
+      default: false
+      type: cumulative
     network.total:
-      description: Total amount of inbound and outbound network traffic on this host,
-        in bytes.  This metric reports with plugin dimension set to "signalfx-metadata".
+      description: Total amount of inbound and outbound network traffic on this host, in bytes.
       default: true
       type: cumulative
   monitorType: net-io

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -8054,7 +8054,7 @@
       "monitorType": "collectd/interface",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Collectd stats about network interfaces on the\nsystem by using the [collectd interface\nplugin](https://collectd.org/wiki/index.php/Plugin:Interface).\n",
+      "doc": "Collectd stats about network interfaces on the\nsystem by using the [collectd interface\nplugin](https://collectd.org/wiki/index.php/Plugin:Interface).\n\n**This monitor is deprecated in favor of the `net-io` monitor. Please\nswitch to that monitor as this monitor will be removed in a future release\nof the agent.**  Note that the `net-io` monitor uses the `interface`\ndimension to identify the network card instead of the `plugin_instance`\ndimension, but otherwise the metrics are the same.\n",
       "groups": {
         "": {
           "description": "",
@@ -35445,12 +35445,18 @@
     {
       "monitorType": "net-io",
       "sendAll": false,
-      "dimensions": null,
+      "dimensions": {
+        "interface": {
+          "description": "The name of the network interface (e.g. `eth0`)"
+        }
+      },
       "doc": "This monitor reports I/O metrics about network interfaces.\n\nOn Linux hosts, this monitor relies on the `/proc` filesystem.\nIf the underlying host's `/proc` file system is mounted somewhere other than\n/proc please specify the path using the top level configuration `procPath`.\n\n```yaml\nprocPath: /proc\nmonitors:\n - type: net-io\n```\n",
       "groups": {
         "": {
           "description": "",
           "metrics": [
+            "if_dropped.rx",
+            "if_dropped.tx",
             "if_errors.rx",
             "if_errors.tx",
             "if_octets.rx",
@@ -35462,6 +35468,18 @@
         }
       },
       "metrics": {
+        "if_dropped.rx": {
+          "type": "cumulative",
+          "description": "Count of received packets dropped by the interface",
+          "group": null,
+          "default": false
+        },
+        "if_dropped.tx": {
+          "type": "cumulative",
+          "description": "Count of transmitted packets dropped by the interface",
+          "group": null,
+          "default": false
+        },
         "if_errors.rx": {
           "type": "cumulative",
           "description": "Count of receive errors on the interface",
@@ -35500,7 +35518,7 @@
         },
         "network.total": {
           "type": "cumulative",
-          "description": "Total amount of inbound and outbound network traffic on this host, in bytes.  This metric reports with plugin dimension set to \"signalfx-metadata\".",
+          "description": "Total amount of inbound and outbound network traffic on this host, in bytes.",
           "group": null,
           "default": true
         }


### PR DESCRIPTION
- Added dropped packet metrics to match collectd/interface
- Replaced collectd/interface with net-io monitor in distributed configs
- Removed plugin and plugin_instance dimensions from datapoints

Breaking Changes:
 - plugin and plugin_dimension dimensions are gone and only the interface dimension remains