### PR TITLE
filesystems Monitor: Remove plugin and plugin_instance dimension

### DIFF
--- a/docs/monitors/filesystems.md
+++ b/docs/monitors/filesystems.md
@@ -56,17 +56,17 @@ Metrics that are categorized as
 
  - ***`df_complex.free`*** (*gauge*)<br>    Free disk space in bytes
  - ***`df_complex.used`*** (*gauge*)<br>    Used disk space in bytes
- - ***`disk.summary_utilization`*** (*gauge*)<br>    Percent of disk space utilized on all volumes on this host. This metric reports with plugin dimension set to "signalfx-metadata".
- - ***`disk.utilization`*** (*gauge*)<br>    Percent of disk used on this volume. This metric reports with plugin dimension set to "signalfx-metadata".
+ - ***`disk.summary_utilization`*** (*gauge*)<br>    Percent of disk space utilized on all volumes on this host.
+ - ***`disk.utilization`*** (*gauge*)<br>    Percent of disk used on this volume.
 
 #### Group inodes
 All of the following metrics are part of the `inodes` metric group. All of
 the non-default metrics below can be turned on by adding `inodes` to the
 monitor config option `extraGroups`:
- - `df_inodes.free` (*gauge*)<br>    (Linux Only) Number of inodes that are free.  This is is only reported if the configuration option `inodes` is set to `true`.
- - `df_inodes.used` (*gauge*)<br>    (Linux Only) Number of inodes that are used.  This is only reported if the configuration option `inodes` is set to `true`.
- - `percent_inodes.free` (*gauge*)<br>    (Linux Only) Free inodes on the file system, expressed as a percentage.  This is only reported if the configuration option `inodes` is set to `true`.
- - `percent_inodes.used` (*gauge*)<br>    (Linux Only) Used inodes on the file system, expressed as a percentage.  This is only reported if the configuration option `inodes` is set to `true`.
+ - `df_inodes.free` (*gauge*)<br>    (Linux Only) Number of inodes that are free.
+ - `df_inodes.used` (*gauge*)<br>    (Linux Only) Number of inodes that are used.
+ - `percent_inodes.free` (*gauge*)<br>    (Linux Only) Free inodes on the file system, expressed as a percentage.
+ - `percent_inodes.used` (*gauge*)<br>    (Linux Only) Used inodes on the file system, expressed as a percentage.
 
 #### Group percentage
 All of the following metrics are part of the `percentage` metric group. All of

--- a/pkg/monitors/filesystems/metadata.yaml
+++ b/pkg/monitors/filesystems/metadata.yaml
@@ -23,25 +23,21 @@ monitors:
       default: true
       type: gauge
     df_inodes.free:
-      description: (Linux Only) Number of inodes that are free.  This is is only reported
-        if the configuration option `inodes` is set to `true`.
+      description: (Linux Only) Number of inodes that are free.
       default: false
       type: gauge
       group: inodes
     df_inodes.used:
-      description: (Linux Only) Number of inodes that are used.  This is only reported
-        if the configuration option `inodes` is set to `true`.
+      description: (Linux Only) Number of inodes that are used.
       default: false
       type: gauge
       group: inodes
     disk.summary_utilization:
-      description: Percent of disk space utilized on all volumes on this host. This
-        metric reports with plugin dimension set to "signalfx-metadata".
+      description: Percent of disk space utilized on all volumes on this host.
       default: true
       type: gauge
     disk.utilization:
-      description: Percent of disk used on this volume. This metric reports with plugin
-        dimension set to "signalfx-metadata".
+      description: Percent of disk used on this volume.
       default: true
       type: gauge
     percent_bytes.free:
@@ -55,14 +51,12 @@ monitors:
       type: gauge
       group: percentage
     percent_inodes.free:
-      description: (Linux Only) Free inodes on the file system, expressed as a percentage.  This
-        is only reported if the configuration option `inodes` is set to `true`.
+      description: (Linux Only) Free inodes on the file system, expressed as a percentage.
       default: false
       type: gauge
       group: inodes
     percent_inodes.used:
-      description: (Linux Only) Used inodes on the file system, expressed as a percentage.  This
-        is only reported if the configuration option `inodes` is set to `true`.
+      description: (Linux Only) Used inodes on the file system, expressed as a percentage.
       default: false
       type: gauge
       group: inodes

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -23125,25 +23125,25 @@
         },
         "df_inodes.free": {
           "type": "gauge",
-          "description": "(Linux Only) Number of inodes that are free.  This is is only reported if the configuration option `inodes` is set to `true`.",
+          "description": "(Linux Only) Number of inodes that are free.",
           "group": "inodes",
           "default": false
         },
         "df_inodes.used": {
           "type": "gauge",
-          "description": "(Linux Only) Number of inodes that are used.  This is only reported if the configuration option `inodes` is set to `true`.",
+          "description": "(Linux Only) Number of inodes that are used.",
           "group": "inodes",
           "default": false
         },
         "disk.summary_utilization": {
           "type": "gauge",
-          "description": "Percent of disk space utilized on all volumes on this host. This metric reports with plugin dimension set to \"signalfx-metadata\".",
+          "description": "Percent of disk space utilized on all volumes on this host.",
           "group": null,
           "default": true
         },
         "disk.utilization": {
           "type": "gauge",
-          "description": "Percent of disk used on this volume. This metric reports with plugin dimension set to \"signalfx-metadata\".",
+          "description": "Percent of disk used on this volume.",
           "group": null,
           "default": true
         },
@@ -23161,13 +23161,13 @@
         },
         "percent_inodes.free": {
           "type": "gauge",
-          "description": "(Linux Only) Free inodes on the file system, expressed as a percentage.  This is only reported if the configuration option `inodes` is set to `true`.",
+          "description": "(Linux Only) Free inodes on the file system, expressed as a percentage.",
           "group": "inodes",
           "default": false
         },
         "percent_inodes.used": {
           "type": "gauge",
-          "description": "(Linux Only) Used inodes on the file system, expressed as a percentage.  This is only reported if the configuration option `inodes` is set to `true`.",
+          "description": "(Linux Only) Used inodes on the file system, expressed as a percentage.",
           "group": "inodes",
           "default": false
         }

--- a/tests/deployments/helm/helm_test.py
+++ b/tests/deployments/helm/helm_test.py
@@ -240,9 +240,7 @@ def test_helm(k8s_cluster, helm_version):
                             ),
                             timeout_seconds=60,
                         )
-                        assert wait_for(
-                            p(has_datapoint, backend, dimensions={"plugin": "signalfx-metadata"}), timeout_seconds=60
-                        )
+                        assert wait_for(p(has_datapoint, backend, metric_name="memory.utilization"), timeout_seconds=60)
                     finally:
                         for pod in get_pods_by_labels("app=signalfx-agent", namespace=k8s_cluster.test_namespace):
                             print("pod/%s:" % pod.metadata.name)

--- a/tests/packaging/package_test.py
+++ b/tests/packaging/package_test.py
@@ -4,15 +4,15 @@ import re
 from functools import partial as p
 
 import pytest
-
-from tests.helpers.assertions import has_datapoint_with_dim
+from tests.helpers.assertions import has_datapoint
 from tests.helpers.util import (
+    copy_file_into_container,
+    get_container_file_content,
+    path_exists_in_container,
     print_lines,
     wait_for,
-    copy_file_into_container,
-    path_exists_in_container,
-    get_container_file_content,
 )
+
 from .common import (
     AGENT_YAML_PATH,
     INIT_SYSTEMD,
@@ -145,7 +145,7 @@ def _test_service_start(container, init_system, backend):
     backend.reset_datapoints()
     assert code == 0, "Agent could not be started"
     assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_START_TIMEOUT)
-    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
+    assert wait_for(p(has_datapoint, backend, metric_name="disk.utilization")), "Datapoints didn't come through"
 
 
 def _test_service_restart(container, init_system, backend):
@@ -157,7 +157,7 @@ def _test_service_restart(container, init_system, backend):
     assert code == 0, "Agent could not be restarted"
     assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_RESTART_TIMEOUT)
     assert agent_has_new_pid(container, old_pid), "Agent pid the same after service restart"
-    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
+    assert wait_for(p(has_datapoint, backend, metric_name="disk.utilization")), "Datapoints didn't come through"
 
 
 def _test_service_stop(container, init_system, backend):
@@ -180,7 +180,7 @@ def _test_system_restart(container, init_system, backend):
     container.start()
     assert wait_for(p(is_agent_running_as_non_root, container), timeout_seconds=INIT_RESTART_TIMEOUT)
     _test_service_status(container, init_system, "active")
-    assert wait_for(p(has_datapoint_with_dim, backend, "plugin", "signalfx-metadata")), "Datapoints didn't come through"
+    assert wait_for(p(has_datapoint, backend, metric_name="disk.utilization")), "Datapoints didn't come through"
 
 
 def _test_service_status_redirect(container):


### PR DESCRIPTION
 - These were legacy holdovers from collectd that are unnecessary now

Dependent on https://github.com/signalfx/content-discovery-staging/pull/139/files