### PR TITLE
Make vmem monitor default on Linux

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -40,7 +40,7 @@ This role sources the following variables:
         - type: collectd/interface
         - type: collectd/load
         - type: memory
-        - type: collectd/vmem
+        - type: vmem
         - type: collectd/signalfx-metadata
           omitProcessInfo: true
         - type: host-metadata

--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -13,4 +13,4 @@ sfx_agent_config:
       omitProcessInfo: true
     - type: host-metadata
     - type: processlist
-    - type: collectd/vmem
+    - type: vmem

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -56,7 +56,7 @@ node['signalfx_agent']['conf'] = {
     {type: "collectd/load"},
     {type: "memory"},
     {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},
-    {type: "collectd/vmem"}
+    {type: "vmem"}
     {type: "host-metadata"},
     {type: "processlist"},
   ],

--- a/deployments/chef/example_attrs.json
+++ b/deployments/chef/example_attrs.json
@@ -15,7 +15,7 @@
       {"type": "collectd/load"},
       {"type": "memory"},
       {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},
-      {"type": "collectd/vmem"},
+      {"type": "vmem"},
       {"type": "host-metadata"}
       {"type": "processlist"}
     ],

--- a/deployments/docker/agent.yaml
+++ b/deployments/docker/agent.yaml
@@ -29,7 +29,7 @@ monitors:
   - type: collectd/interface
   - type: collectd/load
   - type: memory
-  - type: collectd/vmem
+  - type: vmem
   - type: collectd/signalfx-metadata
     omitProcessInfo: true
   - type: host-metadata

--- a/deployments/ecs/agent.yaml
+++ b/deployments/ecs/agent.yaml
@@ -47,7 +47,7 @@ monitors:
     omitProcessInfo: true
   - type: host-metadata
   - type: processlist
-  - type: collectd/vmem
+  - type: vmem
 
   - type: docker-container-stats
     labelsToDimensions:

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -26,7 +26,7 @@ monitors:
   - type: collectd/protocols
   - type: collectd/signalfx-metadata
     omitProcessInfo: true
-  - type: collectd/vmem
+  - type: vmem
 
   - type: ecs-metadata
     excludedImages:

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -43,7 +43,7 @@ data:
     - type: host-metadata
     - type: processlist
     - type: collectd/uptime
-    - type: collectd/vmem
+    - type: vmem
 
     - type: kubelet-stats
       kubeletAPI:

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -67,7 +67,7 @@ data:
     - type: host-metadata
     - type: processlist
     - type: collectd/uptime
-    - type: collectd/vmem
+    - type: vmem
 
     - type: kubelet-stats
       {{- if .Values.containerStatsIntervalSeconds }}

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -29,7 +29,7 @@ class accepts the following parameters:
         {type: "host-metadata"},
         {type: "processlist"},
         {type: "collectd/uptime"},
-        {type: "collectd/vmem"}
+        {type: "vmem"}
       ]
     }
     ```

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -51,7 +51,7 @@ signalfx-agent:
       - type: collectd/interface
       - type: collectd/load
       - type: memory
-      - type: collectd/vmem
+      - type: vmem
       - type: collectd/signalfx-metadata
         omitProcessInfo: true
       - type: host-metadata

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -15,5 +15,5 @@ signalfx-agent:
       - type: memory
       - type: collectd/signalfx-metadata
         omitProcessInfo: true
-      - type: collectd/vmem
+      - type: vmem
       - type: processlist

--- a/docs/monitors/collectd-vmem.md
+++ b/docs/monitors/collectd-vmem.md
@@ -15,6 +15,10 @@ subsystem of the kernel using the [collectd vmem
 plugin](https://collectd.org/wiki/index.php/Plugin:vmem).  There is no
 configuration available for this plugin.
 
+**This monitor is deprecated in favor of the `vmem` monitor.  The metrics
+should be fully compatible with this monitor.** This monitor will be
+removed in a future agent release.
+
 
 ## Configuration
 

--- a/docs/monitors/vmem.md
+++ b/docs/monitors/vmem.md
@@ -10,8 +10,8 @@ Monitor Type: `vmem` ([Source](https://github.com/signalfx/signalfx-agent/tree/m
 
 ## Overview
 
-Collects information about the virtual memory
-subsystem of the kernel.
+Collects information specific to the virtual memory subsystem of the
+kernel.  For general memory statistics, see the [memory monitor](./memory.md).
 
 On Linux hosts, this monitor relies on the `/proc` filesystem.
 If the underlying host's `/proc` file system is mounted somewhere other than

--- a/packaging/etc/agent.yaml
+++ b/packaging/etc/agent.yaml
@@ -28,6 +28,6 @@ monitors:
   - type: memory
   - type: collectd/signalfx-metadata
     omitProcessInfo: true
-  - type: collectd/vmem
+  - type: vmem
 
 enableBuiltInFiltering: true

--- a/pkg/monitors/collectd/vmem/metadata.yaml
+++ b/pkg/monitors/collectd/vmem/metadata.yaml
@@ -5,6 +5,10 @@ monitors:
     subsystem of the kernel using the [collectd vmem
     plugin](https://collectd.org/wiki/index.php/Plugin:vmem).  There is no
     configuration available for this plugin.
+
+    **This monitor is deprecated in favor of the `vmem` monitor.  The metrics
+    should be fully compatible with this monitor.** This monitor will be
+    removed in a future agent release.
   metrics:
     vmpage_faults.majflt:
       description: Number of major page faults on the system

--- a/pkg/monitors/memory/memory_darwin.go
+++ b/pkg/monitors/memory/memory_darwin.go
@@ -1,0 +1,17 @@
+package memory
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+	"github.com/signalfx/golib/v3/datapoint"
+)
+
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+	return []*datapoint.Datapoint{
+		datapoint.New("memory.active", dimensions, datapoint.NewIntValue(int64(memInfo.Active)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.inactive", dimensions, datapoint.NewIntValue(int64(memInfo.Inactive)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.wired", dimensions, datapoint.NewIntValue(int64(memInfo.Wired)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
+	}
+}

--- a/pkg/monitors/memory/memory_linux.go
+++ b/pkg/monitors/memory/memory_linux.go
@@ -1,0 +1,19 @@
+package memory
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+	"github.com/signalfx/golib/v3/datapoint"
+)
+
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+	return []*datapoint.Datapoint{
+		datapoint.New("memory.buffered", dimensions, datapoint.NewIntValue(int64(memInfo.Buffers)), datapoint.Gauge, time.Time{}),
+		// for some reason gopsutil decided to add slab_reclaimable to cached which collectd does not
+		datapoint.New("memory.cached", dimensions, datapoint.NewIntValue(int64(memInfo.Cached-memInfo.SReclaimable)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.slab_recl", dimensions, datapoint.NewIntValue(int64(memInfo.SReclaimable)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.slab_unrecl", dimensions, datapoint.NewIntValue(int64(memInfo.Slab-memInfo.SReclaimable)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
+	}
+}

--- a/pkg/monitors/memory/memory_windows.go
+++ b/pkg/monitors/memory/memory_windows.go
@@ -1,0 +1,14 @@
+package memory
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/mem"
+	"github.com/signalfx/golib/v3/datapoint"
+)
+
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+	return []*datapoint.Datapoint{
+		datapoint.New("memory.available", dimensions, datapoint.NewIntValue(int64(memInfo.Available)), datapoint.Gauge, time.Time{}),
+	}
+}

--- a/pkg/monitors/vmem/metadata.yaml
+++ b/pkg/monitors/vmem/metadata.yaml
@@ -1,8 +1,8 @@
 monitors:
 - dimensions:
   doc: |
-    Collects information about the virtual memory
-    subsystem of the kernel.
+    Collects information specific to the virtual memory subsystem of the
+    kernel.  For general memory statistics, see the [memory monitor](./memory.md).
 
     On Linux hosts, this monitor relies on the `/proc` filesystem.
     If the underlying host's `/proc` file system is mounted somewhere other than

--- a/pkg/monitors/vmem/vmem_linux.go
+++ b/pkg/monitors/vmem/vmem_linux.go
@@ -17,18 +17,18 @@ import (
 )
 
 var cumulativeCounters = map[string]string{
-	"pgpgin":     "vmpage_io.memory.in",
-	"pgpgout":    "vmpage_io.memory.out",
-	"pswpin":     "vmpage_io.swap.in",
-	"pswpout":    "vmpage_io.swap.out",
-	"pgmajfault": "vmpage_faults.majflt",
-	"pgfault":    "vmpage_faults.minflt",
+	"pgpgin":     vmpageIoMemoryIn,
+	"pgpgout":    vmpageIoMemoryOut,
+	"pswpin":     vmpageIoSwapIn,
+	"pswpout":    vmpageIoSwapOut,
+	"pgmajfault": vmpageFaultsMajflt,
+	"pgfault":    vmpageFaultsMinflt,
 }
 
 var gauges = map[string]string{
-	"nr_free_pages": "vmpage_number.free_pages",
-	"nr_mapped":     "vmpage_number.mapped",
-	"nr_shmem":      "vmpage_number.shmem_pmdmapped",
+	"nr_free_pages": vmpageNumberFreePages,
+	"nr_mapped":     vmpageNumberMapped,
+	"nr_shmem":      vmpageNumberShmemPmdmapped,
 }
 
 func (m *Monitor) parseFileForDatapoints(contents []byte) []*datapoint.Datapoint {
@@ -54,7 +54,7 @@ func (m *Monitor) parseFileForDatapoints(contents []byte) []*datapoint.Datapoint
 					m.logger.Errorf("failed to parse value for metric %s", metricName)
 					continue
 				}
-				dps = append(dps, datapoint.New(metricName, map[string]string{"plugin": monitorType}, datapoint.NewIntValue(val), metricType, time.Time{}))
+				dps = append(dps, datapoint.New(metricName, nil, datapoint.NewIntValue(val), metricType, time.Time{}))
 			}
 		}
 	}
@@ -65,7 +65,6 @@ func (m *Monitor) parseFileForDatapoints(contents []byte) []*datapoint.Datapoint
 // Configure and run the monitor on linux
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.logger = logrus.WithField("monitorType", monitorType)
-	m.logger.Warningf("'%s' monitor is in beta on this platform.  For production environments please use 'collectd/%s'.", monitorType, monitorType)
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -16823,7 +16823,7 @@
       "monitorType": "collectd/vmem",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Collects information about the virtual memory\nsubsystem of the kernel using the [collectd vmem\nplugin](https://collectd.org/wiki/index.php/Plugin:vmem).  There is no\nconfiguration available for this plugin.\n",
+      "doc": "Collects information about the virtual memory\nsubsystem of the kernel using the [collectd vmem\nplugin](https://collectd.org/wiki/index.php/Plugin:vmem).  There is no\nconfiguration available for this plugin.\n\n**This monitor is deprecated in favor of the `vmem` monitor.  The metrics\nshould be fully compatible with this monitor.** This monitor will be\nremoved in a future agent release.\n",
       "groups": {
         "": {
           "description": "",
@@ -45200,7 +45200,7 @@
       "monitorType": "vmem",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Collects information about the virtual memory\nsubsystem of the kernel.\n\nOn Linux hosts, this monitor relies on the `/proc` filesystem.\nIf the underlying host's `/proc` file system is mounted somewhere other than\n/proc please specify the path using the top level configuration `procPath`.\n\n```yaml\nprocPath: /proc\nmonitors:\n - type: vmem\n```\n",
+      "doc": "Collects information specific to the virtual memory subsystem of the\nkernel.  For general memory statistics, see the [memory monitor](./memory.md).\n\nOn Linux hosts, this monitor relies on the `/proc` filesystem.\nIf the underlying host's `/proc` file system is mounted somewhere other than\n/proc please specify the path using the top level configuration `procPath`.\n\n```yaml\nprocPath: /proc\nmonitors:\n - type: vmem\n```\n",
       "groups": {
         "": {
           "description": "",

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, TypeVar, cast
 
 import docker
 import netifaces as ni
+import requests
 import yaml
 from tests.helpers.assertions import regex_search_matches_output
 from tests.paths import SELFDESCRIBE_JSON, TEST_SERVICES_DIR
@@ -424,6 +425,11 @@ def retry_on_ebadf(func: T) -> T:
         while True:
             try:
                 return func(*args, **kwargs)
+            except requests.exceptions.ConnectionError as e:
+                if "bad file descriptor" in str(e).lower():
+                    logging.error("Retrying ConnectionError EBADF")
+                    continue
+                raise
             except OSError as e:
                 if e.errno == 9:
                     tries += 1


### PR DESCRIPTION
 - Remove beta warning for Linux
 - Remove plugin dimension
 - Clean up memory monitor