### PR TITLE
Make cpu monitor default instead of collectd/cpu

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -33,8 +33,7 @@ This role sources the following variables:
     sfx_agent_config:
       signalFxAccessToken: MY-TOKEN  # Required
       monitors:
-        - type: collectd/cpu
-        - type: collectd/cpufreq
+        - type: cpu
         - type: filesystems
         - type: disk
         - type: net-io

--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -2,8 +2,7 @@ sfx_agent_config:
   signalFxAccessToken: MyToken
   enableBuiltInFiltering: true
   monitors:
-    - type: collectd/cpu
-    - type: collectd/cpufreq
+    - type: cpu
     - type: filesystems
     - type: disk
     - type: net-io

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -48,8 +48,7 @@ host-level components:
 node['signalfx_agent']['conf'] = {
   signalFxAccessToken: "MY_TOKEN",
   monitors: [
-    {type: "collectd/cpu"},
-    {type: "collectd/cpufreq"},
+    {type: "cpu"},
     {type: "filesystems"},
     {type: "disk"},
     {type: "net-io"},

--- a/deployments/chef/example_attrs.json
+++ b/deployments/chef/example_attrs.json
@@ -7,8 +7,7 @@
       {"type": "host"}
     ], 
     "monitors": [
-      {"type": "collectd/cpu"},
-      {"type": "collectd/cpufreq"},
+      {"type": "cpu"},
       {"type": "filesystems"},
       {"type": "disk"},
       {"type": "net-io"},

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -66,7 +66,7 @@ part of the `monitors` list in the agent config like so:
 ```yaml
 monitors:
   - {"#from": "/etc/signalfx/monitors/*.yaml", flatten: true, optional: true}
-  - type: collectd/cpu
+  - type: cpu
   ...
 ```
 

--- a/deployments/docker/agent.yaml
+++ b/deployments/docker/agent.yaml
@@ -21,8 +21,7 @@ observers:
 
 monitors:
   - {"#from": "/etc/signalfx/monitors/*.yaml", flatten: true, optional: true}
-  - type: collectd/cpu
-  - type: collectd/cpufreq
+  - type: cpu
   - type: filesystems
     hostFSPath: /hostfs
   - type: disk

--- a/deployments/ecs/agent.yaml
+++ b/deployments/ecs/agent.yaml
@@ -35,8 +35,7 @@ observers:
       com.amazonaws.ecs.task-definition-version: ecs_task_version
 
 monitors:
-  - type: collectd/cpu
-  - type: collectd/cpufreq
+  - type: cpu
   - type: filesystems
     hostFSPath: /hostfs
   - type: disk

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -18,7 +18,7 @@ observers:
       com.amazonaws.ecs.container-name: container_spec_name
 
 monitors:
-  - type: collectd/cpu
+  - type: cpu
   - type: disk
   - type: net-io
   - type: load

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -29,8 +29,7 @@ data:
     - type: k8s-api
 
     monitors:
-    - type: collectd/cpu
-    - type: collectd/cpufreq
+    - type: cpu
     - type: filesystems
       hostFSPath: /hostfs
     - type: disk

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -53,8 +53,7 @@ data:
       {{- end }}
 
     monitors:
-    - type: collectd/cpu
-    - type: collectd/cpufreq
+    - type: cpu
     - type: filesystems
       hostFSPath: {{ .Values.hostFSPath }}
     - type: disk

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -17,8 +17,7 @@ class accepts the following parameters:
       signalFxRealm: "us1",
       enableBuiltInFiltering: true,
       monitors: [
-        {type: "collectd/cpu"},
-        {type: "collectd/cpufreq"},
+        {type: "cpu"},
         {type: "filesystems"},
         {type: "disk"},
         {type: "net-io"},

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -44,8 +44,7 @@ signalfx-agent:
   conf:
     signalFxAccessToken: 'My_Token'
     monitors:
-      - type: collectd/cpu
-      - type: collectd/cpufreq
+      - type: cpu
       - type: filesystems
       - type: disk
       - type: net-io

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -6,8 +6,7 @@ signalfx-agent:
     signalFxAccessToken: 'My_Token'
     enableBuiltInFiltering: true
     monitors:
-      - type: collectd/cpu
-      - type: collectd/cpufreq
+      - type: cpu
       - type: filesystems
       - type: disk
       - type: net-io

--- a/docs/advanced-install-options.md
+++ b/docs/advanced-install-options.md
@@ -196,8 +196,7 @@ Next, add a [docker metrics monitor](./monitors/docker-container-stats.md) to th
 
 ```sh
 monitors:
-  - type: collectd/cpu
-  - type: collectd/cpufreq
+  - type: cpu
     .
     .
     .

--- a/docs/auto-discovery.md
+++ b/docs/auto-discovery.md
@@ -4,7 +4,7 @@ The observers are responsible for discovering service endpoints.  For these
 service endpoints to result in a new monitor instance that is watching that
 endpoint, you must apply _discovery rules_ to your monitor configuration. Every
 monitor that supports monitoring specific services (i.e. not a static monitor
-like the `collectd/cpu` monitor) can be configured with a `discoveryRule`
+like the `cpu` monitor) can be configured with a `discoveryRule`
 config option that specifies a rule using a mini rule language.
 
 For example, to monitor a Redis instance that has been discovered by a

--- a/docs/monitors/collectd-cpu.md
+++ b/docs/monitors/collectd-cpu.md
@@ -10,6 +10,10 @@ Monitor Type: `collectd/cpu` ([Source](https://github.com/signalfx/signalfx-agen
 
 ## Overview
 
+**This monitor is deprecated in favor of the `cpu` monitor.  Please switch
+to that monitor, as this monitor will be removed in a future agent
+release.**
+
 This monitor collects cpu usage data using the
 collectd `cpu` plugin.  It aggregates the per-core CPU data into a single
 metric and sends it to the SignalFx Metadata plugin in collectd, where the

--- a/docs/remote-config.md
+++ b/docs/remote-config.md
@@ -117,9 +117,8 @@ that may be empty, such as the following:
 signalFxAccessToken: abcd
 monitors:
  - {"#from": "/etc/signalfx/conf2/*.yaml", flatten: true, optional: true}
- - type: collectd/cpu
- - type: collectd/cpufreq
- - type: collectd/df
+ - type: cpu
+ - type: filesystems
 ```
 
 The key here is the `optional: true` value, which makes it accept globs that

--- a/docs/smart-agent-quickstart.md
+++ b/docs/smart-agent-quickstart.md
@@ -88,7 +88,7 @@ Your monitor list would then look similar to this:
 
 ```
 monitors:
-  - type: collectd/cpu
+  - type: cpu
   .
   .
   .
@@ -113,8 +113,7 @@ Next, you would add a [docker metrics monitor](./monitors/docker-container-stats
 
 ```
 monitors:
-  - type: collectd/cpu
-  - type: collectd/cpufreq
+  - type: cpu
   .
   .
   .

--- a/go.sum
+++ b/go.sum
@@ -750,10 +750,10 @@ github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uY
 github.com/rivo/tview v0.0.0-20190515161233-bd836ef13b4b/go.mod h1:+rKjP5+h9HMwWRpAfhIkkQ9KE3m3Nz5rwn7YtUpwgqk=
 github.com/rivo/uniseg v0.0.0-20190513083848-b9f5b9457d44/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
-github.com/rogpeppe/go-internal v1.2.1/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.2.1/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.2.1/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 h1:7YvPJVmEeFHR1Tj9sZEYsmarJEQfMVYpd/Vyy/A8dqE=
 github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/samuel/go-zookeeper v0.0.0-20180130194729-c4fab1ac1bec h1:6ncX5ko6B9LntYM0YBRXkiSaZMmLYeZ/NWcmeB43mMY=

--- a/packaging/etc/agent.yaml
+++ b/packaging/etc/agent.yaml
@@ -19,8 +19,7 @@ monitors:
   - {"#from": "/etc/signalfx/monitors/*.yaml", flatten: true, optional: true}
   - type: host-metadata
   - type: processlist
-  - type: collectd/cpu
-  - type: collectd/cpufreq
+  - type: cpu
   - type: filesystems
   - type: disk
   - type: net-io

--- a/pkg/monitors/collectd/cpu/metadata.yaml
+++ b/pkg/monitors/collectd/cpu/metadata.yaml
@@ -1,6 +1,10 @@
 monitors:
 - dimensions:
   doc: |
+    **This monitor is deprecated in favor of the `cpu` monitor.  Please switch
+    to that monitor, as this monitor will be removed in a future agent
+    release.**
+
     This monitor collects cpu usage data using the
     collectd `cpu` plugin.  It aggregates the per-core CPU data into a single
     metric and sends it to the SignalFx Metadata plugin in collectd, where the

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -3574,7 +3574,7 @@
       "monitorType": "collectd/cpu",
       "sendAll": false,
       "dimensions": null,
-      "doc": "This monitor collects cpu usage data using the\ncollectd `cpu` plugin.  It aggregates the per-core CPU data into a single\nmetric and sends it to the SignalFx Metadata plugin in collectd, where the\nraw jiffy counts from the `cpu` plugin are converted to percent utilization\n(the `cpu.utilization` metric).\n\nSee https://collectd.org/wiki/index.php/Plugin:CPU\n",
+      "doc": "**This monitor is deprecated in favor of the `cpu` monitor.  Please switch\nto that monitor, as this monitor will be removed in a future agent\nrelease.**\n\nThis monitor collects cpu usage data using the\ncollectd `cpu` plugin.  It aggregates the per-core CPU data into a single\nmetric and sends it to the SignalFx Metadata plugin in collectd, where the\nraw jiffy counts from the `cpu` plugin are converted to percent utilization\n(the `cpu.utilization` metric).\n\nSee https://collectd.org/wiki/index.php/Plugin:CPU\n",
       "groups": {
         "": {
           "description": "",

--- a/tests/basic/basic_test.py
+++ b/tests/basic/basic_test.py
@@ -6,18 +6,17 @@ from tests.helpers.agent import Agent
 from tests.helpers.assertions import has_log_message
 from tests.helpers.util import wait_for
 
-BASIC_CONFIG = """
-monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/cpu
-  - type: collectd/uptime
-"""
-
 
 def test_basic():
     """
     See if we get datapoints from a very standard set of monitors
     """
-    with Agent.run(BASIC_CONFIG) as agent:
+    with Agent.run(
+        """
+monitors:
+  - type: cpu
+  - type: collectd/uptime
+"""
+    ) as agent:
         assert wait_for(lambda: agent.fake_services.datapoints), "Didn't get any datapoints"
         assert has_log_message(agent.output, "info")

--- a/tests/basic/filter_test.py
+++ b/tests/basic/filter_test.py
@@ -6,8 +6,7 @@ from tests.helpers.util import ensure_always, wait_for
 
 BASIC_CONFIG = """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/cpu
+  - type: cpu
   - type: collectd/uptime
 metricsToExclude:
   - metricName: cpu.utilization
@@ -22,8 +21,7 @@ def test_basic_filtering():
 
 NEGATIVE_FILTERING_CONFIG = """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/memory
+  - type: memory
   - type: collectd/uptime
 metricsToExclude:
   - metricName: memory.used
@@ -45,15 +43,14 @@ def test_negated_filter_with_monitor_type():
     with Agent.run(
         """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/memory
-  - type: collectd/df
+  - type: memory
+  - type: filesystems
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:
      - memory.used
      - memory.free
-    monitorType: collectd/memory
+    monitorType: memory
     negated: true
   - metricName: uptime
 """
@@ -69,19 +66,18 @@ def test_combined_filter_with_monitor_type():
     with Agent.run(
         """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/memory
-  - type: collectd/df
+  - type: memory
+  - type: filesystems
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:
      - memory.used
-    monitorType: collectd/memory
+    monitorType: memory
     negated: true
   - metricName: uptime
   - metricNames:
     - memory.free
-    monitorType: collectd/memory
+    monitorType: memory
     negated: true
 """
     ) as agent:
@@ -98,7 +94,7 @@ def test_overlapping_filter_with_monitor_type():
     with Agent.run(
         """
 monitors:
-  - type: collectd/memory
+  - type: memory
   - type: collectd/uptime
 metricsToExclude:
   - metricName: uptime
@@ -120,7 +116,7 @@ def test_overlapping_filter_with_monitor_type2():
     with Agent.run(
         """
 monitors:
-  - type: collectd/memory
+  - type: memory
   - type: collectd/uptime
 metricsToExclude:
   - metricName: uptime
@@ -143,16 +139,16 @@ def test_include_filter_with_monitor_type():
         """
 enableBuiltInFiltering: false
 monitors:
-  - type: collectd/disk
+  - type: disk-io
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:
     - disk_time.read
-    monitorType: collectd/disk
+    monitorType: disk-io
   - metricNames:
     - disk_ops.read
     - disk_ops.write
-    monitorType: collectd/disk
+    monitorType: disk-io
     negated: true
 metricsToInclude:
   - metricNames:
@@ -173,14 +169,13 @@ def test_filter_with_restart():
     with Agent.run(
         """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/df
-  - type: collectd/memory
+  - type: filesystems
+  - type: memory
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:
      - memory.*
-    monitorType: collectd/memory
+    monitorType: memory
 """
     ) as agent:
         assert wait_for(p(has_datapoint, agent.fake_services, metric_name="df_complex.free"))
@@ -190,14 +185,13 @@ metricsToExclude:
         agent.update_config(
             """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/df
-  - type: collectd/memory
+  - type: filesystems
+  - type: memory
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:
      - memory.used
-    monitorType: collectd/memory
+    monitorType: memory
 """
         )
         assert wait_for(p(has_datapoint, agent.fake_services, metric_name="memory.free"))
@@ -210,9 +204,8 @@ def test_monitor_filter():
     with Agent.run(
         """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/df
-  - type: collectd/memory
+  - type: filesystems
+  - type: memory
     metricsToExclude:
      - metricName: memory.used
   - type: collectd/uptime
@@ -225,9 +218,8 @@ monitors:
         agent.update_config(
             """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/df
-  - type: collectd/memory
+  - type: filesystems
+  - type: memory
   - type: collectd/uptime
 """
         )
@@ -239,9 +231,8 @@ def test_mixed_regex_and_non_regex_filters():
     with Agent.run(
         """
 monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/memory
-  - type: collectd/df
+  - type: memory
+  - type: filesystems
   - type: collectd/uptime
 metricsToExclude:
   - metricNames:

--- a/tests/basic/writer_test.py
+++ b/tests/basic/writer_test.py
@@ -4,13 +4,6 @@ from textwrap import dedent
 from tests.helpers.agent import Agent
 from tests.helpers.util import container_ip, run_service
 
-BASIC_CONFIG = """
-monitors:
-  - type: collectd/signalfx-metadata
-  - type: collectd/cpu
-  - type: collectd/uptime
-"""
-
 
 def test_writer_no_skipped_datapoints():
     """


### PR DESCRIPTION
 - Also remove collectd/cpufreq from standard configs
 - Replace collectd/cpu with cpu in some of the integration tests