### PR TITLE
Update vSphere yaml and dimensions

### DIFF
--- a/docs/monitors/vsphere.md
+++ b/docs/monitors/vsphere.md
@@ -88,6 +88,7 @@ monitor config option `extraGroups`:
  - `vsphere.cpu_demand_mhz` (*counter*)<br>    The amount of CPU resources a virtual machine would use if there were no CPU contention or CPU limit.
  - `vsphere.cpu_entitlement_mhz` (*gauge*)<br>    CPU resources devoted by the ESXi scheduler.
  - `vsphere.cpu_idle_ms` (*counter*)<br>    Total time that the CPU spent in an idle state.
+ - `vsphere.cpu_latency_percent` (*gauge*)<br>    Percent of time the virtual machine is unable to run because it is contending for access to the physical CPU(s).
  - `vsphere.cpu_maxlimited_ms` (*counter*)<br>    Time the virtual machine is ready to run, but is not running because it has reached its maximum CPU limit setting.
  - `vsphere.cpu_overlap_ms` (*counter*)<br>    Time the virtual machine was interrupted to perform system services on behalf of itself or other virtual machines.
  - `vsphere.cpu_readiness_percent` (*gauge*)<br>    Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
@@ -97,244 +98,243 @@ monitor config option `extraGroups`:
  - `vsphere.cpu_swapwait_ms` (*gauge*)<br>    CPU time spent waiting for swap-in.
  - `vsphere.cpu_system_ms` (*counter*)<br>    Amount of time spent on system processes on each virtual CPU in the virtual machine.
  - `vsphere.cpu_totalCapacity_mhz` (*gauge*)<br>    Total CPU capacity reserved by and available for virtual machines
- - `vsphere.cpu_usage_percent` (*gauge*)<br>    CPU usage as a percentage during the interval.
+ - ***`vsphere.cpu_usage_percent`*** (*gauge*)<br>    CPU usage as a percentage during the interval.
  - `vsphere.cpu_usagemhz` (*gauge*)<br>    CPU usage, as measured in megahertz, during the interval.
  - `vsphere.cpu_used_percent` (*counter*)<br>    Time accounted to the virtual machine.
  - `vsphere.cpu_utilization_percent` (*gauge*)<br>    CPU utilization as a percentage during the interval. CPU usage and CPU utilization might be different due to power management technologies or hyper-threading.
  - `vsphere.cpu_wait_ms` (*counter*)<br>    Total CPU time spent in wait state. The wait total includes time spent the CPU Idle, CPU Swap Wait, and CPU I/O Wait states.
- - `vsphere_cpu_latency_percent` (*gauge*)<br>    Percent of time the virtual machine is unable to run because it is contending for access to the physical CPU(s).
 
 #### Group datastore
 All of the following metrics are part of the `datastore` metric group. All of
 the non-default metrics below can be turned on by adding `datastore` to the
 monitor config option `extraGroups`:
- - `vsphere.datastore.datastore_read_load_metric` (*gauge*)<br>    Storage DRS datastore metric for read workload model.
- - `vsphere.datastore.datastore_vmobserved_latency_ms` (*gauge*)<br>    The average datastore latency as seen by virtual machines.
- - `vsphere.datastore.datastore_write_load_metric` (*gauge*)<br>    Storage DRS datastore metric for write workload model.
- - `vsphere.datastore.max_total_latency_ms` (*gauge*)<br>    Highest latency value across all datastores used by the host.
- - `vsphere.datastore.read_kbs` (*gauge*)<br>    Rate of reading data from the datastore (kilobytes per second)
- - `vsphere.datastore.size_normalized_datastore_latency_ms` (*gauge*)<br>    Storage I/O Control size-normalized I/O latency.
- - `vsphere.datastore.total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation from the vsphere.datastore. Total latency = kernel latency + device latency.
- - `vsphere.datastore.total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write operation to the vsphere.datastore. Total latency = kernel latency + device latency.
- - `vsphere.datastore.write_kbs` (*gauge*)<br>    Rate of writing data to the datastore.
- - `vsphere.datastore_datastoreIops` (*gauge*)<br>    Average amount of time for an I/O operation to the datastore or LUN across all ESX hosts accessing it.
+ - `vsphere.datastore_datastore_iops` (*gauge*)<br>    Average amount of time for an I/O operation to the datastore or LUN across all ESX hosts accessing it.
+ - `vsphere.datastore_max_total_latency_ms` (*gauge*)<br>    Highest latency value across all datastores used by the host.
+ - `vsphere.datastore_read_kbs` (*gauge*)<br>    Rate of reading data from the datastore (kilobytes per second)
+ - `vsphere.datastore_read_load_metric` (*gauge*)<br>    Storage DRS datastore metric for read workload model.
+ - `vsphere.datastore_size_normalized_datastore_latency_ms` (*gauge*)<br>    Storage I/O Control size-normalized I/O latency.
+ - `vsphere.datastore_total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation from the vsphere datastore. Total latency = kernel latency + device latency.
+ - `vsphere.datastore_total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write operation to the vsphere datastore. Total latency = kernel latency + device latency.
+ - `vsphere.datastore_vmobserved_latency_ms` (*gauge*)<br>    The average datastore latency as seen by virtual machines.
+ - `vsphere.datastore_write_kbs` (*gauge*)<br>    Rate of writing data to the datastore.
+ - `vsphere.datastore_write_load_metric` (*gauge*)<br>    Storage DRS datastore metric for write workload model.
 
 #### Group disk
 All of the following metrics are part of the `disk` metric group. All of
 the non-default metrics below can be turned on by adding `disk` to the
 monitor config option `extraGroups`:
- - `vsphere.disk.bus_resets` (*counter*)<br>    Number of SCSI-bus reset commands issued during the collection interval.
- - `vsphere.disk.commands` (*counter*)<br>    Number of SCSI commands issued during the collection interval.
- - `vsphere.disk.commands_aborted` (*counter*)<br>    Number of SCSI commands aborted during the collection interval.
- - `vsphere.disk.commands_averaged` (*gauge*)<br>    Average number of SCSI commands issued per second during the collection interval.
- - `vsphere.disk.device_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to complete a SCSI command from the physical device.
- - `vsphere.disk.device_read_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to read from the physical device.
- - `vsphere.disk.device_write_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to write to the physical device.
- - `vsphere.disk.kernel_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI command.
- - `vsphere.disk.kernel_read_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI read command.
- - `vsphere.disk.kernel_write_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI write command.
- - `vsphere.disk.max_queue_depth` (*gauge*)<br>    Maximum queue depth.
- - `vsphere.disk.max_total_latency_ms` (*gauge*)<br>    Highest latency value across all disks used by the host.
- - `vsphere.disk.number_read` (*counter*)<br>    Number of disk reads during the collection interval.
- - `vsphere.disk.number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second to the datastore during the collection interval.
- - `vsphere.disk.number_write` (*counter*)<br>    Number of disk writes during the collection interval.
- - `vsphere.disk.number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second to the datastore during the collection interval.
- - `vsphere.disk.queue_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI command, during the collection interval.
- - `vsphere.disk.queue_read_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI read command, during the collection interval.
- - `vsphere.disk.queue_write_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI write command, during the collection interval.
- - `vsphere.disk.read_kbs` (*gauge*)<br>    Average number of kilobytes read from the disk each second during the collection interval.
- - `vsphere.disk.total_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI command issued by the guest OS to the virtual machine.
- - `vsphere.disk.total_read_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI read command issued from the guest OS to the virtual machine.
- - `vsphere.disk.total_write_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI write command issued by the guest OS to the virtual machine.
- - `vsphere.disk.usage_kbs` (*gauge*)<br>    Aggregated disk I/O rate.
- - `vsphere.disk.write_kbs` (*gauge*)<br>    Average number of kilobytes written to disk each second during the collection interval.
+ - `vsphere.disk_bus_resets` (*counter*)<br>    Number of SCSI-bus reset commands issued during the collection interval.
+ - `vsphere.disk_commands` (*counter*)<br>    Number of SCSI commands issued during the collection interval.
+ - `vsphere.disk_commands_aborted` (*counter*)<br>    Number of SCSI commands aborted during the collection interval.
+ - `vsphere.disk_commands_averaged` (*gauge*)<br>    Average number of SCSI commands issued per second during the collection interval.
+ - `vsphere.disk_device_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to complete a SCSI command from the physical device.
+ - `vsphere.disk_device_read_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to read from the physical device.
+ - `vsphere.disk_device_write_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, to write to the physical device.
+ - `vsphere.disk_kernel_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI command.
+ - `vsphere.disk_kernel_read_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI read command.
+ - `vsphere.disk_kernel_write_latency_ms` (*gauge*)<br>    Average amount of time, in milliseconds, spent by VMkernel to process each SCSI write command.
+ - ***`vsphere.disk_max_queue_depth`*** (*gauge*)<br>    Maximum queue depth.
+ - ***`vsphere.disk_max_total_latency_ms`*** (*gauge*)<br>    Highest latency value across all disks used by the host.
+ - `vsphere.disk_number_read` (*counter*)<br>    Number of disk reads during the collection interval.
+ - `vsphere.disk_number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second to the datastore during the collection interval.
+ - `vsphere.disk_number_write` (*counter*)<br>    Number of disk writes during the collection interval.
+ - `vsphere.disk_number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second to the datastore during the collection interval.
+ - `vsphere.disk_queue_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI command, during the collection interval.
+ - `vsphere.disk_queue_read_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI read command, during the collection interval.
+ - `vsphere.disk_queue_write_latency_ms` (*gauge*)<br>    Average amount of time spent in the VMkernel queue, per SCSI write command, during the collection interval.
+ - `vsphere.disk_read_kbs` (*gauge*)<br>    Average number of kilobytes read from the disk each second during the collection interval.
+ - `vsphere.disk_total_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI command issued by the guest OS to the virtual machine.
+ - `vsphere.disk_total_read_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI read command issued from the guest OS to the virtual machine.
+ - `vsphere.disk_total_write_latency_ms` (*gauge*)<br>    Average amount of time taken during the collection interval to process a SCSI write command issued by the guest OS to the virtual machine.
+ - ***`vsphere.disk_usage_kbs`*** (*gauge*)<br>    Aggregated disk I/O rate.
+ - `vsphere.disk_write_kbs` (*gauge*)<br>    Average number of kilobytes written to disk each second during the collection interval.
 
 #### Group hbr
 All of the following metrics are part of the `hbr` metric group. All of
 the non-default metrics below can be turned on by adding `hbr` to the
 monitor config option `extraGroups`:
- - `vsphere.hbr.hbr_net_rx_kbs` (*gauge*)<br>    Kilobytes per second of outgoing host-based replication network traffic (for this virtual machine or host).
- - `vsphere.hbr.hbr_net_tx_kbs` (*gauge*)<br>    Average amount of data transmitted per second.
- - `vsphere.hbr.hbr_num_vms` (*gauge*)<br>    Number of powered-on virtual machines running on this host that currently have host-based replication protection enabled.
+ - `vsphere.hbr_net_rx_kbs` (*gauge*)<br>    Kilobytes per second of outgoing host-based replication network traffic (for this virtual machine or host).
+ - `vsphere.hbr_net_tx_kbs` (*gauge*)<br>    Average amount of data transmitted per second.
+ - `vsphere.hbr_num_vms` (*gauge*)<br>    Number of powered-on virtual machines running on this host that currently have host-based replication protection enabled.
 
 #### Group mem
 All of the following metrics are part of the `mem` metric group. All of
 the non-default metrics below can be turned on by adding `mem` to the
 monitor config option `extraGroups`:
- - `vsphere.mem.active_kb` (*gauge*)<br>    Amount of memory that is actively used, as estimated by VMkernel based on recently touched memory pages.
- - `vsphere.mem.activewrite_kb` (*gauge*)<br>    Estimate for the amount of memory actively being written to by the virtual machine.
- - `vsphere.mem.compressed_kb` (*gauge*)<br>    Amount of memory reserved by userworlds.
- - `vsphere.mem.compression_rate_kbs` (*gauge*)<br>    Rate of memory compression for the virtual machine.
- - `vsphere.mem.consumed_kb` (*gauge*)<br>    Amount of host physical memory consumed by a virtual machine, host, or cluster.
- - `vsphere.mem.decompression_rate_kbs` (*gauge*)<br>    Rate of memory decompression for the virtual machine.
- - `vsphere.mem.entitlement_kb` (*gauge*)<br>    Amount of host physical memory the virtual machine is entitled to, as determined by the ESX scheduler.
- - `vsphere.mem.granted_kb` (*gauge*)<br>    Amount of host physical memory or physical memory that is mapped for a virtual machine or a host.
- - `vsphere.mem.heap_kb` (*gauge*)<br>    VMkernel virtual address space dedicated to VMkernel main heap and related data.
- - `vsphere.mem.heapfree_kb` (*gauge*)<br>    Free address space in the VMkernel main heap.Varies based on number of physical devices and configuration options.
- - `vsphere.mem.latency_percent` (*gauge*)<br>    Percentage of time the virtual machine is waiting to access swapped or compressed memory.
- - `vsphere.mem.ll_swap_in_kb` (*gauge*)<br>    Amount of memory swapped-in from host cache.
- - `vsphere.mem.ll_swap_in_rate_kbs` (*gauge*)<br>    Rate at which memory is being swapped from host cache into active memory.
- - `vsphere.mem.ll_swap_out_kb` (*gauge*)<br>    Amount of memory swapped-out to host cache.
- - `vsphere.mem.ll_swap_out_rate_kbs` (*gauge*)<br>    Rate at which memory is being swapped from active memory to host cache.
- - `vsphere.mem.ll_swap_used_kb` (*gauge*)<br>    Space used for caching swapped pages in the host cache.
- - `vsphere.mem.lowfreethreshold_kb` (*gauge*)<br>    Threshold of free host physical memory below which ESX/ESXi will begin reclaiming memory from virtual machines through ballooning and swapping.
- - `vsphere.mem.overhead_kb` (*gauge*)<br>    Host physical memory (KB) consumed by the virtualization infrastructure for running the virtual machine.
- - `vsphere.mem.overhead_max_kb` (*gauge*)<br>    Host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.
- - `vsphere.mem.overhead_touched_kb` (*gauge*)<br>    Actively touched overhead host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.
- - `vsphere.mem.reserved_capacity_mb` (*gauge*)<br>    Total amount of memory reservation used by powered-on virtual machines and vSphere services on the host.
- - `vsphere.mem.shared_kb` (*gauge*)<br>    Amount of guest physical memory that is shared with other virtual machines, relative to a single virtual machine or to all powered-on virtual machines on a host.
- - `vsphere.mem.sharedcommon_kb` (*gauge*)<br>    Amount of machine memory that is shared by all powered-on virtual machines and vSphere services on the host.Subtract this metric from the shared metric to gauge how much machine memory is saved due to sharing -- shared - sharedcommon = machine memory (host memory) savings (KB).
- - `vsphere.mem.state` (*gauge*)<br>    One of four threshold levels representing the percentage of free memory on the host. The counter value determines swapping and ballooning behavior for memory reclamation.
- - `vsphere.mem.swapin_kb` (*gauge*)<br>    Amount swapped-in to memory from disk.
- - `vsphere.mem.swapin_rate_kbs` (*gauge*)<br>    Rate at which memory is swapped from disk into active memory during the interval.
- - `vsphere.mem.swapout_kb` (*gauge*)<br>    Amount of memory swapped-out to disk.
- - `vsphere.mem.swapout_rate_kbs` (*gauge*)<br>    Rate at which memory is being swapped from active memory to disk during the current interval.
- - `vsphere.mem.swapped_kb` (*gauge*)<br>    Current amount of guest physical memory swapped out to the virtual machine swap file by the VMkernel.
- - `vsphere.mem.swaptarget_kb` (*gauge*)<br>    Target size for the virtual machine swap file.
- - `vsphere.mem.swapused_kb` (*gauge*)<br>    Amount of memory that is used by swap.
- - `vsphere.mem.sys_usage_kb` (*gauge*)<br>    Amount of host physical memory used by VMkernel for core functionality, such as device drivers and other internal uses.
- - `vsphere.mem.total_capacity_mb` (*gauge*)<br>    Total amount of memory reservation used by and available for powered-on virtual machines and vSphere services on the host.
- - `vsphere.mem.unreserved_kb` (*gauge*)<br>    Amount of memory that is unreserved.
- - `vsphere.mem.usage_percent` (*gauge*)<br>    Percentage of host physical memory that has been consumed.
- - `vsphere.mem.vmfs_pbc_cap_miss_ratio_percent` (*gauge*)<br>    Trailing average of the ratio of capacity misses to compulsory misses for the VMFS PB Cache.
- - `vsphere.mem.vmfs_pbc_overhead_kb` (*gauge*)<br>    Amount of VMFS heap used by the VMFS PB Cache.
- - `vsphere.mem.vmfs_pbc_size_max_mb` (*gauge*)<br>    Maximum size the VMFS Pointer Block Cache can grow to.
- - `vsphere.mem.vmfs_pbc_size_mb` (*gauge*)<br>    Space used for holding VMFS Pointer Blocks in memory.
- - `vsphere.mem.vmfs_pbc_working_set_max_tb` (*gauge*)<br>    Maximum amount of file blocks whose addresses are cached in the VMFS PB Cache.
- - `vsphere.mem.vmfs_pbc_working_set_tb` (*gauge*)<br>    Amount of file blocks whose addresses are cached in the VMFS PB Cache.
- - `vsphere.mem.vmmemctl_kb` (*gauge*)<br>    Amount of memory allocated by the virtual machine memory control driver.
- - `vsphere.mem.vmmemctltarget_kb` (*gauge*)<br>    Target value set by VMkernal for the virtual machine's memory balloon size.
- - `vsphere.mem.zero_kb` (*gauge*)<br>    Memory that contains 0s only.
- - `vsphere.mem.zip_saved_kb` (*gauge*)<br>    Memory (KB) saved due to memory zipping.
- - `vsphere.mem.zipped_kb` (*gauge*)<br>    Memory (KB) zipped.
+ - `vsphere.mem_active_kb` (*gauge*)<br>    Amount of memory that is actively used, as estimated by VMkernel based on recently touched memory pages.
+ - `vsphere.mem_activewrite_kb` (*gauge*)<br>    Estimate for the amount of memory actively being written to by the virtual machine.
+ - `vsphere.mem_compressed_kb` (*gauge*)<br>    Amount of memory reserved by userworlds.
+ - `vsphere.mem_compression_rate_kbs` (*gauge*)<br>    Rate of memory compression for the virtual machine.
+ - `vsphere.mem_consumed_kb` (*gauge*)<br>    Amount of host physical memory consumed by a virtual machine, host, or cluster.
+ - `vsphere.mem_decompression_rate_kbs` (*gauge*)<br>    Rate of memory decompression for the virtual machine.
+ - `vsphere.mem_entitlement_kb` (*gauge*)<br>    Amount of host physical memory the virtual machine is entitled to, as determined by the ESX scheduler.
+ - `vsphere.mem_granted_kb` (*gauge*)<br>    Amount of host physical memory or physical memory that is mapped for a virtual machine or a host.
+ - `vsphere.mem_heap_kb` (*gauge*)<br>    VMkernel virtual address space dedicated to VMkernel main heap and related data.
+ - `vsphere.mem_heapfree_kb` (*gauge*)<br>    Free address space in the VMkernel main heap.Varies based on number of physical devices and configuration options.
+ - `vsphere.mem_latency_percent` (*gauge*)<br>    Percentage of time the virtual machine is waiting to access swapped or compressed memory.
+ - `vsphere.mem_ll_swap_in_kb` (*gauge*)<br>    Amount of memory swapped-in from host cache.
+ - `vsphere.mem_ll_swap_in_rate_kbs` (*gauge*)<br>    Rate at which memory is being swapped from host cache into active memory.
+ - `vsphere.mem_ll_swap_out_kb` (*gauge*)<br>    Amount of memory swapped-out to host cache.
+ - `vsphere.mem_ll_swap_out_rate_kbs` (*gauge*)<br>    Rate at which memory is being swapped from active memory to host cache.
+ - `vsphere.mem_ll_swap_used_kb` (*gauge*)<br>    Space used for caching swapped pages in the host cache.
+ - `vsphere.mem_lowfreethreshold_kb` (*gauge*)<br>    Threshold of free host physical memory below which ESX/ESXi will begin reclaiming memory from virtual machines through ballooning and swapping.
+ - `vsphere.mem_overhead_kb` (*gauge*)<br>    Host physical memory (KB) consumed by the virtualization infrastructure for running the virtual machine.
+ - `vsphere.mem_overhead_max_kb` (*gauge*)<br>    Host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.
+ - `vsphere.mem_overhead_touched_kb` (*gauge*)<br>    Actively touched overhead host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.
+ - `vsphere.mem_reserved_capacity_mb` (*gauge*)<br>    Total amount of memory reservation used by powered-on virtual machines and vSphere services on the host.
+ - `vsphere.mem_shared_kb` (*gauge*)<br>    Amount of guest physical memory that is shared with other virtual machines, relative to a single virtual machine or to all powered-on virtual machines on a host.
+ - `vsphere.mem_sharedcommon_kb` (*gauge*)<br>    Amount of machine memory that is shared by all powered-on virtual machines and vSphere services on the host.Subtract this metric from the shared metric to gauge how much machine memory is saved due to sharing -- shared - sharedcommon = machine memory (host memory) savings (KB).
+ - `vsphere.mem_state` (*gauge*)<br>    One of four threshold levels representing the percentage of free memory on the host. The counter value determines swapping and ballooning behavior for memory reclamation.
+ - `vsphere.mem_swapin_kb` (*gauge*)<br>    Amount swapped-in to memory from disk.
+ - ***`vsphere.mem_swapin_rate_kbs`*** (*gauge*)<br>    Rate at which memory is swapped from disk into active memory during the interval.
+ - `vsphere.mem_swapout_kb` (*gauge*)<br>    Amount of memory swapped-out to disk.
+ - ***`vsphere.mem_swapout_rate_kbs`*** (*gauge*)<br>    Rate at which memory is being swapped from active memory to disk during the current interval.
+ - `vsphere.mem_swapped_kb` (*gauge*)<br>    Current amount of guest physical memory swapped out to the virtual machine swap file by the VMkernel.
+ - `vsphere.mem_swaptarget_kb` (*gauge*)<br>    Target size for the virtual machine swap file.
+ - `vsphere.mem_swapused_kb` (*gauge*)<br>    Amount of memory that is used by swap.
+ - `vsphere.mem_sys_usage_kb` (*gauge*)<br>    Amount of host physical memory used by VMkernel for core functionality, such as device drivers and other internal uses.
+ - `vsphere.mem_total_capacity_mb` (*gauge*)<br>    Total amount of memory reservation used by and available for powered-on virtual machines and vSphere services on the host.
+ - `vsphere.mem_unreserved_kb` (*gauge*)<br>    Amount of memory that is unreserved.
+ - ***`vsphere.mem_usage_percent`*** (*gauge*)<br>    Percentage of host physical memory that has been consumed.
+ - `vsphere.mem_vmfs_pbc_cap_miss_ratio_percent` (*gauge*)<br>    Trailing average of the ratio of capacity misses to compulsory misses for the VMFS PB Cache.
+ - `vsphere.mem_vmfs_pbc_overhead_kb` (*gauge*)<br>    Amount of VMFS heap used by the VMFS PB Cache.
+ - `vsphere.mem_vmfs_pbc_size_max_mb` (*gauge*)<br>    Maximum size the VMFS Pointer Block Cache can grow to.
+ - `vsphere.mem_vmfs_pbc_size_mb` (*gauge*)<br>    Space used for holding VMFS Pointer Blocks in memory.
+ - `vsphere.mem_vmfs_pbc_working_set_max_tb` (*gauge*)<br>    Maximum amount of file blocks whose addresses are cached in the VMFS PB Cache.
+ - `vsphere.mem_vmfs_pbc_working_set_tb` (*gauge*)<br>    Amount of file blocks whose addresses are cached in the VMFS PB Cache.
+ - `vsphere.mem_vmmemctl_kb` (*gauge*)<br>    Amount of memory allocated by the virtual machine memory control driver.
+ - `vsphere.mem_vmmemctltarget_kb` (*gauge*)<br>    Target value set by VMkernal for the virtual machine's memory balloon size.
+ - `vsphere.mem_zero_kb` (*gauge*)<br>    Memory that contains 0s only.
+ - `vsphere.mem_zip_saved_kb` (*gauge*)<br>    Memory (KB) saved due to memory zipping.
+ - `vsphere.mem_zipped_kb` (*gauge*)<br>    Memory (KB) zipped.
 
 #### Group net
 All of the following metrics are part of the `net` metric group. All of
 the non-default metrics below can be turned on by adding `net` to the
 monitor config option `extraGroups`:
- - `vsphere.net.broadcast_rx` (*counter*)<br>    Number of broadcast packets received during the sampling interval.
- - `vsphere.net.broadcast_tx` (*counter*)<br>    Number of broadcast packets transmitted during the sampling interval.
- - `vsphere.net.bytes_rx_kbs` (*gauge*)<br>    Average amount of data received per second.
- - `vsphere.net.bytes_tx_kbs` (*gauge*)<br>    Average amount of data transmitted per second.
- - `vsphere.net.dropped_rx` (*counter*)<br>    Number of received packets dropped during the collection interval.
- - `vsphere.net.dropped_tx` (*counter*)<br>    Number of transmitted packets dropped during the collection interval.
- - `vsphere.net.errors_rx` (*counter*)<br>    Number of packets with errors received during the sampling interval.
- - `vsphere.net.errors_tx` (*counter*)<br>    Number of packets with errors transmitted during the sampling interval.
- - `vsphere.net.multicast_rx` (*counter*)<br>    Number of multicast packets received during the sampling interval.
- - `vsphere.net.multicast_tx` (*counter*)<br>    Number of multicast packets transmitted during the sampling interval.
- - `vsphere.net.packets_rx` (*counter*)<br>    Number of packets received during the interval.
- - `vsphere.net.packets_tx` (*counter*)<br>    Number of packets transmitted during the interval.
- - `vsphere.net.received_kbs` (*gauge*)<br>    Average rate at which data was received during the interval.
- - `vsphere.net.transmitted_kbs` (*gauge*)<br>    Average rate at which data was transmitted during the interval. This represents the bandwidth of the network.
- - `vsphere.net.unknown_protos` (*counter*)<br>    Number of frames with unknown protocol received during the sampling interval
- - `vsphere.net.usage_kbs` (*gauge*)<br>    Network utilization (combined transmit- and receive-rates) during the interval.
+ - `vsphere.net_broadcast_rx` (*counter*)<br>    Number of broadcast packets received during the sampling interval.
+ - `vsphere.net_broadcast_tx` (*counter*)<br>    Number of broadcast packets transmitted during the sampling interval.
+ - `vsphere.net_bytes_rx_kbs` (*gauge*)<br>    Average amount of data received per second.
+ - `vsphere.net_bytes_tx_kbs` (*gauge*)<br>    Average amount of data transmitted per second.
+ - `vsphere.net_dropped_rx` (*counter*)<br>    Number of received packets dropped during the collection interval.
+ - `vsphere.net_dropped_tx` (*counter*)<br>    Number of transmitted packets dropped during the collection interval.
+ - `vsphere.net_errors_rx` (*counter*)<br>    Number of packets with errors received during the sampling interval.
+ - `vsphere.net_errors_tx` (*counter*)<br>    Number of packets with errors transmitted during the sampling interval.
+ - `vsphere.net_multicast_rx` (*counter*)<br>    Number of multicast packets received during the sampling interval.
+ - `vsphere.net_multicast_tx` (*counter*)<br>    Number of multicast packets transmitted during the sampling interval.
+ - `vsphere.net_packets_rx` (*counter*)<br>    Number of packets received during the interval.
+ - `vsphere.net_packets_tx` (*counter*)<br>    Number of packets transmitted during the interval.
+ - ***`vsphere.net_received_kbs`*** (*gauge*)<br>    Average rate at which data was received during the interval.
+ - ***`vsphere.net_transmitted_kbs`*** (*gauge*)<br>    Average rate at which data was transmitted during the interval. This represents the bandwidth of the network.
+ - `vsphere.net_unknown_protos` (*counter*)<br>    Number of frames with unknown protocol received during the sampling interval
+ - `vsphere.net_usage_kbs` (*gauge*)<br>    Network utilization (combined transmit- and receive-rates) during the interval.
 
 #### Group power
 All of the following metrics are part of the `power` metric group. All of
 the non-default metrics below can be turned on by adding `power` to the
 monitor config option `extraGroups`:
- - `vsphere.power.energy_joules` (*counter*)<br>    Total energy used since last stats reset.
- - `vsphere.power.power_cap_watts` (*gauge*)<br>    Maximum allowed power usage.
- - `vsphere.power.power_watts` (*gauge*)<br>    Current power usage.
+ - `vsphere.power_cap_watts` (*gauge*)<br>    Maximum allowed power usage.
+ - `vsphere.power_energy_joules` (*counter*)<br>    Total energy used since last stats reset.
+ - `vsphere.power_watts` (*gauge*)<br>    Current power usage.
 
 #### Group rescpu
 All of the following metrics are part of the `rescpu` metric group. All of
 the non-default metrics below can be turned on by adding `rescpu` to the
 monitor config option `extraGroups`:
- - `vsphere.rescpu.actav1` (*gauge*)<br>    CPU active average over 1 minute.
- - `vsphere.rescpu.actav15_percent` (*gauge*)<br>    CPU active average over 15 minutes.
- - `vsphere.rescpu.actav5_percent` (*gauge*)<br>    CPU active average over 5 minutes.
- - `vsphere.rescpu.actpk15_percent` (*gauge*)<br>    CPU active peak over 15 minutes.
- - `vsphere.rescpu.actpk1_percent` (*gauge*)<br>    CPU active peak over 1 minute.
- - `vsphere.rescpu.actpk5_percent` (*gauge*)<br>    CPU active peak over 5 minutes.
- - `vsphere.rescpu.max_limited15_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 15 minutes.
- - `vsphere.rescpu.max_limited1_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 1 minute.
- - `vsphere.rescpu.max_limited5_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 5 minutes.
- - `vsphere.rescpu.runav15_percent` (*gauge*)<br>    CPU running average over 15 minutes.
- - `vsphere.rescpu.runav1_percent` (*gauge*)<br>    CPU running average over 1 minute.
- - `vsphere.rescpu.runav5_percent` (*gauge*)<br>    CPU running average over 5 minutes.
- - `vsphere.rescpu.runpk15_percent` (*gauge*)<br>    CPU running peak over 15 minutes.
- - `vsphere.rescpu.runpk1_percent` (*gauge*)<br>    CPU running peak over 1 minute.
- - `vsphere.rescpu.runpk5_percent` (*gauge*)<br>    CPU running peak over 5 minutes.
- - `vsphere.rescpu.sample_count` (*gauge*)<br>    Group CPU sample count.
- - `vsphere.rescpu.sample_period_ms` (*gauge*)<br>    Group CPU sample period.
+ - `vsphere.rescpu_actav1` (*gauge*)<br>    CPU active average over 1 minute.
+ - `vsphere.rescpu_actav15_percent` (*gauge*)<br>    CPU active average over 15 minutes.
+ - `vsphere.rescpu_actav5_percent` (*gauge*)<br>    CPU active average over 5 minutes.
+ - `vsphere.rescpu_actpk15_percent` (*gauge*)<br>    CPU active peak over 15 minutes.
+ - `vsphere.rescpu_actpk1_percent` (*gauge*)<br>    CPU active peak over 1 minute.
+ - `vsphere.rescpu_actpk5_percent` (*gauge*)<br>    CPU active peak over 5 minutes.
+ - `vsphere.rescpu_max_limited15_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 15 minutes.
+ - `vsphere.rescpu_max_limited1_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 1 minute.
+ - `vsphere.rescpu_max_limited5_percent` (*gauge*)<br>    Amount of CPU resources over the limit that were refused, average over 5 minutes.
+ - `vsphere.rescpu_runav15_percent` (*gauge*)<br>    CPU running average over 15 minutes.
+ - `vsphere.rescpu_runav1_percent` (*gauge*)<br>    CPU running average over 1 minute.
+ - `vsphere.rescpu_runav5_percent` (*gauge*)<br>    CPU running average over 5 minutes.
+ - `vsphere.rescpu_runpk15_percent` (*gauge*)<br>    CPU running peak over 15 minutes.
+ - `vsphere.rescpu_runpk1_percent` (*gauge*)<br>    CPU running peak over 1 minute.
+ - `vsphere.rescpu_runpk5_percent` (*gauge*)<br>    CPU running peak over 5 minutes.
+ - `vsphere.rescpu_sample_count` (*gauge*)<br>    Group CPU sample count.
+ - `vsphere.rescpu_sample_period_ms` (*gauge*)<br>    Group CPU sample period.
 
 #### Group storage_adapter
 All of the following metrics are part of the `storage_adapter` metric group. All of
 the non-default metrics below can be turned on by adding `storage_adapter` to the
 monitor config option `extraGroups`:
- - `vsphere.storage_adapter.commands_averaged` (*gauge*)<br>    Average number of commands issued per second by the storage adapter during the collection interval.
- - `vsphere.storage_adapter.max_total_latency_ms` (*gauge*)<br>    Highest latency value across all storage adapters used by the host.
- - `vsphere.storage_adapter.number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second by the storage adapter during the collection interval.
- - `vsphere.storage_adapter.number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second by the storage adapter during the collection interval.
- - `vsphere.storage_adapter.read_kbs` (*gauge*)<br>    Rate of reading data by the storage adapter.
- - `vsphere.storage_adapter.total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation by the storage adapter. Total latency = kernel latency + device latency.
- - `vsphere.storage_adapter.total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write operation by the storage adapter. Total latency = kernel latency + device latency.
- - `vsphere.storage_adapter.write_kbs` (*gauge*)<br>    Rate of writing data by the storage adapter.
+ - `vsphere.storage_adapter_commands_averaged` (*gauge*)<br>    Average number of commands issued per second by the storage adapter during the collection interval.
+ - `vsphere.storage_adapter_max_total_latency_ms` (*gauge*)<br>    Highest latency value across all storage adapters used by the host.
+ - `vsphere.storage_adapter_number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second by the storage adapter during the collection interval.
+ - `vsphere.storage_adapter_number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second by the storage adapter during the collection interval.
+ - `vsphere.storage_adapter_read_kbs` (*gauge*)<br>    Rate of reading data by the storage adapter.
+ - `vsphere.storage_adapter_total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation by the storage adapter. Total latency = kernel latency + device latency.
+ - `vsphere.storage_adapter_total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write operation by the storage adapter. Total latency = kernel latency + device latency.
+ - `vsphere.storage_adapter_write_kbs` (*gauge*)<br>    Rate of writing data by the storage adapter.
 
 #### Group storage_path
 All of the following metrics are part of the `storage_path` metric group. All of
 the non-default metrics below can be turned on by adding `storage_path` to the
 monitor config option `extraGroups`:
- - `vsphere.storage_path.commands_averaged` (*gauge*)<br>    Average number of commands issued per second on the storage path during the collection interval.
- - `vsphere.storage_path.max_total_latency_ms` (*gauge*)<br>    Highest latency value across all storage paths used by the host.
- - `vsphere.storage_path.number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second on the storage path during the collection interval.
- - `vsphere.storage_path.number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second on the storage path during the collection interval.
- - `vsphere.storage_path.read_kbs` (*gauge*)<br>    Rate of reading data on the storage path.
- - `vsphere.storage_path.total_read_latency_ms` (*gauge*)<br>    The average time a read issued on the storage path takes.
- - `vsphere.storage_path.total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write issued on the storage path. Total latency = kernel latency + device latency.
- - `vsphere.storage_path.write_kbs` (*gauge*)<br>    Rate of writing data on the storage path.
+ - `vsphere.storage_path_commands_averaged` (*gauge*)<br>    Average number of commands issued per second on the storage path during the collection interval.
+ - `vsphere.storage_path_max_total_latency_ms` (*gauge*)<br>    Highest latency value across all storage paths used by the host.
+ - `vsphere.storage_path_number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second on the storage path during the collection interval.
+ - `vsphere.storage_path_number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second on the storage path during the collection interval.
+ - `vsphere.storage_path_read_kbs` (*gauge*)<br>    Rate of reading data on the storage path.
+ - `vsphere.storage_path_total_read_latency_ms` (*gauge*)<br>    The average time a read issued on the storage path takes.
+ - `vsphere.storage_path_total_write_latency_ms` (*gauge*)<br>    Average amount of time for a write issued on the storage path. Total latency = kernel latency + device latency.
+ - `vsphere.storage_path_write_kbs` (*gauge*)<br>    Rate of writing data on the storage path.
 
 #### Group sys
 All of the following metrics are part of the `sys` metric group. All of
 the non-default metrics below can be turned on by adding `sys` to the
 monitor config option `extraGroups`:
- - `vsphere.sys.heartbeat` (*counter*)<br>    Number of heartbeats issued per virtual machine during the interval.
- - `vsphere.sys.os_uptime_seconds` (*gauge*)<br>    Total time elapsed, in seconds, since last operating system boot-up.
- - `vsphere.sys.resource_cpu_act1_percent` (*gauge*)<br>    CPU active average over 1 minute of the system resource group.
- - `vsphere.sys.resource_cpu_act5` (*gauge*)<br>    CPU active average over 5 minutes of the system resource group.
- - `vsphere.sys.resource_cpu_alloc_min_mhz` (*gauge*)<br>    CPU allocation reservation (in MHz) of the system resource group.
- - `vsphere.sys.resource_cpu_alloc_shares` (*gauge*)<br>    CPU allocation shares of the system resource group.
- - `vsphere.sys.resource_cpu_max_limited1_percent` (*gauge*)<br>    CPU maximum limited over 1 minute of the system resource group.
- - `vsphere.sys.resource_cpu_max_limited5_percent` (*gauge*)<br>    CPU maximum limited over 5 minutes of the system resource group.
- - `vsphere.sys.resource_cpu_run1_percent` (*gauge*)<br>    CPU running average over 1 minute of the system resource group.
- - `vsphere.sys.resource_cpu_run5_percent` (*gauge*)<br>    CPU running average over 5 minutes of the system resource group.
- - `vsphere.sys.resource_cpu_usage_mhz` (*gauge*)<br>    Amount of CPU used by the Service Console and other applications during the interval by the Service Console and other applications.
- - `vsphere.sys.resource_fd_usage` (*gauge*)<br>    Number of file descriptors used by the system resource group.
- - `vsphere.sys.resource_mem_alloc_max_kb` (*gauge*)<br>    Memory allocation limit (in KB) of the system resource group.
- - `vsphere.sys.resource_mem_alloc_min_kb` (*gauge*)<br>    Memory allocation reservation (in KB) of the system resource group.
- - `vsphere.sys.resource_mem_alloc_shares` (*gauge*)<br>    Memory allocation shares of the system resource group.
- - `vsphere.sys.resource_mem_consumed_kb` (*gauge*)<br>    Memory consumed by the system resource group.
- - `vsphere.sys.resource_mem_cow_kb` (*gauge*)<br>    Memory shared by the system resource group.
- - `vsphere.sys.resource_mem_mapped_kb` (*gauge*)<br>    Memory mapped by the system resource group.
- - `vsphere.sys.resource_mem_overhead_kb` (*gauge*)<br>    Overhead memory consumed by the system resource group.
- - `vsphere.sys.resource_mem_shared_kb` (*gauge*)<br>    Memory saved due to sharing by the system resource group.
- - `vsphere.sys.resource_mem_swapped_kb` (*gauge*)<br>    Memory swapped out by the system resource group.
- - `vsphere.sys.resource_mem_touched_kb` (*gauge*)<br>    Memory touched by the system resource group.
- - `vsphere.sys.resource_mem_zero_kb` (*gauge*)<br>    Zero filled memory used by the system resource group.
- - `vsphere.sys.uptime_seconds` (*gauge*)<br>    Total time elapsed, in seconds, since last system startup.
+ - `vsphere.sys_heartbeat` (*counter*)<br>    Number of heartbeats issued per virtual machine during the interval.
+ - `vsphere.sys_os_uptime_seconds` (*gauge*)<br>    Total time elapsed, in seconds, since last operating system boot-up.
+ - `vsphere.sys_resource_cpu_act1_percent` (*gauge*)<br>    CPU active average over 1 minute of the system resource group.
+ - `vsphere.sys_resource_cpu_act5` (*gauge*)<br>    CPU active average over 5 minutes of the system resource group.
+ - `vsphere.sys_resource_cpu_alloc_min_mhz` (*gauge*)<br>    CPU allocation reservation (in MHz) of the system resource group.
+ - `vsphere.sys_resource_cpu_alloc_shares` (*gauge*)<br>    CPU allocation shares of the system resource group.
+ - `vsphere.sys_resource_cpu_max_limited1_percent` (*gauge*)<br>    CPU maximum limited over 1 minute of the system resource group.
+ - `vsphere.sys_resource_cpu_max_limited5_percent` (*gauge*)<br>    CPU maximum limited over 5 minutes of the system resource group.
+ - `vsphere.sys_resource_cpu_run1_percent` (*gauge*)<br>    CPU running average over 1 minute of the system resource group.
+ - `vsphere.sys_resource_cpu_run5_percent` (*gauge*)<br>    CPU running average over 5 minutes of the system resource group.
+ - `vsphere.sys_resource_cpu_usage_mhz` (*gauge*)<br>    Amount of CPU used by the Service Console and other applications during the interval by the Service Console and other applications.
+ - `vsphere.sys_resource_fd_usage` (*gauge*)<br>    Number of file descriptors used by the system resource group.
+ - `vsphere.sys_resource_mem_alloc_max_kb` (*gauge*)<br>    Memory allocation limit (in KB) of the system resource group.
+ - `vsphere.sys_resource_mem_alloc_min_kb` (*gauge*)<br>    Memory allocation reservation (in KB) of the system resource group.
+ - `vsphere.sys_resource_mem_alloc_shares` (*gauge*)<br>    Memory allocation shares of the system resource group.
+ - `vsphere.sys_resource_mem_consumed_kb` (*gauge*)<br>    Memory consumed by the system resource group.
+ - `vsphere.sys_resource_mem_cow_kb` (*gauge*)<br>    Memory shared by the system resource group.
+ - `vsphere.sys_resource_mem_mapped_kb` (*gauge*)<br>    Memory mapped by the system resource group.
+ - `vsphere.sys_resource_mem_overhead_kb` (*gauge*)<br>    Overhead memory consumed by the system resource group.
+ - `vsphere.sys_resource_mem_shared_kb` (*gauge*)<br>    Memory saved due to sharing by the system resource group.
+ - `vsphere.sys_resource_mem_swapped_kb` (*gauge*)<br>    Memory swapped out by the system resource group.
+ - `vsphere.sys_resource_mem_touched_kb` (*gauge*)<br>    Memory touched by the system resource group.
+ - `vsphere.sys_resource_mem_zero_kb` (*gauge*)<br>    Zero filled memory used by the system resource group.
+ - `vsphere.sys_uptime_seconds` (*gauge*)<br>    Total time elapsed, in seconds, since last system startup.
 
 #### Group virtual_disk
 All of the following metrics are part of the `virtual_disk` metric group. All of
 the non-default metrics below can be turned on by adding `virtual_disk` to the
 monitor config option `extraGroups`:
- - `vsphere.virtual_disk.large_seeks` (*gauge*)<br>    Number of seeks during the interval that were greater than 8192 LBNs apart.
- - `vsphere.virtual_disk.medium_seeks` (*gauge*)<br>    Number of seeks during the interval that were between 64 and 8192 LBNs apart.
- - `vsphere.virtual_disk.number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second to the virtual disk during the collection interval.
- - `vsphere.virtual_disk.number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second to the virtual disk during the collection interval.
- - `vsphere.virtual_disk.read_iosize` (*gauge*)<br>    Average read request size in bytes.
- - `vsphere.virtual_disk.read_kbs` (*gauge*)<br>    Rate of reading data from the virtual disk.
- - `vsphere.virtual_disk.read_latency_us` (*gauge*)<br>    Read latency in microseconds.
- - `vsphere.virtual_disk.read_load_metric` (*gauge*)<br>    Storage DRS virtual disk metric for the read workload model.
- - `vsphere.virtual_disk.read_oio` (*gauge*)<br>    Average number of outstanding read requests to the virtual disk during the collection interval.
- - `vsphere.virtual_disk.small_seeks` (*gauge*)<br>    Number of seeks during the interval that were less than 64 LBNs apart.
- - `vsphere.virtual_disk.total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation from the virtual disk. Total latency = kernel latency + device latency.
- - `vsphere.virtual_disk.total_write_latency_ms` (*gauge*)<br>    The average time a write to the virtual disk takes.
- - `vsphere.virtual_disk.write_iosize` (*gauge*)<br>    Average write request size in bytes.
- - `vsphere.virtual_disk.write_kbs` (*gauge*)<br>    Rate of writing data to the virtual disk.
- - `vsphere.virtual_disk.write_latency_us` (*gauge*)<br>    Write latency in microseconds.
- - `vsphere.virtual_disk.write_load_metric` (*gauge*)<br>    Storage DRS virtual disk metric for the write workload model.
- - `vsphere.virtual_disk.write_oio` (*gauge*)<br>    Average number of outstanding write requests to the virtual disk during the collection interval.
+ - `vsphere.virtual_disk_large_seeks` (*gauge*)<br>    Number of seeks during the interval that were greater than 8192 LBNs apart.
+ - `vsphere.virtual_disk_medium_seeks` (*gauge*)<br>    Number of seeks during the interval that were between 64 and 8192 LBNs apart.
+ - `vsphere.virtual_disk_number_read_averaged` (*gauge*)<br>    Average number of read commands issued per second to the virtual disk during the collection interval.
+ - `vsphere.virtual_disk_number_write_averaged` (*gauge*)<br>    Average number of write commands issued per second to the virtual disk during the collection interval.
+ - `vsphere.virtual_disk_read_iosize` (*gauge*)<br>    Average read request size in bytes.
+ - ***`vsphere.virtual_disk_read_kbs`*** (*gauge*)<br>    Rate of reading data from the virtual disk.
+ - `vsphere.virtual_disk_read_latency_us` (*gauge*)<br>    Read latency in microseconds.
+ - `vsphere.virtual_disk_read_load_metric` (*gauge*)<br>    Storage DRS virtual disk metric for the read workload model.
+ - `vsphere.virtual_disk_read_oio` (*gauge*)<br>    Average number of outstanding read requests to the virtual disk during the collection interval.
+ - `vsphere.virtual_disk_small_seeks` (*gauge*)<br>    Number of seeks during the interval that were less than 64 LBNs apart.
+ - `vsphere.virtual_disk_total_read_latency_ms` (*gauge*)<br>    Average amount of time for a read operation from the virtual disk. Total latency = kernel latency + device latency.
+ - `vsphere.virtual_disk_total_write_latency_ms` (*gauge*)<br>    The average time a write to the virtual disk takes.
+ - `vsphere.virtual_disk_write_iosize` (*gauge*)<br>    Average write request size in bytes.
+ - ***`vsphere.virtual_disk_write_kbs`*** (*gauge*)<br>    Rate of writing data to the virtual disk.
+ - `vsphere.virtual_disk_write_latency_us` (*gauge*)<br>    Write latency in microseconds.
+ - `vsphere.virtual_disk_write_load_metric` (*gauge*)<br>    Storage DRS virtual disk metric for the write workload model.
+ - `vsphere.virtual_disk_write_oio` (*gauge*)<br>    Average number of outstanding write requests to the virtual disk during the collection interval.
 
 ### Non-default metrics (version 4.7.0+)
 

--- a/pkg/monitors/vsphere/genmetadata.go
+++ b/pkg/monitors/vsphere/genmetadata.go
@@ -46,6 +46,7 @@ const (
 	vsphereCPUDemandMhz                              = "vsphere.cpu_demand_mhz"
 	vsphereCPUEntitlementMhz                         = "vsphere.cpu_entitlement_mhz"
 	vsphereCPUIdleMs                                 = "vsphere.cpu_idle_ms"
+	vsphereCPULatencyPercent                         = "vsphere.cpu_latency_percent"
 	vsphereCPUMaxlimitedMs                           = "vsphere.cpu_maxlimited_ms"
 	vsphereCPUOverlapMs                              = "vsphere.cpu_overlap_ms"
 	vsphereCPUReadinessPercent                       = "vsphere.cpu_readiness_percent"
@@ -60,184 +61,183 @@ const (
 	vsphereCPUUsedPercent                            = "vsphere.cpu_used_percent"
 	vsphereCPUUtilizationPercent                     = "vsphere.cpu_utilization_percent"
 	vsphereCPUWaitMs                                 = "vsphere.cpu_wait_ms"
-	vsphereDatastoreDatastoreReadLoadMetric          = "vsphere.datastore.datastore_read_load_metric"
-	vsphereDatastoreDatastoreVmobservedLatencyMs     = "vsphere.datastore.datastore_vmobserved_latency_ms"
-	vsphereDatastoreDatastoreWriteLoadMetric         = "vsphere.datastore.datastore_write_load_metric"
-	vsphereDatastoreMaxTotalLatencyMs                = "vsphere.datastore.max_total_latency_ms"
-	vsphereDatastoreReadKbs                          = "vsphere.datastore.read_kbs"
-	vsphereDatastoreSizeNormalizedDatastoreLatencyMs = "vsphere.datastore.size_normalized_datastore_latency_ms"
-	vsphereDatastoreTotalReadLatencyMs               = "vsphere.datastore.total_read_latency_ms"
-	vsphereDatastoreTotalWriteLatencyMs              = "vsphere.datastore.total_write_latency_ms"
-	vsphereDatastoreWriteKbs                         = "vsphere.datastore.write_kbs"
-	vsphereDatastoreDatastoreIops                    = "vsphere.datastore_datastoreIops"
-	vsphereDiskBusResets                             = "vsphere.disk.bus_resets"
-	vsphereDiskCommands                              = "vsphere.disk.commands"
-	vsphereDiskCommandsAborted                       = "vsphere.disk.commands_aborted"
-	vsphereDiskCommandsAveraged                      = "vsphere.disk.commands_averaged"
-	vsphereDiskDeviceLatencyMs                       = "vsphere.disk.device_latency_ms"
-	vsphereDiskDeviceReadLatencyMs                   = "vsphere.disk.device_read_latency_ms"
-	vsphereDiskDeviceWriteLatencyMs                  = "vsphere.disk.device_write_latency_ms"
-	vsphereDiskKernelLatencyMs                       = "vsphere.disk.kernel_latency_ms"
-	vsphereDiskKernelReadLatencyMs                   = "vsphere.disk.kernel_read_latency_ms"
-	vsphereDiskKernelWriteLatencyMs                  = "vsphere.disk.kernel_write_latency_ms"
-	vsphereDiskMaxQueueDepth                         = "vsphere.disk.max_queue_depth"
-	vsphereDiskMaxTotalLatencyMs                     = "vsphere.disk.max_total_latency_ms"
-	vsphereDiskNumberRead                            = "vsphere.disk.number_read"
-	vsphereDiskNumberReadAveraged                    = "vsphere.disk.number_read_averaged"
-	vsphereDiskNumberWrite                           = "vsphere.disk.number_write"
-	vsphereDiskNumberWriteAveraged                   = "vsphere.disk.number_write_averaged"
-	vsphereDiskQueueLatencyMs                        = "vsphere.disk.queue_latency_ms"
-	vsphereDiskQueueReadLatencyMs                    = "vsphere.disk.queue_read_latency_ms"
-	vsphereDiskQueueWriteLatencyMs                   = "vsphere.disk.queue_write_latency_ms"
-	vsphereDiskReadKbs                               = "vsphere.disk.read_kbs"
-	vsphereDiskTotalLatencyMs                        = "vsphere.disk.total_latency_ms"
-	vsphereDiskTotalReadLatencyMs                    = "vsphere.disk.total_read_latency_ms"
-	vsphereDiskTotalWriteLatencyMs                   = "vsphere.disk.total_write_latency_ms"
-	vsphereDiskUsageKbs                              = "vsphere.disk.usage_kbs"
-	vsphereDiskWriteKbs                              = "vsphere.disk.write_kbs"
-	vsphereHbrHbrNetRxKbs                            = "vsphere.hbr.hbr_net_rx_kbs"
-	vsphereHbrHbrNetTxKbs                            = "vsphere.hbr.hbr_net_tx_kbs"
-	vsphereHbrHbrNumVms                              = "vsphere.hbr.hbr_num_vms"
-	vsphereMemActiveKb                               = "vsphere.mem.active_kb"
-	vsphereMemActivewriteKb                          = "vsphere.mem.activewrite_kb"
-	vsphereMemCompressedKb                           = "vsphere.mem.compressed_kb"
-	vsphereMemCompressionRateKbs                     = "vsphere.mem.compression_rate_kbs"
-	vsphereMemConsumedKb                             = "vsphere.mem.consumed_kb"
-	vsphereMemDecompressionRateKbs                   = "vsphere.mem.decompression_rate_kbs"
-	vsphereMemEntitlementKb                          = "vsphere.mem.entitlement_kb"
-	vsphereMemGrantedKb                              = "vsphere.mem.granted_kb"
-	vsphereMemHeapKb                                 = "vsphere.mem.heap_kb"
-	vsphereMemHeapfreeKb                             = "vsphere.mem.heapfree_kb"
-	vsphereMemLatencyPercent                         = "vsphere.mem.latency_percent"
-	vsphereMemLlSwapInKb                             = "vsphere.mem.ll_swap_in_kb"
-	vsphereMemLlSwapInRateKbs                        = "vsphere.mem.ll_swap_in_rate_kbs"
-	vsphereMemLlSwapOutKb                            = "vsphere.mem.ll_swap_out_kb"
-	vsphereMemLlSwapOutRateKbs                       = "vsphere.mem.ll_swap_out_rate_kbs"
-	vsphereMemLlSwapUsedKb                           = "vsphere.mem.ll_swap_used_kb"
-	vsphereMemLowfreethresholdKb                     = "vsphere.mem.lowfreethreshold_kb"
-	vsphereMemOverheadKb                             = "vsphere.mem.overhead_kb"
-	vsphereMemOverheadMaxKb                          = "vsphere.mem.overhead_max_kb"
-	vsphereMemOverheadTouchedKb                      = "vsphere.mem.overhead_touched_kb"
-	vsphereMemReservedCapacityMb                     = "vsphere.mem.reserved_capacity_mb"
-	vsphereMemSharedKb                               = "vsphere.mem.shared_kb"
-	vsphereMemSharedcommonKb                         = "vsphere.mem.sharedcommon_kb"
-	vsphereMemState                                  = "vsphere.mem.state"
-	vsphereMemSwapinKb                               = "vsphere.mem.swapin_kb"
-	vsphereMemSwapinRateKbs                          = "vsphere.mem.swapin_rate_kbs"
-	vsphereMemSwapoutKb                              = "vsphere.mem.swapout_kb"
-	vsphereMemSwapoutRateKbs                         = "vsphere.mem.swapout_rate_kbs"
-	vsphereMemSwappedKb                              = "vsphere.mem.swapped_kb"
-	vsphereMemSwaptargetKb                           = "vsphere.mem.swaptarget_kb"
-	vsphereMemSwapusedKb                             = "vsphere.mem.swapused_kb"
-	vsphereMemSysUsageKb                             = "vsphere.mem.sys_usage_kb"
-	vsphereMemTotalCapacityMb                        = "vsphere.mem.total_capacity_mb"
-	vsphereMemUnreservedKb                           = "vsphere.mem.unreserved_kb"
-	vsphereMemUsagePercent                           = "vsphere.mem.usage_percent"
-	vsphereMemVmfsPbcCapMissRatioPercent             = "vsphere.mem.vmfs_pbc_cap_miss_ratio_percent"
-	vsphereMemVmfsPbcOverheadKb                      = "vsphere.mem.vmfs_pbc_overhead_kb"
-	vsphereMemVmfsPbcSizeMaxMb                       = "vsphere.mem.vmfs_pbc_size_max_mb"
-	vsphereMemVmfsPbcSizeMb                          = "vsphere.mem.vmfs_pbc_size_mb"
-	vsphereMemVmfsPbcWorkingSetMaxTb                 = "vsphere.mem.vmfs_pbc_working_set_max_tb"
-	vsphereMemVmfsPbcWorkingSetTb                    = "vsphere.mem.vmfs_pbc_working_set_tb"
-	vsphereMemVmmemctlKb                             = "vsphere.mem.vmmemctl_kb"
-	vsphereMemVmmemctltargetKb                       = "vsphere.mem.vmmemctltarget_kb"
-	vsphereMemZeroKb                                 = "vsphere.mem.zero_kb"
-	vsphereMemZipSavedKb                             = "vsphere.mem.zip_saved_kb"
-	vsphereMemZippedKb                               = "vsphere.mem.zipped_kb"
-	vsphereNetBroadcastRx                            = "vsphere.net.broadcast_rx"
-	vsphereNetBroadcastTx                            = "vsphere.net.broadcast_tx"
-	vsphereNetBytesRxKbs                             = "vsphere.net.bytes_rx_kbs"
-	vsphereNetBytesTxKbs                             = "vsphere.net.bytes_tx_kbs"
-	vsphereNetDroppedRx                              = "vsphere.net.dropped_rx"
-	vsphereNetDroppedTx                              = "vsphere.net.dropped_tx"
-	vsphereNetErrorsRx                               = "vsphere.net.errors_rx"
-	vsphereNetErrorsTx                               = "vsphere.net.errors_tx"
-	vsphereNetMulticastRx                            = "vsphere.net.multicast_rx"
-	vsphereNetMulticastTx                            = "vsphere.net.multicast_tx"
-	vsphereNetPacketsRx                              = "vsphere.net.packets_rx"
-	vsphereNetPacketsTx                              = "vsphere.net.packets_tx"
-	vsphereNetReceivedKbs                            = "vsphere.net.received_kbs"
-	vsphereNetTransmittedKbs                         = "vsphere.net.transmitted_kbs"
-	vsphereNetUnknownProtos                          = "vsphere.net.unknown_protos"
-	vsphereNetUsageKbs                               = "vsphere.net.usage_kbs"
-	vspherePowerEnergyJoules                         = "vsphere.power.energy_joules"
-	vspherePowerPowerCapWatts                        = "vsphere.power.power_cap_watts"
-	vspherePowerPowerWatts                           = "vsphere.power.power_watts"
-	vsphereRescpuActav1                              = "vsphere.rescpu.actav1"
-	vsphereRescpuActav15Percent                      = "vsphere.rescpu.actav15_percent"
-	vsphereRescpuActav5Percent                       = "vsphere.rescpu.actav5_percent"
-	vsphereRescpuActpk15Percent                      = "vsphere.rescpu.actpk15_percent"
-	vsphereRescpuActpk1Percent                       = "vsphere.rescpu.actpk1_percent"
-	vsphereRescpuActpk5Percent                       = "vsphere.rescpu.actpk5_percent"
-	vsphereRescpuMaxLimited15Percent                 = "vsphere.rescpu.max_limited15_percent"
-	vsphereRescpuMaxLimited1Percent                  = "vsphere.rescpu.max_limited1_percent"
-	vsphereRescpuMaxLimited5Percent                  = "vsphere.rescpu.max_limited5_percent"
-	vsphereRescpuRunav15Percent                      = "vsphere.rescpu.runav15_percent"
-	vsphereRescpuRunav1Percent                       = "vsphere.rescpu.runav1_percent"
-	vsphereRescpuRunav5Percent                       = "vsphere.rescpu.runav5_percent"
-	vsphereRescpuRunpk15Percent                      = "vsphere.rescpu.runpk15_percent"
-	vsphereRescpuRunpk1Percent                       = "vsphere.rescpu.runpk1_percent"
-	vsphereRescpuRunpk5Percent                       = "vsphere.rescpu.runpk5_percent"
-	vsphereRescpuSampleCount                         = "vsphere.rescpu.sample_count"
-	vsphereRescpuSamplePeriodMs                      = "vsphere.rescpu.sample_period_ms"
-	vsphereStorageAdapterCommandsAveraged            = "vsphere.storage_adapter.commands_averaged"
-	vsphereStorageAdapterMaxTotalLatencyMs           = "vsphere.storage_adapter.max_total_latency_ms"
-	vsphereStorageAdapterNumberReadAveraged          = "vsphere.storage_adapter.number_read_averaged"
-	vsphereStorageAdapterNumberWriteAveraged         = "vsphere.storage_adapter.number_write_averaged"
-	vsphereStorageAdapterReadKbs                     = "vsphere.storage_adapter.read_kbs"
-	vsphereStorageAdapterTotalReadLatencyMs          = "vsphere.storage_adapter.total_read_latency_ms"
-	vsphereStorageAdapterTotalWriteLatencyMs         = "vsphere.storage_adapter.total_write_latency_ms"
-	vsphereStorageAdapterWriteKbs                    = "vsphere.storage_adapter.write_kbs"
-	vsphereStoragePathCommandsAveraged               = "vsphere.storage_path.commands_averaged"
-	vsphereStoragePathMaxTotalLatencyMs              = "vsphere.storage_path.max_total_latency_ms"
-	vsphereStoragePathNumberReadAveraged             = "vsphere.storage_path.number_read_averaged"
-	vsphereStoragePathNumberWriteAveraged            = "vsphere.storage_path.number_write_averaged"
-	vsphereStoragePathReadKbs                        = "vsphere.storage_path.read_kbs"
-	vsphereStoragePathTotalReadLatencyMs             = "vsphere.storage_path.total_read_latency_ms"
-	vsphereStoragePathTotalWriteLatencyMs            = "vsphere.storage_path.total_write_latency_ms"
-	vsphereStoragePathWriteKbs                       = "vsphere.storage_path.write_kbs"
-	vsphereSysHeartbeat                              = "vsphere.sys.heartbeat"
-	vsphereSysOsUptimeSeconds                        = "vsphere.sys.os_uptime_seconds"
-	vsphereSysResourceCPUAct1Percent                 = "vsphere.sys.resource_cpu_act1_percent"
-	vsphereSysResourceCPUAct5                        = "vsphere.sys.resource_cpu_act5"
-	vsphereSysResourceCPUAllocMinMhz                 = "vsphere.sys.resource_cpu_alloc_min_mhz"
-	vsphereSysResourceCPUAllocShares                 = "vsphere.sys.resource_cpu_alloc_shares"
-	vsphereSysResourceCPUMaxLimited1Percent          = "vsphere.sys.resource_cpu_max_limited1_percent"
-	vsphereSysResourceCPUMaxLimited5Percent          = "vsphere.sys.resource_cpu_max_limited5_percent"
-	vsphereSysResourceCPURun1Percent                 = "vsphere.sys.resource_cpu_run1_percent"
-	vsphereSysResourceCPURun5Percent                 = "vsphere.sys.resource_cpu_run5_percent"
-	vsphereSysResourceCPUUsageMhz                    = "vsphere.sys.resource_cpu_usage_mhz"
-	vsphereSysResourceFdUsage                        = "vsphere.sys.resource_fd_usage"
-	vsphereSysResourceMemAllocMaxKb                  = "vsphere.sys.resource_mem_alloc_max_kb"
-	vsphereSysResourceMemAllocMinKb                  = "vsphere.sys.resource_mem_alloc_min_kb"
-	vsphereSysResourceMemAllocShares                 = "vsphere.sys.resource_mem_alloc_shares"
-	vsphereSysResourceMemConsumedKb                  = "vsphere.sys.resource_mem_consumed_kb"
-	vsphereSysResourceMemCowKb                       = "vsphere.sys.resource_mem_cow_kb"
-	vsphereSysResourceMemMappedKb                    = "vsphere.sys.resource_mem_mapped_kb"
-	vsphereSysResourceMemOverheadKb                  = "vsphere.sys.resource_mem_overhead_kb"
-	vsphereSysResourceMemSharedKb                    = "vsphere.sys.resource_mem_shared_kb"
-	vsphereSysResourceMemSwappedKb                   = "vsphere.sys.resource_mem_swapped_kb"
-	vsphereSysResourceMemTouchedKb                   = "vsphere.sys.resource_mem_touched_kb"
-	vsphereSysResourceMemZeroKb                      = "vsphere.sys.resource_mem_zero_kb"
-	vsphereSysUptimeSeconds                          = "vsphere.sys.uptime_seconds"
-	vsphereVirtualDiskLargeSeeks                     = "vsphere.virtual_disk.large_seeks"
-	vsphereVirtualDiskMediumSeeks                    = "vsphere.virtual_disk.medium_seeks"
-	vsphereVirtualDiskNumberReadAveraged             = "vsphere.virtual_disk.number_read_averaged"
-	vsphereVirtualDiskNumberWriteAveraged            = "vsphere.virtual_disk.number_write_averaged"
-	vsphereVirtualDiskReadIosize                     = "vsphere.virtual_disk.read_iosize"
-	vsphereVirtualDiskReadKbs                        = "vsphere.virtual_disk.read_kbs"
-	vsphereVirtualDiskReadLatencyUs                  = "vsphere.virtual_disk.read_latency_us"
-	vsphereVirtualDiskReadLoadMetric                 = "vsphere.virtual_disk.read_load_metric"
-	vsphereVirtualDiskReadOio                        = "vsphere.virtual_disk.read_oio"
-	vsphereVirtualDiskSmallSeeks                     = "vsphere.virtual_disk.small_seeks"
-	vsphereVirtualDiskTotalReadLatencyMs             = "vsphere.virtual_disk.total_read_latency_ms"
-	vsphereVirtualDiskTotalWriteLatencyMs            = "vsphere.virtual_disk.total_write_latency_ms"
-	vsphereVirtualDiskWriteIosize                    = "vsphere.virtual_disk.write_iosize"
-	vsphereVirtualDiskWriteKbs                       = "vsphere.virtual_disk.write_kbs"
-	vsphereVirtualDiskWriteLatencyUs                 = "vsphere.virtual_disk.write_latency_us"
-	vsphereVirtualDiskWriteLoadMetric                = "vsphere.virtual_disk.write_load_metric"
-	vsphereVirtualDiskWriteOio                       = "vsphere.virtual_disk.write_oio"
-	vsphereCPULatencyPercent                         = "vsphere_cpu_latency_percent"
+	vsphereDatastoreDatastoreIops                    = "vsphere.datastore_datastore_iops"
+	vsphereDatastoreMaxTotalLatencyMs                = "vsphere.datastore_max_total_latency_ms"
+	vsphereDatastoreReadKbs                          = "vsphere.datastore_read_kbs"
+	vsphereDatastoreReadLoadMetric                   = "vsphere.datastore_read_load_metric"
+	vsphereDatastoreSizeNormalizedDatastoreLatencyMs = "vsphere.datastore_size_normalized_datastore_latency_ms"
+	vsphereDatastoreTotalReadLatencyMs               = "vsphere.datastore_total_read_latency_ms"
+	vsphereDatastoreTotalWriteLatencyMs              = "vsphere.datastore_total_write_latency_ms"
+	vsphereDatastoreVmobservedLatencyMs              = "vsphere.datastore_vmobserved_latency_ms"
+	vsphereDatastoreWriteKbs                         = "vsphere.datastore_write_kbs"
+	vsphereDatastoreWriteLoadMetric                  = "vsphere.datastore_write_load_metric"
+	vsphereDiskBusResets                             = "vsphere.disk_bus_resets"
+	vsphereDiskCommands                              = "vsphere.disk_commands"
+	vsphereDiskCommandsAborted                       = "vsphere.disk_commands_aborted"
+	vsphereDiskCommandsAveraged                      = "vsphere.disk_commands_averaged"
+	vsphereDiskDeviceLatencyMs                       = "vsphere.disk_device_latency_ms"
+	vsphereDiskDeviceReadLatencyMs                   = "vsphere.disk_device_read_latency_ms"
+	vsphereDiskDeviceWriteLatencyMs                  = "vsphere.disk_device_write_latency_ms"
+	vsphereDiskKernelLatencyMs                       = "vsphere.disk_kernel_latency_ms"
+	vsphereDiskKernelReadLatencyMs                   = "vsphere.disk_kernel_read_latency_ms"
+	vsphereDiskKernelWriteLatencyMs                  = "vsphere.disk_kernel_write_latency_ms"
+	vsphereDiskMaxQueueDepth                         = "vsphere.disk_max_queue_depth"
+	vsphereDiskMaxTotalLatencyMs                     = "vsphere.disk_max_total_latency_ms"
+	vsphereDiskNumberRead                            = "vsphere.disk_number_read"
+	vsphereDiskNumberReadAveraged                    = "vsphere.disk_number_read_averaged"
+	vsphereDiskNumberWrite                           = "vsphere.disk_number_write"
+	vsphereDiskNumberWriteAveraged                   = "vsphere.disk_number_write_averaged"
+	vsphereDiskQueueLatencyMs                        = "vsphere.disk_queue_latency_ms"
+	vsphereDiskQueueReadLatencyMs                    = "vsphere.disk_queue_read_latency_ms"
+	vsphereDiskQueueWriteLatencyMs                   = "vsphere.disk_queue_write_latency_ms"
+	vsphereDiskReadKbs                               = "vsphere.disk_read_kbs"
+	vsphereDiskTotalLatencyMs                        = "vsphere.disk_total_latency_ms"
+	vsphereDiskTotalReadLatencyMs                    = "vsphere.disk_total_read_latency_ms"
+	vsphereDiskTotalWriteLatencyMs                   = "vsphere.disk_total_write_latency_ms"
+	vsphereDiskUsageKbs                              = "vsphere.disk_usage_kbs"
+	vsphereDiskWriteKbs                              = "vsphere.disk_write_kbs"
+	vsphereHbrNetRxKbs                               = "vsphere.hbr_net_rx_kbs"
+	vsphereHbrNetTxKbs                               = "vsphere.hbr_net_tx_kbs"
+	vsphereHbrNumVms                                 = "vsphere.hbr_num_vms"
+	vsphereMemActiveKb                               = "vsphere.mem_active_kb"
+	vsphereMemActivewriteKb                          = "vsphere.mem_activewrite_kb"
+	vsphereMemCompressedKb                           = "vsphere.mem_compressed_kb"
+	vsphereMemCompressionRateKbs                     = "vsphere.mem_compression_rate_kbs"
+	vsphereMemConsumedKb                             = "vsphere.mem_consumed_kb"
+	vsphereMemDecompressionRateKbs                   = "vsphere.mem_decompression_rate_kbs"
+	vsphereMemEntitlementKb                          = "vsphere.mem_entitlement_kb"
+	vsphereMemGrantedKb                              = "vsphere.mem_granted_kb"
+	vsphereMemHeapKb                                 = "vsphere.mem_heap_kb"
+	vsphereMemHeapfreeKb                             = "vsphere.mem_heapfree_kb"
+	vsphereMemLatencyPercent                         = "vsphere.mem_latency_percent"
+	vsphereMemLlSwapInKb                             = "vsphere.mem_ll_swap_in_kb"
+	vsphereMemLlSwapInRateKbs                        = "vsphere.mem_ll_swap_in_rate_kbs"
+	vsphereMemLlSwapOutKb                            = "vsphere.mem_ll_swap_out_kb"
+	vsphereMemLlSwapOutRateKbs                       = "vsphere.mem_ll_swap_out_rate_kbs"
+	vsphereMemLlSwapUsedKb                           = "vsphere.mem_ll_swap_used_kb"
+	vsphereMemLowfreethresholdKb                     = "vsphere.mem_lowfreethreshold_kb"
+	vsphereMemOverheadKb                             = "vsphere.mem_overhead_kb"
+	vsphereMemOverheadMaxKb                          = "vsphere.mem_overhead_max_kb"
+	vsphereMemOverheadTouchedKb                      = "vsphere.mem_overhead_touched_kb"
+	vsphereMemReservedCapacityMb                     = "vsphere.mem_reserved_capacity_mb"
+	vsphereMemSharedKb                               = "vsphere.mem_shared_kb"
+	vsphereMemSharedcommonKb                         = "vsphere.mem_sharedcommon_kb"
+	vsphereMemState                                  = "vsphere.mem_state"
+	vsphereMemSwapinKb                               = "vsphere.mem_swapin_kb"
+	vsphereMemSwapinRateKbs                          = "vsphere.mem_swapin_rate_kbs"
+	vsphereMemSwapoutKb                              = "vsphere.mem_swapout_kb"
+	vsphereMemSwapoutRateKbs                         = "vsphere.mem_swapout_rate_kbs"
+	vsphereMemSwappedKb                              = "vsphere.mem_swapped_kb"
+	vsphereMemSwaptargetKb                           = "vsphere.mem_swaptarget_kb"
+	vsphereMemSwapusedKb                             = "vsphere.mem_swapused_kb"
+	vsphereMemSysUsageKb                             = "vsphere.mem_sys_usage_kb"
+	vsphereMemTotalCapacityMb                        = "vsphere.mem_total_capacity_mb"
+	vsphereMemUnreservedKb                           = "vsphere.mem_unreserved_kb"
+	vsphereMemUsagePercent                           = "vsphere.mem_usage_percent"
+	vsphereMemVmfsPbcCapMissRatioPercent             = "vsphere.mem_vmfs_pbc_cap_miss_ratio_percent"
+	vsphereMemVmfsPbcOverheadKb                      = "vsphere.mem_vmfs_pbc_overhead_kb"
+	vsphereMemVmfsPbcSizeMaxMb                       = "vsphere.mem_vmfs_pbc_size_max_mb"
+	vsphereMemVmfsPbcSizeMb                          = "vsphere.mem_vmfs_pbc_size_mb"
+	vsphereMemVmfsPbcWorkingSetMaxTb                 = "vsphere.mem_vmfs_pbc_working_set_max_tb"
+	vsphereMemVmfsPbcWorkingSetTb                    = "vsphere.mem_vmfs_pbc_working_set_tb"
+	vsphereMemVmmemctlKb                             = "vsphere.mem_vmmemctl_kb"
+	vsphereMemVmmemctltargetKb                       = "vsphere.mem_vmmemctltarget_kb"
+	vsphereMemZeroKb                                 = "vsphere.mem_zero_kb"
+	vsphereMemZipSavedKb                             = "vsphere.mem_zip_saved_kb"
+	vsphereMemZippedKb                               = "vsphere.mem_zipped_kb"
+	vsphereNetBroadcastRx                            = "vsphere.net_broadcast_rx"
+	vsphereNetBroadcastTx                            = "vsphere.net_broadcast_tx"
+	vsphereNetBytesRxKbs                             = "vsphere.net_bytes_rx_kbs"
+	vsphereNetBytesTxKbs                             = "vsphere.net_bytes_tx_kbs"
+	vsphereNetDroppedRx                              = "vsphere.net_dropped_rx"
+	vsphereNetDroppedTx                              = "vsphere.net_dropped_tx"
+	vsphereNetErrorsRx                               = "vsphere.net_errors_rx"
+	vsphereNetErrorsTx                               = "vsphere.net_errors_tx"
+	vsphereNetMulticastRx                            = "vsphere.net_multicast_rx"
+	vsphereNetMulticastTx                            = "vsphere.net_multicast_tx"
+	vsphereNetPacketsRx                              = "vsphere.net_packets_rx"
+	vsphereNetPacketsTx                              = "vsphere.net_packets_tx"
+	vsphereNetReceivedKbs                            = "vsphere.net_received_kbs"
+	vsphereNetTransmittedKbs                         = "vsphere.net_transmitted_kbs"
+	vsphereNetUnknownProtos                          = "vsphere.net_unknown_protos"
+	vsphereNetUsageKbs                               = "vsphere.net_usage_kbs"
+	vspherePowerCapWatts                             = "vsphere.power_cap_watts"
+	vspherePowerEnergyJoules                         = "vsphere.power_energy_joules"
+	vspherePowerWatts                                = "vsphere.power_watts"
+	vsphereRescpuActav1                              = "vsphere.rescpu_actav1"
+	vsphereRescpuActav15Percent                      = "vsphere.rescpu_actav15_percent"
+	vsphereRescpuActav5Percent                       = "vsphere.rescpu_actav5_percent"
+	vsphereRescpuActpk15Percent                      = "vsphere.rescpu_actpk15_percent"
+	vsphereRescpuActpk1Percent                       = "vsphere.rescpu_actpk1_percent"
+	vsphereRescpuActpk5Percent                       = "vsphere.rescpu_actpk5_percent"
+	vsphereRescpuMaxLimited15Percent                 = "vsphere.rescpu_max_limited15_percent"
+	vsphereRescpuMaxLimited1Percent                  = "vsphere.rescpu_max_limited1_percent"
+	vsphereRescpuMaxLimited5Percent                  = "vsphere.rescpu_max_limited5_percent"
+	vsphereRescpuRunav15Percent                      = "vsphere.rescpu_runav15_percent"
+	vsphereRescpuRunav1Percent                       = "vsphere.rescpu_runav1_percent"
+	vsphereRescpuRunav5Percent                       = "vsphere.rescpu_runav5_percent"
+	vsphereRescpuRunpk15Percent                      = "vsphere.rescpu_runpk15_percent"
+	vsphereRescpuRunpk1Percent                       = "vsphere.rescpu_runpk1_percent"
+	vsphereRescpuRunpk5Percent                       = "vsphere.rescpu_runpk5_percent"
+	vsphereRescpuSampleCount                         = "vsphere.rescpu_sample_count"
+	vsphereRescpuSamplePeriodMs                      = "vsphere.rescpu_sample_period_ms"
+	vsphereStorageAdapterCommandsAveraged            = "vsphere.storage_adapter_commands_averaged"
+	vsphereStorageAdapterMaxTotalLatencyMs           = "vsphere.storage_adapter_max_total_latency_ms"
+	vsphereStorageAdapterNumberReadAveraged          = "vsphere.storage_adapter_number_read_averaged"
+	vsphereStorageAdapterNumberWriteAveraged         = "vsphere.storage_adapter_number_write_averaged"
+	vsphereStorageAdapterReadKbs                     = "vsphere.storage_adapter_read_kbs"
+	vsphereStorageAdapterTotalReadLatencyMs          = "vsphere.storage_adapter_total_read_latency_ms"
+	vsphereStorageAdapterTotalWriteLatencyMs         = "vsphere.storage_adapter_total_write_latency_ms"
+	vsphereStorageAdapterWriteKbs                    = "vsphere.storage_adapter_write_kbs"
+	vsphereStoragePathCommandsAveraged               = "vsphere.storage_path_commands_averaged"
+	vsphereStoragePathMaxTotalLatencyMs              = "vsphere.storage_path_max_total_latency_ms"
+	vsphereStoragePathNumberReadAveraged             = "vsphere.storage_path_number_read_averaged"
+	vsphereStoragePathNumberWriteAveraged            = "vsphere.storage_path_number_write_averaged"
+	vsphereStoragePathReadKbs                        = "vsphere.storage_path_read_kbs"
+	vsphereStoragePathTotalReadLatencyMs             = "vsphere.storage_path_total_read_latency_ms"
+	vsphereStoragePathTotalWriteLatencyMs            = "vsphere.storage_path_total_write_latency_ms"
+	vsphereStoragePathWriteKbs                       = "vsphere.storage_path_write_kbs"
+	vsphereSysHeartbeat                              = "vsphere.sys_heartbeat"
+	vsphereSysOsUptimeSeconds                        = "vsphere.sys_os_uptime_seconds"
+	vsphereSysResourceCPUAct1Percent                 = "vsphere.sys_resource_cpu_act1_percent"
+	vsphereSysResourceCPUAct5                        = "vsphere.sys_resource_cpu_act5"
+	vsphereSysResourceCPUAllocMinMhz                 = "vsphere.sys_resource_cpu_alloc_min_mhz"
+	vsphereSysResourceCPUAllocShares                 = "vsphere.sys_resource_cpu_alloc_shares"
+	vsphereSysResourceCPUMaxLimited1Percent          = "vsphere.sys_resource_cpu_max_limited1_percent"
+	vsphereSysResourceCPUMaxLimited5Percent          = "vsphere.sys_resource_cpu_max_limited5_percent"
+	vsphereSysResourceCPURun1Percent                 = "vsphere.sys_resource_cpu_run1_percent"
+	vsphereSysResourceCPURun5Percent                 = "vsphere.sys_resource_cpu_run5_percent"
+	vsphereSysResourceCPUUsageMhz                    = "vsphere.sys_resource_cpu_usage_mhz"
+	vsphereSysResourceFdUsage                        = "vsphere.sys_resource_fd_usage"
+	vsphereSysResourceMemAllocMaxKb                  = "vsphere.sys_resource_mem_alloc_max_kb"
+	vsphereSysResourceMemAllocMinKb                  = "vsphere.sys_resource_mem_alloc_min_kb"
+	vsphereSysResourceMemAllocShares                 = "vsphere.sys_resource_mem_alloc_shares"
+	vsphereSysResourceMemConsumedKb                  = "vsphere.sys_resource_mem_consumed_kb"
+	vsphereSysResourceMemCowKb                       = "vsphere.sys_resource_mem_cow_kb"
+	vsphereSysResourceMemMappedKb                    = "vsphere.sys_resource_mem_mapped_kb"
+	vsphereSysResourceMemOverheadKb                  = "vsphere.sys_resource_mem_overhead_kb"
+	vsphereSysResourceMemSharedKb                    = "vsphere.sys_resource_mem_shared_kb"
+	vsphereSysResourceMemSwappedKb                   = "vsphere.sys_resource_mem_swapped_kb"
+	vsphereSysResourceMemTouchedKb                   = "vsphere.sys_resource_mem_touched_kb"
+	vsphereSysResourceMemZeroKb                      = "vsphere.sys_resource_mem_zero_kb"
+	vsphereSysUptimeSeconds                          = "vsphere.sys_uptime_seconds"
+	vsphereVirtualDiskLargeSeeks                     = "vsphere.virtual_disk_large_seeks"
+	vsphereVirtualDiskMediumSeeks                    = "vsphere.virtual_disk_medium_seeks"
+	vsphereVirtualDiskNumberReadAveraged             = "vsphere.virtual_disk_number_read_averaged"
+	vsphereVirtualDiskNumberWriteAveraged            = "vsphere.virtual_disk_number_write_averaged"
+	vsphereVirtualDiskReadIosize                     = "vsphere.virtual_disk_read_iosize"
+	vsphereVirtualDiskReadKbs                        = "vsphere.virtual_disk_read_kbs"
+	vsphereVirtualDiskReadLatencyUs                  = "vsphere.virtual_disk_read_latency_us"
+	vsphereVirtualDiskReadLoadMetric                 = "vsphere.virtual_disk_read_load_metric"
+	vsphereVirtualDiskReadOio                        = "vsphere.virtual_disk_read_oio"
+	vsphereVirtualDiskSmallSeeks                     = "vsphere.virtual_disk_small_seeks"
+	vsphereVirtualDiskTotalReadLatencyMs             = "vsphere.virtual_disk_total_read_latency_ms"
+	vsphereVirtualDiskTotalWriteLatencyMs            = "vsphere.virtual_disk_total_write_latency_ms"
+	vsphereVirtualDiskWriteIosize                    = "vsphere.virtual_disk_write_iosize"
+	vsphereVirtualDiskWriteKbs                       = "vsphere.virtual_disk_write_kbs"
+	vsphereVirtualDiskWriteLatencyUs                 = "vsphere.virtual_disk_write_latency_us"
+	vsphereVirtualDiskWriteLoadMetric                = "vsphere.virtual_disk_write_load_metric"
+	vsphereVirtualDiskWriteOio                       = "vsphere.virtual_disk_write_oio"
 )
 
 var metricSet = map[string]monitors.MetricInfo{
@@ -247,6 +247,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	vsphereCPUDemandMhz:                              {Type: datapoint.Count, Group: groupCPU},
 	vsphereCPUEntitlementMhz:                         {Type: datapoint.Gauge, Group: groupCPU},
 	vsphereCPUIdleMs:                                 {Type: datapoint.Count, Group: groupCPU},
+	vsphereCPULatencyPercent:                         {Type: datapoint.Gauge, Group: groupCPU},
 	vsphereCPUMaxlimitedMs:                           {Type: datapoint.Count, Group: groupCPU},
 	vsphereCPUOverlapMs:                              {Type: datapoint.Count, Group: groupCPU},
 	vsphereCPUReadinessPercent:                       {Type: datapoint.Gauge, Group: groupCPU},
@@ -261,16 +262,16 @@ var metricSet = map[string]monitors.MetricInfo{
 	vsphereCPUUsedPercent:                            {Type: datapoint.Count, Group: groupCPU},
 	vsphereCPUUtilizationPercent:                     {Type: datapoint.Gauge, Group: groupCPU},
 	vsphereCPUWaitMs:                                 {Type: datapoint.Count, Group: groupCPU},
-	vsphereDatastoreDatastoreReadLoadMetric:          {Type: datapoint.Gauge, Group: groupDatastore},
-	vsphereDatastoreDatastoreVmobservedLatencyMs:     {Type: datapoint.Gauge, Group: groupDatastore},
-	vsphereDatastoreDatastoreWriteLoadMetric:         {Type: datapoint.Gauge, Group: groupDatastore},
+	vsphereDatastoreDatastoreIops:                    {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreMaxTotalLatencyMs:                {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreReadKbs:                          {Type: datapoint.Gauge, Group: groupDatastore},
+	vsphereDatastoreReadLoadMetric:                   {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreSizeNormalizedDatastoreLatencyMs: {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreTotalReadLatencyMs:               {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreTotalWriteLatencyMs:              {Type: datapoint.Gauge, Group: groupDatastore},
+	vsphereDatastoreVmobservedLatencyMs:              {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDatastoreWriteKbs:                         {Type: datapoint.Gauge, Group: groupDatastore},
-	vsphereDatastoreDatastoreIops:                    {Type: datapoint.Gauge, Group: groupDatastore},
+	vsphereDatastoreWriteLoadMetric:                  {Type: datapoint.Gauge, Group: groupDatastore},
 	vsphereDiskBusResets:                             {Type: datapoint.Count, Group: groupDisk},
 	vsphereDiskCommands:                              {Type: datapoint.Count, Group: groupDisk},
 	vsphereDiskCommandsAborted:                       {Type: datapoint.Count, Group: groupDisk},
@@ -296,9 +297,9 @@ var metricSet = map[string]monitors.MetricInfo{
 	vsphereDiskTotalWriteLatencyMs:                   {Type: datapoint.Gauge, Group: groupDisk},
 	vsphereDiskUsageKbs:                              {Type: datapoint.Gauge, Group: groupDisk},
 	vsphereDiskWriteKbs:                              {Type: datapoint.Gauge, Group: groupDisk},
-	vsphereHbrHbrNetRxKbs:                            {Type: datapoint.Gauge, Group: groupHbr},
-	vsphereHbrHbrNetTxKbs:                            {Type: datapoint.Gauge, Group: groupHbr},
-	vsphereHbrHbrNumVms:                              {Type: datapoint.Gauge, Group: groupHbr},
+	vsphereHbrNetRxKbs:                               {Type: datapoint.Gauge, Group: groupHbr},
+	vsphereHbrNetTxKbs:                               {Type: datapoint.Gauge, Group: groupHbr},
+	vsphereHbrNumVms:                                 {Type: datapoint.Gauge, Group: groupHbr},
 	vsphereMemActiveKb:                               {Type: datapoint.Gauge, Group: groupMem},
 	vsphereMemActivewriteKb:                          {Type: datapoint.Gauge, Group: groupMem},
 	vsphereMemCompressedKb:                           {Type: datapoint.Gauge, Group: groupMem},
@@ -361,9 +362,9 @@ var metricSet = map[string]monitors.MetricInfo{
 	vsphereNetTransmittedKbs:                         {Type: datapoint.Gauge, Group: groupNet},
 	vsphereNetUnknownProtos:                          {Type: datapoint.Count, Group: groupNet},
 	vsphereNetUsageKbs:                               {Type: datapoint.Gauge, Group: groupNet},
+	vspherePowerCapWatts:                             {Type: datapoint.Gauge, Group: groupPower},
 	vspherePowerEnergyJoules:                         {Type: datapoint.Count, Group: groupPower},
-	vspherePowerPowerCapWatts:                        {Type: datapoint.Gauge, Group: groupPower},
-	vspherePowerPowerWatts:                           {Type: datapoint.Gauge, Group: groupPower},
+	vspherePowerWatts:                                {Type: datapoint.Gauge, Group: groupPower},
 	vsphereRescpuActav1:                              {Type: datapoint.Gauge, Group: groupRescpu},
 	vsphereRescpuActav15Percent:                      {Type: datapoint.Gauge, Group: groupRescpu},
 	vsphereRescpuActav5Percent:                       {Type: datapoint.Gauge, Group: groupRescpu},
@@ -438,10 +439,21 @@ var metricSet = map[string]monitors.MetricInfo{
 	vsphereVirtualDiskWriteLatencyUs:                 {Type: datapoint.Gauge, Group: groupVirtualDisk},
 	vsphereVirtualDiskWriteLoadMetric:                {Type: datapoint.Gauge, Group: groupVirtualDisk},
 	vsphereVirtualDiskWriteOio:                       {Type: datapoint.Gauge, Group: groupVirtualDisk},
-	vsphereCPULatencyPercent:                         {Type: datapoint.Gauge, Group: groupCPU},
 }
 
-var defaultMetrics = map[string]bool{}
+var defaultMetrics = map[string]bool{
+	vsphereCPUUsagePercent:       true,
+	vsphereDiskMaxQueueDepth:     true,
+	vsphereDiskMaxTotalLatencyMs: true,
+	vsphereDiskUsageKbs:          true,
+	vsphereMemSwapinRateKbs:      true,
+	vsphereMemSwapoutRateKbs:     true,
+	vsphereMemUsagePercent:       true,
+	vsphereNetReceivedKbs:        true,
+	vsphereNetTransmittedKbs:     true,
+	vsphereVirtualDiskReadKbs:    true,
+	vsphereVirtualDiskWriteKbs:   true,
+}
 
 var groupMetricsMap = map[string][]string{
 	groupCPU: []string{
@@ -451,6 +463,7 @@ var groupMetricsMap = map[string][]string{
 		vsphereCPUDemandMhz,
 		vsphereCPUEntitlementMhz,
 		vsphereCPUIdleMs,
+		vsphereCPULatencyPercent,
 		vsphereCPUMaxlimitedMs,
 		vsphereCPUOverlapMs,
 		vsphereCPUReadinessPercent,
@@ -465,19 +478,18 @@ var groupMetricsMap = map[string][]string{
 		vsphereCPUUsedPercent,
 		vsphereCPUUtilizationPercent,
 		vsphereCPUWaitMs,
-		vsphereCPULatencyPercent,
 	},
 	groupDatastore: []string{
-		vsphereDatastoreDatastoreReadLoadMetric,
-		vsphereDatastoreDatastoreVmobservedLatencyMs,
-		vsphereDatastoreDatastoreWriteLoadMetric,
+		vsphereDatastoreDatastoreIops,
 		vsphereDatastoreMaxTotalLatencyMs,
 		vsphereDatastoreReadKbs,
+		vsphereDatastoreReadLoadMetric,
 		vsphereDatastoreSizeNormalizedDatastoreLatencyMs,
 		vsphereDatastoreTotalReadLatencyMs,
 		vsphereDatastoreTotalWriteLatencyMs,
+		vsphereDatastoreVmobservedLatencyMs,
 		vsphereDatastoreWriteKbs,
-		vsphereDatastoreDatastoreIops,
+		vsphereDatastoreWriteLoadMetric,
 	},
 	groupDisk: []string{
 		vsphereDiskBusResets,
@@ -507,9 +519,9 @@ var groupMetricsMap = map[string][]string{
 		vsphereDiskWriteKbs,
 	},
 	groupHbr: []string{
-		vsphereHbrHbrNetRxKbs,
-		vsphereHbrHbrNetTxKbs,
-		vsphereHbrHbrNumVms,
+		vsphereHbrNetRxKbs,
+		vsphereHbrNetTxKbs,
+		vsphereHbrNumVms,
 	},
 	groupMem: []string{
 		vsphereMemActiveKb,
@@ -578,9 +590,9 @@ var groupMetricsMap = map[string][]string{
 		vsphereNetUsageKbs,
 	},
 	groupPower: []string{
+		vspherePowerCapWatts,
 		vspherePowerEnergyJoules,
-		vspherePowerPowerCapWatts,
-		vspherePowerPowerWatts,
+		vspherePowerWatts,
 	},
 	groupRescpu: []string{
 		vsphereRescpuActav1,

--- a/pkg/monitors/vsphere/metadata.yaml
+++ b/pkg/monitors/vsphere/metadata.yaml
@@ -88,7 +88,7 @@ monitors:
         type: counter
         default: false
         group: cpu
-      vsphere_cpu_latency_percent:
+      vsphere.cpu_latency_percent:
         description: Percent of time the virtual machine is unable to run because it is contending for access to the
           physical CPU(s).
         type: gauge
@@ -147,7 +147,7 @@ monitors:
       vsphere.cpu_usage_percent:
         description: CPU usage as a percentage during the interval.
         type: gauge
-        default: false
+        default: true
         group: cpu
       vsphere.cpu_usagemhz:
         description: CPU usage, as measured in megahertz, during the interval.
@@ -171,925 +171,925 @@ monitors:
         type: counter
         default: false
         group: cpu
-      vsphere.datastore_datastoreIops:
+      vsphere.datastore_datastore_iops:
         description: Average amount of time for an I/O operation to the datastore or LUN across all ESX hosts accessing
           it.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.datastore_read_load_metric:
+      vsphere.datastore_read_load_metric:
         description: Storage DRS datastore metric for read workload model.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.datastore_vmobserved_latency_ms:
+      vsphere.datastore_vmobserved_latency_ms:
         description: The average datastore latency as seen by virtual machines.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.datastore_write_load_metric:
+      vsphere.datastore_write_load_metric:
         description: Storage DRS datastore metric for write workload model.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.max_total_latency_ms:
+      vsphere.datastore_max_total_latency_ms:
         description: Highest latency value across all datastores used by the host.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.read_kbs:
+      vsphere.datastore_read_kbs:
         description: Rate of reading data from the datastore (kilobytes per second)
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.size_normalized_datastore_latency_ms:
+      vsphere.datastore_size_normalized_datastore_latency_ms:
         description: Storage I/O Control size-normalized I/O latency.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.total_read_latency_ms:
-        description: Average amount of time for a read operation from the vsphere.datastore.
+      vsphere.datastore_total_read_latency_ms:
+        description: Average amount of time for a read operation from the vsphere datastore.
           Total latency = kernel latency + device latency.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.total_write_latency_ms:
-        description: Average amount of time for a write operation to the vsphere.datastore.
+      vsphere.datastore_total_write_latency_ms:
+        description: Average amount of time for a write operation to the vsphere datastore.
           Total latency = kernel latency + device latency.
         type: gauge
         default: false
         group: datastore
-      vsphere.datastore.write_kbs:
+      vsphere.datastore_write_kbs:
         description: Rate of writing data to the datastore.
         type: gauge
         default: false
         group: datastore
-      vsphere.disk.bus_resets:
+      vsphere.disk_bus_resets:
         description: Number of SCSI-bus reset commands issued during the collection interval.
         type: counter
         default: false
         group: disk
-      vsphere.disk.commands:
+      vsphere.disk_commands:
         description: Number of SCSI commands issued during the collection interval.
         type: counter
         default: false
         group: disk
-      vsphere.disk.commands_aborted:
+      vsphere.disk_commands_aborted:
         description: Number of SCSI commands aborted during the collection interval.
         type: counter
         default: false
         group: disk
-      vsphere.disk.commands_averaged:
+      vsphere.disk_commands_averaged:
         description: Average number of SCSI commands issued per second during the collection interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.device_latency_ms:
+      vsphere.disk_device_latency_ms:
         description: Average amount of time, in milliseconds, to complete a SCSI command from the physical device.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.device_read_latency_ms:
+      vsphere.disk_device_read_latency_ms:
         description: Average amount of time, in milliseconds, to read from the physical device.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.device_write_latency_ms:
+      vsphere.disk_device_write_latency_ms:
         description: Average amount of time, in milliseconds, to write to the physical device.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.kernel_latency_ms:
+      vsphere.disk_kernel_latency_ms:
         description: Average amount of time, in milliseconds, spent by VMkernel to process each SCSI command.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.kernel_read_latency_ms:
+      vsphere.disk_kernel_read_latency_ms:
         description: Average amount of time, in milliseconds, spent by VMkernel to process each SCSI read command.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.kernel_write_latency_ms:
+      vsphere.disk_kernel_write_latency_ms:
         description: Average amount of time, in milliseconds, spent by VMkernel to process each SCSI write command.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.max_queue_depth:
+      vsphere.disk_max_queue_depth:
         description: Maximum queue depth.
         type: gauge
-        default: false
+        default: true
         group: disk
-      vsphere.disk.max_total_latency_ms:
+      vsphere.disk_max_total_latency_ms:
         description: Highest latency value across all disks used by the host.
         type: gauge
-        default: false
+        default: true
         group: disk
-      vsphere.disk.number_read:
+      vsphere.disk_number_read:
         description: Number of disk reads during the collection interval.
         type: counter
         default: false
         group: disk
-      vsphere.disk.number_read_averaged:
+      vsphere.disk_number_read_averaged:
         description: Average number of read commands issued per second to the datastore during the collection interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.number_write:
+      vsphere.disk_number_write:
         description: Number of disk writes during the collection interval.
         type: counter
         default: false
         group: disk
-      vsphere.disk.number_write_averaged:
+      vsphere.disk_number_write_averaged:
         description: Average number of write commands issued per second to the datastore during the collection interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.queue_latency_ms:
+      vsphere.disk_queue_latency_ms:
         description: Average amount of time spent in the VMkernel queue, per SCSI command, during the collection
           interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.queue_read_latency_ms:
+      vsphere.disk_queue_read_latency_ms:
         description: Average amount of time spent in the VMkernel queue, per SCSI read command, during the collection
           interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.queue_write_latency_ms:
+      vsphere.disk_queue_write_latency_ms:
         description: Average amount of time spent in the VMkernel queue, per SCSI write command, during the collection
           interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.read_kbs:
+      vsphere.disk_read_kbs:
         description: Average number of kilobytes read from the disk each second during the collection interval.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.total_latency_ms:
+      vsphere.disk_total_latency_ms:
         description: Average amount of time taken during the collection interval to process a SCSI command issued by the
           guest OS to the virtual machine.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.total_read_latency_ms:
+      vsphere.disk_total_read_latency_ms:
         description: Average amount of time taken during the collection interval to process a SCSI read command issued
           from the guest OS to the virtual machine.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.total_write_latency_ms:
+      vsphere.disk_total_write_latency_ms:
         description: Average amount of time taken during the collection interval to process a SCSI write command issued
           by the guest OS to the virtual machine.
         type: gauge
         default: false
         group: disk
-      vsphere.disk.usage_kbs:
+      vsphere.disk_usage_kbs:
         description: Aggregated disk I/O rate.
         type: gauge
-        default: false
+        default: true
         group: disk
-      vsphere.disk.write_kbs:
+      vsphere.disk_write_kbs:
         description: Average number of kilobytes written to disk each second during the collection interval.
         type: gauge
         default: false
         group: disk
-      vsphere.hbr.hbr_net_rx_kbs:
+      vsphere.hbr_net_rx_kbs:
         description: Kilobytes per second of outgoing host-based replication network traffic (for this virtual machine
           or host).
         type: gauge
         default: false
         group: hbr
-      vsphere.hbr.hbr_net_tx_kbs:
+      vsphere.hbr_net_tx_kbs:
         description: Average amount of data transmitted per second.
         type: gauge
         default: false
         group: hbr
-      vsphere.hbr.hbr_num_vms:
+      vsphere.hbr_num_vms:
         description: Number of powered-on virtual machines running on this host that currently have host-based
           replication protection enabled.
         type: gauge
         default: false
         group: hbr
-      vsphere.mem.active_kb:
+      vsphere.mem_active_kb:
         description: Amount of memory that is actively used, as estimated by VMkernel based on recently touched
           memory pages.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.activewrite_kb:
+      vsphere.mem_activewrite_kb:
         description: Estimate for the amount of memory actively being written to by the virtual machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.compressed_kb:
+      vsphere.mem_compressed_kb:
         description: Amount of memory reserved by userworlds.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.compression_rate_kbs:
+      vsphere.mem_compression_rate_kbs:
         description: Rate of memory compression for the virtual machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.consumed_kb:
+      vsphere.mem_consumed_kb:
         description: Amount of host physical memory consumed by a virtual machine, host, or cluster.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.decompression_rate_kbs:
+      vsphere.mem_decompression_rate_kbs:
         description: Rate of memory decompression for the virtual machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.entitlement_kb:
+      vsphere.mem_entitlement_kb:
         description: Amount of host physical memory the virtual machine is entitled to, as determined by the ESX
           scheduler.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.granted_kb:
+      vsphere.mem_granted_kb:
         description: Amount of host physical memory or physical memory that is mapped for a virtual machine or a host.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.heap_kb:
+      vsphere.mem_heap_kb:
         description: VMkernel virtual address space dedicated to VMkernel main heap and related data.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.heapfree_kb:
+      vsphere.mem_heapfree_kb:
         description: Free address space in the VMkernel main heap.Varies based on number of physical devices and
           configuration options.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.latency_percent:
+      vsphere.mem_latency_percent:
         description: Percentage of time the virtual machine is waiting to access swapped or compressed memory.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.ll_swap_in_kb:
+      vsphere.mem_ll_swap_in_kb:
         description: Amount of memory swapped-in from host cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.ll_swap_in_rate_kbs:
+      vsphere.mem_ll_swap_in_rate_kbs:
         description: Rate at which memory is being swapped from host cache into active memory.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.ll_swap_out_kb:
+      vsphere.mem_ll_swap_out_kb:
         description: Amount of memory swapped-out to host cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.ll_swap_out_rate_kbs:
+      vsphere.mem_ll_swap_out_rate_kbs:
         description: Rate at which memory is being swapped from active memory to host cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.ll_swap_used_kb:
+      vsphere.mem_ll_swap_used_kb:
         description: Space used for caching swapped pages in the host cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.lowfreethreshold_kb:
+      vsphere.mem_lowfreethreshold_kb:
         description: Threshold of free host physical memory below which ESX/ESXi will begin reclaiming memory from
           virtual machines through ballooning and swapping.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.overhead_kb:
+      vsphere.mem_overhead_kb:
         description: Host physical memory (KB) consumed by the virtualization infrastructure for running the virtual
           machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.overhead_max_kb:
+      vsphere.mem_overhead_max_kb:
         description: Host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.overhead_touched_kb:
+      vsphere.mem_overhead_touched_kb:
         description: Actively touched overhead host physical memory (KB) reserved for use as the virtualization overhead
           for the virtual machine.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.reserved_capacity_mb:
+      vsphere.mem_reserved_capacity_mb:
         description: Total amount of memory reservation used by powered-on virtual machines and vSphere services on the
           host.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.shared_kb:
+      vsphere.mem_shared_kb:
         description: Amount of guest physical memory that is shared with other virtual machines, relative to a single
           virtual machine or to all powered-on virtual machines on a host.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.sharedcommon_kb:
+      vsphere.mem_sharedcommon_kb:
         description: Amount of machine memory that is shared by all powered-on virtual machines and vSphere services on
           the host.Subtract this metric from the shared metric to gauge how much machine memory is saved due to
           sharing -- shared - sharedcommon = machine memory (host memory) savings (KB).
         type: gauge
         default: false
         group: mem
-      vsphere.mem.state:
+      vsphere.mem_state:
         description: One of four threshold levels representing the percentage of free memory on the host. The counter
           value determines swapping and ballooning behavior for memory reclamation.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.swapin_kb:
+      vsphere.mem_swapin_kb:
         description: Amount swapped-in to memory from disk.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.swapin_rate_kbs:
+      vsphere.mem_swapin_rate_kbs:
         description: Rate at which memory is swapped from disk into active memory during the interval.
         type: gauge
-        default: false
+        default: true
         group: mem
-      vsphere.mem.swapout_kb:
+      vsphere.mem_swapout_kb:
         description: Amount of memory swapped-out to disk.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.swapout_rate_kbs:
+      vsphere.mem_swapout_rate_kbs:
         description: Rate at which memory is being swapped from active memory to disk during the current interval.
         type: gauge
-        default: false
+        default: true
         group: mem
-      vsphere.mem.swapped_kb:
+      vsphere.mem_swapped_kb:
         description: Current amount of guest physical memory swapped out to the virtual machine swap file by the
           VMkernel.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.swaptarget_kb:
+      vsphere.mem_swaptarget_kb:
         description: Target size for the virtual machine swap file.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.swapused_kb:
+      vsphere.mem_swapused_kb:
         description: Amount of memory that is used by swap.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.sys_usage_kb:
+      vsphere.mem_sys_usage_kb:
         description: Amount of host physical memory used by VMkernel for core functionality, such as device drivers and
           other internal uses.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.total_capacity_mb:
+      vsphere.mem_total_capacity_mb:
         description: Total amount of memory reservation used by and available for powered-on virtual machines and
           vSphere services on the host.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.unreserved_kb:
+      vsphere.mem_unreserved_kb:
         description: Amount of memory that is unreserved.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.usage_percent:
+      vsphere.mem_usage_percent:
         description: Percentage of host physical memory that has been consumed.
         type: gauge
-        default: false
+        default: true
         group: mem
-      vsphere.mem.vmfs_pbc_cap_miss_ratio_percent:
+      vsphere.mem_vmfs_pbc_cap_miss_ratio_percent:
         description: Trailing average of the ratio of capacity misses to compulsory misses for the VMFS PB Cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmfs_pbc_overhead_kb:
+      vsphere.mem_vmfs_pbc_overhead_kb:
         description: Amount of VMFS heap used by the VMFS PB Cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmfs_pbc_size_mb:
+      vsphere.mem_vmfs_pbc_size_mb:
         description: Space used for holding VMFS Pointer Blocks in memory.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmfs_pbc_size_max_mb:
+      vsphere.mem_vmfs_pbc_size_max_mb:
         description: Maximum size the VMFS Pointer Block Cache can grow to.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmfs_pbc_working_set_tb:
+      vsphere.mem_vmfs_pbc_working_set_tb:
         description: Amount of file blocks whose addresses are cached in the VMFS PB Cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmfs_pbc_working_set_max_tb:
+      vsphere.mem_vmfs_pbc_working_set_max_tb:
         description: Maximum amount of file blocks whose addresses are cached in the VMFS PB Cache.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmmemctl_kb:
+      vsphere.mem_vmmemctl_kb:
         description: Amount of memory allocated by the virtual machine memory control driver.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.vmmemctltarget_kb:
+      vsphere.mem_vmmemctltarget_kb:
         description: Target value set by VMkernal for the virtual machine's memory balloon size.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.zero_kb:
+      vsphere.mem_zero_kb:
         description: Memory that contains 0s only.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.zip_saved_kb:
+      vsphere.mem_zip_saved_kb:
         description: Memory (KB) saved due to memory zipping.
         type: gauge
         default: false
         group: mem
-      vsphere.mem.zipped_kb:
+      vsphere.mem_zipped_kb:
         description: Memory (KB) zipped.
         type: gauge
         default: false
         group: mem
-      vsphere.net.broadcast_rx:
+      vsphere.net_broadcast_rx:
         description: Number of broadcast packets received during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.broadcast_tx:
+      vsphere.net_broadcast_tx:
         description: Number of broadcast packets transmitted during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.bytes_rx_kbs:
+      vsphere.net_bytes_rx_kbs:
         description: Average amount of data received per second.
         type: gauge
         default: false
         group: net
-      vsphere.net.bytes_tx_kbs:
+      vsphere.net_bytes_tx_kbs:
         description: Average amount of data transmitted per second.
         type: gauge
         default: false
         group: net
-      vsphere.net.dropped_rx:
+      vsphere.net_dropped_rx:
         description: Number of received packets dropped during the collection interval.
         type: counter
         default: false
         group: net
-      vsphere.net.dropped_tx:
+      vsphere.net_dropped_tx:
         description: Number of transmitted packets dropped during the collection interval.
         type: counter
         default: false
         group: net
-      vsphere.net.errors_rx:
+      vsphere.net_errors_rx:
         description: Number of packets with errors received during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.errors_tx:
+      vsphere.net_errors_tx:
         description: Number of packets with errors transmitted during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.multicast_rx:
+      vsphere.net_multicast_rx:
         description: Number of multicast packets received during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.multicast_tx:
+      vsphere.net_multicast_tx:
         description: Number of multicast packets transmitted during the sampling interval.
         type: counter
         default: false
         group: net
-      vsphere.net.packets_rx:
+      vsphere.net_packets_rx:
         description: Number of packets received during the interval.
         type: counter
         default: false
         group: net
-      vsphere.net.packets_tx:
+      vsphere.net_packets_tx:
         description: Number of packets transmitted during the interval.
         type: counter
         default: false
         group: net
-      vsphere.net.received_kbs:
+      vsphere.net_received_kbs:
         description: Average rate at which data was received during the interval.
         type: gauge
-        default: false
+        default: true
         group: net
-      vsphere.net.transmitted_kbs:
+      vsphere.net_transmitted_kbs:
         description: Average rate at which data was transmitted during the interval. This represents the bandwidth of
           the network.
         type: gauge
-        default: false
+        default: true
         group: net
-      vsphere.net.unknown_protos:
+      vsphere.net_unknown_protos:
         description: Number of frames with unknown protocol received during the sampling interval
         type: counter
         default: false
         group: net
-      vsphere.net.usage_kbs:
+      vsphere.net_usage_kbs:
         description: Network utilization (combined transmit- and receive-rates) during the interval.
         type: gauge
         default: false
         group: net
-      vsphere.power.energy_joules:
+      vsphere.power_energy_joules:
         description: Total energy used since last stats reset.
         type: counter
         default: false
         group: power
-      vsphere.power.power_watts:
+      vsphere.power_watts:
         description: Current power usage.
         type: gauge
         default: false
         group: power
-      vsphere.power.power_cap_watts:
+      vsphere.power_cap_watts:
         description: Maximum allowed power usage.
         type: gauge
         default: false
         group: power
-      vsphere.rescpu.actav1:
+      vsphere.rescpu_actav1:
         description: CPU active average over 1 minute.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.actav15_percent:
+      vsphere.rescpu_actav15_percent:
         description: CPU active average over 15 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.actav5_percent:
+      vsphere.rescpu_actav5_percent:
         description: CPU active average over 5 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.actpk1_percent:
+      vsphere.rescpu_actpk1_percent:
         description: CPU active peak over 1 minute.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.actpk15_percent:
+      vsphere.rescpu_actpk15_percent:
         description: CPU active peak over 15 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.actpk5_percent:
+      vsphere.rescpu_actpk5_percent:
         description: CPU active peak over 5 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.max_limited1_percent:
+      vsphere.rescpu_max_limited1_percent:
         description: Amount of CPU resources over the limit that were refused, average over 1 minute.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.max_limited15_percent:
+      vsphere.rescpu_max_limited15_percent:
         description: Amount of CPU resources over the limit that were refused, average over 15 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.max_limited5_percent:
+      vsphere.rescpu_max_limited5_percent:
         description: Amount of CPU resources over the limit that were refused, average over 5 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runav1_percent:
+      vsphere.rescpu_runav1_percent:
         description: CPU running average over 1 minute.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runav15_percent:
+      vsphere.rescpu_runav15_percent:
         description: CPU running average over 15 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runav5_percent:
+      vsphere.rescpu_runav5_percent:
         description: CPU running average over 5 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runpk1_percent:
+      vsphere.rescpu_runpk1_percent:
         description: CPU running peak over 1 minute.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runpk15_percent:
+      vsphere.rescpu_runpk15_percent:
         description: CPU running peak over 15 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.runpk5_percent:
+      vsphere.rescpu_runpk5_percent:
         description: CPU running peak over 5 minutes.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.sample_count:
+      vsphere.rescpu_sample_count:
         description: Group CPU sample count.
         type: gauge
         default: false
         group: rescpu
-      vsphere.rescpu.sample_period_ms:
+      vsphere.rescpu_sample_period_ms:
         description: Group CPU sample period.
         type: gauge
         default: false
         group: rescpu
-      vsphere.storage_adapter.commands_averaged:
+      vsphere.storage_adapter_commands_averaged:
         description: Average number of commands issued per second by the storage adapter during the collection
           interval.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.max_total_latency_ms:
+      vsphere.storage_adapter_max_total_latency_ms:
         description: Highest latency value across all storage adapters used by the host.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.number_read_averaged:
+      vsphere.storage_adapter_number_read_averaged:
         description: Average number of read commands issued per second by the storage adapter during the collection
           interval.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.number_write_averaged:
+      vsphere.storage_adapter_number_write_averaged:
         description: Average number of write commands issued per second by the storage adapter during the collection
           interval.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.read_kbs:
+      vsphere.storage_adapter_read_kbs:
         description: Rate of reading data by the storage adapter.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.total_read_latency_ms:
+      vsphere.storage_adapter_total_read_latency_ms:
         description: Average amount of time for a read operation by the storage adapter. Total latency = kernel
           latency + device latency.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.total_write_latency_ms:
+      vsphere.storage_adapter_total_write_latency_ms:
         description: Average amount of time for a write operation by the storage adapter. Total latency = kernel
           latency + device latency.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_adapter.write_kbs:
+      vsphere.storage_adapter_write_kbs:
         description: Rate of writing data by the storage adapter.
         type: gauge
         default: false
         group: storage_adapter
-      vsphere.storage_path.commands_averaged:
+      vsphere.storage_path_commands_averaged:
         description: Average number of commands issued per second on the storage path during the collection interval.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.max_total_latency_ms:
+      vsphere.storage_path_max_total_latency_ms:
         description: Highest latency value across all storage paths used by the host.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.number_read_averaged:
+      vsphere.storage_path_number_read_averaged:
         description: Average number of read commands issued per second on the storage path during the collection
           interval.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.number_write_averaged:
+      vsphere.storage_path_number_write_averaged:
         description: Average number of write commands issued per second on the storage path during the collection
           interval.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.read_kbs:
+      vsphere.storage_path_read_kbs:
         description: Rate of reading data on the storage path.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.total_read_latency_ms:
+      vsphere.storage_path_total_read_latency_ms:
         description: The average time a read issued on the storage path takes.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.total_write_latency_ms:
+      vsphere.storage_path_total_write_latency_ms:
         description: Average amount of time for a write issued on the storage path.
           Total latency = kernel latency + device latency.
         type: gauge
         default: false
         group: storage_path
-      vsphere.storage_path.write_kbs:
+      vsphere.storage_path_write_kbs:
         description: Rate of writing data on the storage path.
         type: gauge
         default: false
         group: storage_path
-      vsphere.sys.heartbeat:
+      vsphere.sys_heartbeat:
         description: Number of heartbeats issued per virtual machine during the interval.
         type: counter
         default: false
         group: sys
-      vsphere.sys.os_uptime_seconds:
+      vsphere.sys_os_uptime_seconds:
         description: Total time elapsed, in seconds, since last operating system boot-up.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_act1_percent:
+      vsphere.sys_resource_cpu_act1_percent:
         description: CPU active average over 1 minute of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_act5:
+      vsphere.sys_resource_cpu_act5:
         description: CPU active average over 5 minutes of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_alloc_min_mhz:
+      vsphere.sys_resource_cpu_alloc_min_mhz:
         description: CPU allocation reservation (in MHz) of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_alloc_shares:
+      vsphere.sys_resource_cpu_alloc_shares:
         description: CPU allocation shares of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_max_limited1_percent:
+      vsphere.sys_resource_cpu_max_limited1_percent:
         description: CPU maximum limited over 1 minute of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_max_limited5_percent:
+      vsphere.sys_resource_cpu_max_limited5_percent:
         description: CPU maximum limited over 5 minutes of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_run1_percent:
+      vsphere.sys_resource_cpu_run1_percent:
         description: CPU running average over 1 minute of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_run5_percent:
+      vsphere.sys_resource_cpu_run5_percent:
         description: CPU running average over 5 minutes of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_cpu_usage_mhz:
+      vsphere.sys_resource_cpu_usage_mhz:
         description: Amount of CPU used by the Service Console and other applications during the interval by the
           Service Console and other applications.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_fd_usage:
+      vsphere.sys_resource_fd_usage:
         description: Number of file descriptors used by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_alloc_max_kb:
+      vsphere.sys_resource_mem_alloc_max_kb:
         description: Memory allocation limit (in KB) of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_alloc_min_kb:
+      vsphere.sys_resource_mem_alloc_min_kb:
         description: Memory allocation reservation (in KB) of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_alloc_shares:
+      vsphere.sys_resource_mem_alloc_shares:
         description: Memory allocation shares of the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_consumed_kb:
+      vsphere.sys_resource_mem_consumed_kb:
         description: Memory consumed by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_cow_kb:
+      vsphere.sys_resource_mem_cow_kb:
         description: Memory shared by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_mapped_kb:
+      vsphere.sys_resource_mem_mapped_kb:
         description: Memory mapped by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_overhead_kb:
+      vsphere.sys_resource_mem_overhead_kb:
         description: Overhead memory consumed by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_shared_kb:
+      vsphere.sys_resource_mem_shared_kb:
         description: Memory saved due to sharing by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_swapped_kb:
+      vsphere.sys_resource_mem_swapped_kb:
         description: Memory swapped out by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_touched_kb:
+      vsphere.sys_resource_mem_touched_kb:
         description: Memory touched by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.resource_mem_zero_kb:
+      vsphere.sys_resource_mem_zero_kb:
         description: Zero filled memory used by the system resource group.
         type: gauge
         default: false
         group: sys
-      vsphere.sys.uptime_seconds:
+      vsphere.sys_uptime_seconds:
         description: Total time elapsed, in seconds, since last system startup.
         type: gauge
         default: false
         group: sys
-      vsphere.virtual_disk.large_seeks:
+      vsphere.virtual_disk_large_seeks:
         description: Number of seeks during the interval that were greater than 8192 LBNs apart.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.medium_seeks:
+      vsphere.virtual_disk_medium_seeks:
         description: Number of seeks during the interval that were between 64 and 8192 LBNs apart.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.number_read_averaged:
+      vsphere.virtual_disk_number_read_averaged:
         description: Average number of read commands issued per second to the virtual disk during the collection
           interval.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.number_write_averaged:
+      vsphere.virtual_disk_number_write_averaged:
         description: Average number of write commands issued per second to the virtual disk during the collection
           interval.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.read_kbs:
+      vsphere.virtual_disk_read_kbs:
         description: Rate of reading data from the virtual disk.
         type: gauge
-        default: false
+        default: true
         group: virtual_disk
-      vsphere.virtual_disk.read_iosize:
+      vsphere.virtual_disk_read_iosize:
         description: Average read request size in bytes.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.read_latency_us:
+      vsphere.virtual_disk_read_latency_us:
         description: Read latency in microseconds.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.read_load_metric:
+      vsphere.virtual_disk_read_load_metric:
         description: Storage DRS virtual disk metric for the read workload model.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.read_oio:
+      vsphere.virtual_disk_read_oio:
         description: Average number of outstanding read requests to the virtual disk during the collection interval.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.small_seeks:
+      vsphere.virtual_disk_small_seeks:
         description: Number of seeks during the interval that were less than 64 LBNs apart.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.total_read_latency_ms:
+      vsphere.virtual_disk_total_read_latency_ms:
         description: Average amount of time for a read operation from the virtual disk.
           Total latency = kernel latency + device latency.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.total_write_latency_ms:
+      vsphere.virtual_disk_total_write_latency_ms:
         description: The average time a write to the virtual disk takes.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.write_kbs:
+      vsphere.virtual_disk_write_kbs:
         description: Rate of writing data to the virtual disk.
         type: gauge
-        default: false
+        default: true
         group: virtual_disk
-      vsphere.virtual_disk.write_iosize:
+      vsphere.virtual_disk_write_iosize:
         description: Average write request size in bytes.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.write_latency_us:
+      vsphere.virtual_disk_write_latency_us:
         description: Write latency in microseconds.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.write_load_metric:
+      vsphere.virtual_disk_write_load_metric:
         description: Storage DRS virtual disk metric for the write workload model.
         type: gauge
         default: false
         group: virtual_disk
-      vsphere.virtual_disk.write_oio:
+      vsphere.virtual_disk_write_oio:
         description: Average number of outstanding write requests to the virtual disk during the collection interval.
         type: gauge
         default: false

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -20,15 +20,21 @@ type IGateway interface {
 	queryPerfProviderSummary(mor types.ManagedObjectReference) (*types.QueryPerfProviderSummaryResponse, error)
 	queryPerf(invObjs []*model.InventoryObject, maxSample int32) (*types.QueryPerfResponse, error)
 	retrieveCurrentTime() (*time.Time, error)
+	vcenterName() string
 }
 
 type Gateway struct {
 	ctx    context.Context
 	client *govmomi.Client
+	vcName string
 }
 
 func NewGateway(ctx context.Context, client *govmomi.Client) *Gateway {
-	return &Gateway{ctx, client}
+	return &Gateway{
+		ctx:    ctx,
+		client: client,
+		vcName: client.Client.URL().Host,
+	}
 }
 
 func (g *Gateway) retrievePerformanceManager() (*mo.PerformanceManager, error) {
@@ -101,4 +107,8 @@ func (g *Gateway) queryPerf(invObjs []*model.InventoryObject, maxSample int32) (
 
 func (g *Gateway) retrieveCurrentTime() (*time.Time, error) {
 	return methods.GetCurrentTime(g.ctx, g.client)
+}
+
+func (g *Gateway) vcenterName() string {
+	return g.vcName
 }

--- a/pkg/monitors/vsphere/service/inventory.go
+++ b/pkg/monitors/vsphere/service/inventory.go
@@ -89,10 +89,10 @@ func (svc *InventorySvc) retrieveCluster(ref types.ManagedObjectReference, inv *
 			return nil, err
 		}
 
-		hostInvObj := model.NewInventoryObject(host.Self, map[string]string{
-			"host_name": host.Name,
-			"os_type":   host.Config.Product.OsType,
-		})
+		hostDims := map[string]string{
+			"esx_ip": host.Name,
+		}
+		hostInvObj := model.NewInventoryObject(host.Self, hostDims)
 		inv.AddObject(hostInvObj)
 
 		for _, vmRef := range host.Vm {
@@ -102,10 +102,15 @@ func (svc *InventorySvc) retrieveCluster(ref types.ManagedObjectReference, inv *
 				return nil, err
 			}
 
-			vmInvObj := model.NewInventoryObject(vm.Self, map[string]string{
-				"vm_name":  vm.Name,
-				"guest_id": vm.Config.GuestId,
-			})
+			vmDims := map[string]string{
+				"vm_name":        vm.Name,           // e.g. "MyDebian10Host"
+				"guest_id":       vm.Config.GuestId, // e.g. "debian10_64Guest"
+				"vm_ip":          vm.Guest.IpAddress,
+				"guest_family":   vm.Guest.GuestFamily,   // e.g. "linuxGuest"
+				"guest_fullname": vm.Guest.GuestFullName, // e.g. "Other 4.x or later Linux (64-bit)"
+			}
+			updateMap(vmDims, hostDims)
+			vmInvObj := model.NewInventoryObject(vm.Self, vmDims)
 			inv.AddObject(vmInvObj)
 		}
 	}

--- a/pkg/monitors/vsphere/service/inventory_test.go
+++ b/pkg/monitors/vsphere/service/inventory_test.go
@@ -18,9 +18,9 @@ func TestRetrieveInventory(t *testing.T) {
 		case model.HostType:
 			require.Equal(t, "host-0", dims["ref_id"])
 			require.Equal(t, model.HostType, dims["object_type"])
-			require.Equal(t, "foo host", dims["host_name"])
-			require.Equal(t, "foo os type", dims["os_type"])
+			require.Equal(t, "4.4.4.4", dims["esx_ip"])
 		case model.VMType:
+			require.Equal(t, "4.4.4.4", dims["esx_ip"])
 			require.Equal(t, "vm-0", dims["ref_id"])
 			require.Equal(t, model.VMType, dims["object_type"])
 			require.Equal(t, "foo vm", dims["vm_name"])

--- a/pkg/monitors/vsphere/service/points.go
+++ b/pkg/monitors/vsphere/service/points.go
@@ -62,6 +62,8 @@ func (svc *PointsSvc) RetrievePoints(vsInfo *model.VsphereInfo, numSamplesReqd i
 				dims["object"] = intSeries.Id.Instance
 			}
 
+			dims["vcenter"] = svc.gateway.vcenterName()
+
 			if len(intSeries.Value) > 0 && intSeries.Value[0] > 0 {
 				svc.log.Debugf(
 					"metric = %s, type = (%s->%s), dims = %v, values = %v",
@@ -91,14 +93,6 @@ func (svc *PointsSvc) RetrievePoints(vsInfo *model.VsphereInfo, numSamplesReqd i
 		}
 	}
 	return dps, latestSampleTime
-}
-
-func copyMap(in map[string]string) map[string]string {
-	out := make(map[string]string)
-	for k, v := range in {
-		out[k] = v
-	}
-	return out
 }
 
 func statsTypeToMetricType(statsType types.PerfStatsType) datapoint.MetricType {

--- a/pkg/monitors/vsphere/service/points_test.go
+++ b/pkg/monitors/vsphere/service/points_test.go
@@ -21,4 +21,5 @@ func TestRetrievePoints(t *testing.T) {
 	require.Equal(t, "vsphere.cpu_core_utilization_percent", pt.Metric)
 	require.Equal(t, datapoint.Count, pt.MetricType)
 	require.EqualValues(t, 1.11, pt.Value)
+	require.Equal(t, "my-vc", pt.Dimensions["vcenter"])
 }

--- a/pkg/monitors/vsphere/service/service_test.go
+++ b/pkg/monitors/vsphere/service/service_test.go
@@ -71,7 +71,7 @@ func (g *fakeGateway) retrieveRefProperties(mor types.ManagedObjectReference, ds
 		t.Name = "foo dc"
 	case *mo.HostSystem:
 		t.Self = mor
-		t.Name = "foo host"
+		t.Name = "4.4.4.4"
 		t.Config = &types.HostConfigInfo{
 			Product: types.AboutInfo{
 				OsType: "foo os type",
@@ -83,6 +83,11 @@ func (g *fakeGateway) retrieveRefProperties(mor types.ManagedObjectReference, ds
 		t.Name = "foo vm"
 		t.Config = &types.VirtualMachineConfigInfo{
 			GuestId: "foo guest id",
+		}
+		t.Guest = &types.GuestInfo{
+			IpAddress:     "1.2.3.4",
+			GuestFamily:   "fooFam",
+			GuestFullName: "fooFullName",
 		}
 	default:
 		return fmt.Errorf("type not found %v", t)
@@ -139,4 +144,8 @@ func (g *fakeGateway) createRefs(key string, prefix string, size int) []types.Ma
 
 func (g *fakeGateway) retrieveCurrentTime() (*time.Time, error) {
 	panic("implement me")
+}
+
+func (g *fakeGateway) vcenterName() string {
+	return "my-vc"
 }

--- a/pkg/monitors/vsphere/service/util.go
+++ b/pkg/monitors/vsphere/service/util.go
@@ -1,0 +1,15 @@
+package service
+
+func copyMap(in map[string]string) map[string]string {
+	out := make(map[string]string)
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func updateMap(target, updates map[string]string) {
+	for k, v := range updates {
+		target[k] = v
+	}
+}

--- a/pkg/monitors/vsphere/service/util_test.go
+++ b/pkg/monitors/vsphere/service/util_test.go
@@ -1,0 +1,14 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateMap(t *testing.T) {
+	target := map[string]string{"foo": "bar"}
+	updates := map[string]string{"baz": "glarch"}
+	updateMap(target, updates)
+	require.Equal(t, target, map[string]string{"foo": "bar", "baz": "glarch"})
+}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -46260,6 +46260,7 @@
             "vsphere.cpu_demand_mhz",
             "vsphere.cpu_entitlement_mhz",
             "vsphere.cpu_idle_ms",
+            "vsphere.cpu_latency_percent",
             "vsphere.cpu_maxlimited_ms",
             "vsphere.cpu_overlap_ms",
             "vsphere.cpu_readiness_percent",
@@ -46273,240 +46274,239 @@
             "vsphere.cpu_usagemhz",
             "vsphere.cpu_used_percent",
             "vsphere.cpu_utilization_percent",
-            "vsphere.cpu_wait_ms",
-            "vsphere_cpu_latency_percent"
+            "vsphere.cpu_wait_ms"
           ]
         },
         "datastore": {
           "description": "I/O operations on datastores",
           "metrics": [
-            "vsphere.datastore.datastore_read_load_metric",
-            "vsphere.datastore.datastore_vmobserved_latency_ms",
-            "vsphere.datastore.datastore_write_load_metric",
-            "vsphere.datastore.max_total_latency_ms",
-            "vsphere.datastore.read_kbs",
-            "vsphere.datastore.size_normalized_datastore_latency_ms",
-            "vsphere.datastore.total_read_latency_ms",
-            "vsphere.datastore.total_write_latency_ms",
-            "vsphere.datastore.write_kbs",
-            "vsphere.datastore_datastoreIops"
+            "vsphere.datastore_datastore_iops",
+            "vsphere.datastore_max_total_latency_ms",
+            "vsphere.datastore_read_kbs",
+            "vsphere.datastore_read_load_metric",
+            "vsphere.datastore_size_normalized_datastore_latency_ms",
+            "vsphere.datastore_total_read_latency_ms",
+            "vsphere.datastore_total_write_latency_ms",
+            "vsphere.datastore_vmobserved_latency_ms",
+            "vsphere.datastore_write_kbs",
+            "vsphere.datastore_write_load_metric"
           ]
         },
         "disk": {
           "description": "I/O performance (such as latency and read- and write-speeds), and utilization",
           "metrics": [
-            "vsphere.disk.bus_resets",
-            "vsphere.disk.commands",
-            "vsphere.disk.commands_aborted",
-            "vsphere.disk.commands_averaged",
-            "vsphere.disk.device_latency_ms",
-            "vsphere.disk.device_read_latency_ms",
-            "vsphere.disk.device_write_latency_ms",
-            "vsphere.disk.kernel_latency_ms",
-            "vsphere.disk.kernel_read_latency_ms",
-            "vsphere.disk.kernel_write_latency_ms",
-            "vsphere.disk.max_queue_depth",
-            "vsphere.disk.max_total_latency_ms",
-            "vsphere.disk.number_read",
-            "vsphere.disk.number_read_averaged",
-            "vsphere.disk.number_write",
-            "vsphere.disk.number_write_averaged",
-            "vsphere.disk.queue_latency_ms",
-            "vsphere.disk.queue_read_latency_ms",
-            "vsphere.disk.queue_write_latency_ms",
-            "vsphere.disk.read_kbs",
-            "vsphere.disk.total_latency_ms",
-            "vsphere.disk.total_read_latency_ms",
-            "vsphere.disk.total_write_latency_ms",
-            "vsphere.disk.usage_kbs",
-            "vsphere.disk.write_kbs"
+            "vsphere.disk_bus_resets",
+            "vsphere.disk_commands",
+            "vsphere.disk_commands_aborted",
+            "vsphere.disk_commands_averaged",
+            "vsphere.disk_device_latency_ms",
+            "vsphere.disk_device_read_latency_ms",
+            "vsphere.disk_device_write_latency_ms",
+            "vsphere.disk_kernel_latency_ms",
+            "vsphere.disk_kernel_read_latency_ms",
+            "vsphere.disk_kernel_write_latency_ms",
+            "vsphere.disk_max_queue_depth",
+            "vsphere.disk_max_total_latency_ms",
+            "vsphere.disk_number_read",
+            "vsphere.disk_number_read_averaged",
+            "vsphere.disk_number_write",
+            "vsphere.disk_number_write_averaged",
+            "vsphere.disk_queue_latency_ms",
+            "vsphere.disk_queue_read_latency_ms",
+            "vsphere.disk_queue_write_latency_ms",
+            "vsphere.disk_read_kbs",
+            "vsphere.disk_total_latency_ms",
+            "vsphere.disk_total_read_latency_ms",
+            "vsphere.disk_total_write_latency_ms",
+            "vsphere.disk_usage_kbs",
+            "vsphere.disk_write_kbs"
           ]
         },
         "hbr": {
           "description": "Host-based replication",
           "metrics": [
-            "vsphere.hbr.hbr_net_rx_kbs",
-            "vsphere.hbr.hbr_net_tx_kbs",
-            "vsphere.hbr.hbr_num_vms"
+            "vsphere.hbr_net_rx_kbs",
+            "vsphere.hbr_net_tx_kbs",
+            "vsphere.hbr_num_vms"
           ]
         },
         "mem": {
           "description": "Guest physical memory for VMs and machine memory for hosts",
           "metrics": [
-            "vsphere.mem.active_kb",
-            "vsphere.mem.activewrite_kb",
-            "vsphere.mem.compressed_kb",
-            "vsphere.mem.compression_rate_kbs",
-            "vsphere.mem.consumed_kb",
-            "vsphere.mem.decompression_rate_kbs",
-            "vsphere.mem.entitlement_kb",
-            "vsphere.mem.granted_kb",
-            "vsphere.mem.heap_kb",
-            "vsphere.mem.heapfree_kb",
-            "vsphere.mem.latency_percent",
-            "vsphere.mem.ll_swap_in_kb",
-            "vsphere.mem.ll_swap_in_rate_kbs",
-            "vsphere.mem.ll_swap_out_kb",
-            "vsphere.mem.ll_swap_out_rate_kbs",
-            "vsphere.mem.ll_swap_used_kb",
-            "vsphere.mem.lowfreethreshold_kb",
-            "vsphere.mem.overhead_kb",
-            "vsphere.mem.overhead_max_kb",
-            "vsphere.mem.overhead_touched_kb",
-            "vsphere.mem.reserved_capacity_mb",
-            "vsphere.mem.shared_kb",
-            "vsphere.mem.sharedcommon_kb",
-            "vsphere.mem.state",
-            "vsphere.mem.swapin_kb",
-            "vsphere.mem.swapin_rate_kbs",
-            "vsphere.mem.swapout_kb",
-            "vsphere.mem.swapout_rate_kbs",
-            "vsphere.mem.swapped_kb",
-            "vsphere.mem.swaptarget_kb",
-            "vsphere.mem.swapused_kb",
-            "vsphere.mem.sys_usage_kb",
-            "vsphere.mem.total_capacity_mb",
-            "vsphere.mem.unreserved_kb",
-            "vsphere.mem.usage_percent",
-            "vsphere.mem.vmfs_pbc_cap_miss_ratio_percent",
-            "vsphere.mem.vmfs_pbc_overhead_kb",
-            "vsphere.mem.vmfs_pbc_size_max_mb",
-            "vsphere.mem.vmfs_pbc_size_mb",
-            "vsphere.mem.vmfs_pbc_working_set_max_tb",
-            "vsphere.mem.vmfs_pbc_working_set_tb",
-            "vsphere.mem.vmmemctl_kb",
-            "vsphere.mem.vmmemctltarget_kb",
-            "vsphere.mem.zero_kb",
-            "vsphere.mem.zip_saved_kb",
-            "vsphere.mem.zipped_kb"
+            "vsphere.mem_active_kb",
+            "vsphere.mem_activewrite_kb",
+            "vsphere.mem_compressed_kb",
+            "vsphere.mem_compression_rate_kbs",
+            "vsphere.mem_consumed_kb",
+            "vsphere.mem_decompression_rate_kbs",
+            "vsphere.mem_entitlement_kb",
+            "vsphere.mem_granted_kb",
+            "vsphere.mem_heap_kb",
+            "vsphere.mem_heapfree_kb",
+            "vsphere.mem_latency_percent",
+            "vsphere.mem_ll_swap_in_kb",
+            "vsphere.mem_ll_swap_in_rate_kbs",
+            "vsphere.mem_ll_swap_out_kb",
+            "vsphere.mem_ll_swap_out_rate_kbs",
+            "vsphere.mem_ll_swap_used_kb",
+            "vsphere.mem_lowfreethreshold_kb",
+            "vsphere.mem_overhead_kb",
+            "vsphere.mem_overhead_max_kb",
+            "vsphere.mem_overhead_touched_kb",
+            "vsphere.mem_reserved_capacity_mb",
+            "vsphere.mem_shared_kb",
+            "vsphere.mem_sharedcommon_kb",
+            "vsphere.mem_state",
+            "vsphere.mem_swapin_kb",
+            "vsphere.mem_swapin_rate_kbs",
+            "vsphere.mem_swapout_kb",
+            "vsphere.mem_swapout_rate_kbs",
+            "vsphere.mem_swapped_kb",
+            "vsphere.mem_swaptarget_kb",
+            "vsphere.mem_swapused_kb",
+            "vsphere.mem_sys_usage_kb",
+            "vsphere.mem_total_capacity_mb",
+            "vsphere.mem_unreserved_kb",
+            "vsphere.mem_usage_percent",
+            "vsphere.mem_vmfs_pbc_cap_miss_ratio_percent",
+            "vsphere.mem_vmfs_pbc_overhead_kb",
+            "vsphere.mem_vmfs_pbc_size_max_mb",
+            "vsphere.mem_vmfs_pbc_size_mb",
+            "vsphere.mem_vmfs_pbc_working_set_max_tb",
+            "vsphere.mem_vmfs_pbc_working_set_tb",
+            "vsphere.mem_vmmemctl_kb",
+            "vsphere.mem_vmmemctltarget_kb",
+            "vsphere.mem_zero_kb",
+            "vsphere.mem_zip_saved_kb",
+            "vsphere.mem_zipped_kb"
           ]
         },
         "net": {
           "description": "Physical and virtual NICs and other network devices, such as virtual switches",
           "metrics": [
-            "vsphere.net.broadcast_rx",
-            "vsphere.net.broadcast_tx",
-            "vsphere.net.bytes_rx_kbs",
-            "vsphere.net.bytes_tx_kbs",
-            "vsphere.net.dropped_rx",
-            "vsphere.net.dropped_tx",
-            "vsphere.net.errors_rx",
-            "vsphere.net.errors_tx",
-            "vsphere.net.multicast_rx",
-            "vsphere.net.multicast_tx",
-            "vsphere.net.packets_rx",
-            "vsphere.net.packets_tx",
-            "vsphere.net.received_kbs",
-            "vsphere.net.transmitted_kbs",
-            "vsphere.net.unknown_protos",
-            "vsphere.net.usage_kbs"
+            "vsphere.net_broadcast_rx",
+            "vsphere.net_broadcast_tx",
+            "vsphere.net_bytes_rx_kbs",
+            "vsphere.net_bytes_tx_kbs",
+            "vsphere.net_dropped_rx",
+            "vsphere.net_dropped_tx",
+            "vsphere.net_errors_rx",
+            "vsphere.net_errors_tx",
+            "vsphere.net_multicast_rx",
+            "vsphere.net_multicast_tx",
+            "vsphere.net_packets_rx",
+            "vsphere.net_packets_tx",
+            "vsphere.net_received_kbs",
+            "vsphere.net_transmitted_kbs",
+            "vsphere.net_unknown_protos",
+            "vsphere.net_usage_kbs"
           ]
         },
         "power": {
           "description": "Power resources",
           "metrics": [
-            "vsphere.power.energy_joules",
-            "vsphere.power.power_cap_watts",
-            "vsphere.power.power_watts"
+            "vsphere.power_cap_watts",
+            "vsphere.power_energy_joules",
+            "vsphere.power_watts"
           ]
         },
         "rescpu": {
           "description": "CPU-load-history statistics about resource pools and virtual machines",
           "metrics": [
-            "vsphere.rescpu.actav1",
-            "vsphere.rescpu.actav15_percent",
-            "vsphere.rescpu.actav5_percent",
-            "vsphere.rescpu.actpk15_percent",
-            "vsphere.rescpu.actpk1_percent",
-            "vsphere.rescpu.actpk5_percent",
-            "vsphere.rescpu.max_limited15_percent",
-            "vsphere.rescpu.max_limited1_percent",
-            "vsphere.rescpu.max_limited5_percent",
-            "vsphere.rescpu.runav15_percent",
-            "vsphere.rescpu.runav1_percent",
-            "vsphere.rescpu.runav5_percent",
-            "vsphere.rescpu.runpk15_percent",
-            "vsphere.rescpu.runpk1_percent",
-            "vsphere.rescpu.runpk5_percent",
-            "vsphere.rescpu.sample_count",
-            "vsphere.rescpu.sample_period_ms"
+            "vsphere.rescpu_actav1",
+            "vsphere.rescpu_actav15_percent",
+            "vsphere.rescpu_actav5_percent",
+            "vsphere.rescpu_actpk15_percent",
+            "vsphere.rescpu_actpk1_percent",
+            "vsphere.rescpu_actpk5_percent",
+            "vsphere.rescpu_max_limited15_percent",
+            "vsphere.rescpu_max_limited1_percent",
+            "vsphere.rescpu_max_limited5_percent",
+            "vsphere.rescpu_runav15_percent",
+            "vsphere.rescpu_runav1_percent",
+            "vsphere.rescpu_runav5_percent",
+            "vsphere.rescpu_runpk15_percent",
+            "vsphere.rescpu_runpk1_percent",
+            "vsphere.rescpu_runpk5_percent",
+            "vsphere.rescpu_sample_count",
+            "vsphere.rescpu_sample_period_ms"
           ]
         },
         "storage_adapter": {
           "description": "I/O operations on storage adapters",
           "metrics": [
-            "vsphere.storage_adapter.commands_averaged",
-            "vsphere.storage_adapter.max_total_latency_ms",
-            "vsphere.storage_adapter.number_read_averaged",
-            "vsphere.storage_adapter.number_write_averaged",
-            "vsphere.storage_adapter.read_kbs",
-            "vsphere.storage_adapter.total_read_latency_ms",
-            "vsphere.storage_adapter.total_write_latency_ms",
-            "vsphere.storage_adapter.write_kbs"
+            "vsphere.storage_adapter_commands_averaged",
+            "vsphere.storage_adapter_max_total_latency_ms",
+            "vsphere.storage_adapter_number_read_averaged",
+            "vsphere.storage_adapter_number_write_averaged",
+            "vsphere.storage_adapter_read_kbs",
+            "vsphere.storage_adapter_total_read_latency_ms",
+            "vsphere.storage_adapter_total_write_latency_ms",
+            "vsphere.storage_adapter_write_kbs"
           ]
         },
         "storage_path": {
           "description": "I/O operations on a storage path",
           "metrics": [
-            "vsphere.storage_path.commands_averaged",
-            "vsphere.storage_path.max_total_latency_ms",
-            "vsphere.storage_path.number_read_averaged",
-            "vsphere.storage_path.number_write_averaged",
-            "vsphere.storage_path.read_kbs",
-            "vsphere.storage_path.total_read_latency_ms",
-            "vsphere.storage_path.total_write_latency_ms",
-            "vsphere.storage_path.write_kbs"
+            "vsphere.storage_path_commands_averaged",
+            "vsphere.storage_path_max_total_latency_ms",
+            "vsphere.storage_path_number_read_averaged",
+            "vsphere.storage_path_number_write_averaged",
+            "vsphere.storage_path_read_kbs",
+            "vsphere.storage_path_total_read_latency_ms",
+            "vsphere.storage_path_total_write_latency_ms",
+            "vsphere.storage_path_write_kbs"
           ]
         },
         "sys": {
           "description": "Overall system availability",
           "metrics": [
-            "vsphere.sys.heartbeat",
-            "vsphere.sys.os_uptime_seconds",
-            "vsphere.sys.resource_cpu_act1_percent",
-            "vsphere.sys.resource_cpu_act5",
-            "vsphere.sys.resource_cpu_alloc_min_mhz",
-            "vsphere.sys.resource_cpu_alloc_shares",
-            "vsphere.sys.resource_cpu_max_limited1_percent",
-            "vsphere.sys.resource_cpu_max_limited5_percent",
-            "vsphere.sys.resource_cpu_run1_percent",
-            "vsphere.sys.resource_cpu_run5_percent",
-            "vsphere.sys.resource_cpu_usage_mhz",
-            "vsphere.sys.resource_fd_usage",
-            "vsphere.sys.resource_mem_alloc_max_kb",
-            "vsphere.sys.resource_mem_alloc_min_kb",
-            "vsphere.sys.resource_mem_alloc_shares",
-            "vsphere.sys.resource_mem_consumed_kb",
-            "vsphere.sys.resource_mem_cow_kb",
-            "vsphere.sys.resource_mem_mapped_kb",
-            "vsphere.sys.resource_mem_overhead_kb",
-            "vsphere.sys.resource_mem_shared_kb",
-            "vsphere.sys.resource_mem_swapped_kb",
-            "vsphere.sys.resource_mem_touched_kb",
-            "vsphere.sys.resource_mem_zero_kb",
-            "vsphere.sys.uptime_seconds"
+            "vsphere.sys_heartbeat",
+            "vsphere.sys_os_uptime_seconds",
+            "vsphere.sys_resource_cpu_act1_percent",
+            "vsphere.sys_resource_cpu_act5",
+            "vsphere.sys_resource_cpu_alloc_min_mhz",
+            "vsphere.sys_resource_cpu_alloc_shares",
+            "vsphere.sys_resource_cpu_max_limited1_percent",
+            "vsphere.sys_resource_cpu_max_limited5_percent",
+            "vsphere.sys_resource_cpu_run1_percent",
+            "vsphere.sys_resource_cpu_run5_percent",
+            "vsphere.sys_resource_cpu_usage_mhz",
+            "vsphere.sys_resource_fd_usage",
+            "vsphere.sys_resource_mem_alloc_max_kb",
+            "vsphere.sys_resource_mem_alloc_min_kb",
+            "vsphere.sys_resource_mem_alloc_shares",
+            "vsphere.sys_resource_mem_consumed_kb",
+            "vsphere.sys_resource_mem_cow_kb",
+            "vsphere.sys_resource_mem_mapped_kb",
+            "vsphere.sys_resource_mem_overhead_kb",
+            "vsphere.sys_resource_mem_shared_kb",
+            "vsphere.sys_resource_mem_swapped_kb",
+            "vsphere.sys_resource_mem_touched_kb",
+            "vsphere.sys_resource_mem_zero_kb",
+            "vsphere.sys_uptime_seconds"
           ]
         },
         "virtual_disk": {
           "description": "I/O operations on virtual disks",
           "metrics": [
-            "vsphere.virtual_disk.large_seeks",
-            "vsphere.virtual_disk.medium_seeks",
-            "vsphere.virtual_disk.number_read_averaged",
-            "vsphere.virtual_disk.number_write_averaged",
-            "vsphere.virtual_disk.read_iosize",
-            "vsphere.virtual_disk.read_kbs",
-            "vsphere.virtual_disk.read_latency_us",
-            "vsphere.virtual_disk.read_load_metric",
-            "vsphere.virtual_disk.read_oio",
-            "vsphere.virtual_disk.small_seeks",
-            "vsphere.virtual_disk.total_read_latency_ms",
-            "vsphere.virtual_disk.total_write_latency_ms",
-            "vsphere.virtual_disk.write_iosize",
-            "vsphere.virtual_disk.write_kbs",
-            "vsphere.virtual_disk.write_latency_us",
-            "vsphere.virtual_disk.write_load_metric",
-            "vsphere.virtual_disk.write_oio"
+            "vsphere.virtual_disk_large_seeks",
+            "vsphere.virtual_disk_medium_seeks",
+            "vsphere.virtual_disk_number_read_averaged",
+            "vsphere.virtual_disk_number_write_averaged",
+            "vsphere.virtual_disk_read_iosize",
+            "vsphere.virtual_disk_read_kbs",
+            "vsphere.virtual_disk_read_latency_us",
+            "vsphere.virtual_disk_read_load_metric",
+            "vsphere.virtual_disk_read_oio",
+            "vsphere.virtual_disk_small_seeks",
+            "vsphere.virtual_disk_total_read_latency_ms",
+            "vsphere.virtual_disk_total_write_latency_ms",
+            "vsphere.virtual_disk_write_iosize",
+            "vsphere.virtual_disk_write_kbs",
+            "vsphere.virtual_disk_write_latency_us",
+            "vsphere.virtual_disk_write_load_metric",
+            "vsphere.virtual_disk_write_oio"
           ]
         }
       },
@@ -46544,6 +46544,12 @@
         "vsphere.cpu_idle_ms": {
           "type": "counter",
           "description": "Total time that the CPU spent in an idle state.",
+          "group": "cpu",
+          "default": false
+        },
+        "vsphere.cpu_latency_percent": {
+          "type": "gauge",
+          "description": "Percent of time the virtual machine is unable to run because it is contending for access to the physical CPU(s).",
           "group": "cpu",
           "default": false
         },
@@ -46605,7 +46611,7 @@
           "type": "gauge",
           "description": "CPU usage as a percentage during the interval.",
           "group": "cpu",
-          "default": false
+          "default": true
         },
         "vsphere.cpu_usagemhz": {
           "type": "gauge",
@@ -46631,1072 +46637,1066 @@
           "group": "cpu",
           "default": false
         },
-        "vsphere.datastore.datastore_read_load_metric": {
-          "type": "gauge",
-          "description": "Storage DRS datastore metric for read workload model.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.datastore_vmobserved_latency_ms": {
-          "type": "gauge",
-          "description": "The average datastore latency as seen by virtual machines.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.datastore_write_load_metric": {
-          "type": "gauge",
-          "description": "Storage DRS datastore metric for write workload model.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.max_total_latency_ms": {
-          "type": "gauge",
-          "description": "Highest latency value across all datastores used by the host.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.read_kbs": {
-          "type": "gauge",
-          "description": "Rate of reading data from the datastore (kilobytes per second)",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.size_normalized_datastore_latency_ms": {
-          "type": "gauge",
-          "description": "Storage I/O Control size-normalized I/O latency.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.total_read_latency_ms": {
-          "type": "gauge",
-          "description": "Average amount of time for a read operation from the vsphere.datastore. Total latency = kernel latency + device latency.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.total_write_latency_ms": {
-          "type": "gauge",
-          "description": "Average amount of time for a write operation to the vsphere.datastore. Total latency = kernel latency + device latency.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore.write_kbs": {
-          "type": "gauge",
-          "description": "Rate of writing data to the datastore.",
-          "group": "datastore",
-          "default": false
-        },
-        "vsphere.datastore_datastoreIops": {
+        "vsphere.datastore_datastore_iops": {
           "type": "gauge",
           "description": "Average amount of time for an I/O operation to the datastore or LUN across all ESX hosts accessing it.",
           "group": "datastore",
           "default": false
         },
-        "vsphere.disk.bus_resets": {
+        "vsphere.datastore_max_total_latency_ms": {
+          "type": "gauge",
+          "description": "Highest latency value across all datastores used by the host.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_read_kbs": {
+          "type": "gauge",
+          "description": "Rate of reading data from the datastore (kilobytes per second)",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_read_load_metric": {
+          "type": "gauge",
+          "description": "Storage DRS datastore metric for read workload model.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_size_normalized_datastore_latency_ms": {
+          "type": "gauge",
+          "description": "Storage I/O Control size-normalized I/O latency.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_total_read_latency_ms": {
+          "type": "gauge",
+          "description": "Average amount of time for a read operation from the vsphere datastore. Total latency = kernel latency + device latency.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_total_write_latency_ms": {
+          "type": "gauge",
+          "description": "Average amount of time for a write operation to the vsphere datastore. Total latency = kernel latency + device latency.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_vmobserved_latency_ms": {
+          "type": "gauge",
+          "description": "The average datastore latency as seen by virtual machines.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_write_kbs": {
+          "type": "gauge",
+          "description": "Rate of writing data to the datastore.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.datastore_write_load_metric": {
+          "type": "gauge",
+          "description": "Storage DRS datastore metric for write workload model.",
+          "group": "datastore",
+          "default": false
+        },
+        "vsphere.disk_bus_resets": {
           "type": "counter",
           "description": "Number of SCSI-bus reset commands issued during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.commands": {
+        "vsphere.disk_commands": {
           "type": "counter",
           "description": "Number of SCSI commands issued during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.commands_aborted": {
+        "vsphere.disk_commands_aborted": {
           "type": "counter",
           "description": "Number of SCSI commands aborted during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.commands_averaged": {
+        "vsphere.disk_commands_averaged": {
           "type": "gauge",
           "description": "Average number of SCSI commands issued per second during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.device_latency_ms": {
+        "vsphere.disk_device_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, to complete a SCSI command from the physical device.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.device_read_latency_ms": {
+        "vsphere.disk_device_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, to read from the physical device.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.device_write_latency_ms": {
+        "vsphere.disk_device_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, to write to the physical device.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.kernel_latency_ms": {
+        "vsphere.disk_kernel_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, spent by VMkernel to process each SCSI command.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.kernel_read_latency_ms": {
+        "vsphere.disk_kernel_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, spent by VMkernel to process each SCSI read command.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.kernel_write_latency_ms": {
+        "vsphere.disk_kernel_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time, in milliseconds, spent by VMkernel to process each SCSI write command.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.max_queue_depth": {
+        "vsphere.disk_max_queue_depth": {
           "type": "gauge",
           "description": "Maximum queue depth.",
           "group": "disk",
-          "default": false
+          "default": true
         },
-        "vsphere.disk.max_total_latency_ms": {
+        "vsphere.disk_max_total_latency_ms": {
           "type": "gauge",
           "description": "Highest latency value across all disks used by the host.",
           "group": "disk",
-          "default": false
+          "default": true
         },
-        "vsphere.disk.number_read": {
+        "vsphere.disk_number_read": {
           "type": "counter",
           "description": "Number of disk reads during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.number_read_averaged": {
+        "vsphere.disk_number_read_averaged": {
           "type": "gauge",
           "description": "Average number of read commands issued per second to the datastore during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.number_write": {
+        "vsphere.disk_number_write": {
           "type": "counter",
           "description": "Number of disk writes during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.number_write_averaged": {
+        "vsphere.disk_number_write_averaged": {
           "type": "gauge",
           "description": "Average number of write commands issued per second to the datastore during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.queue_latency_ms": {
+        "vsphere.disk_queue_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time spent in the VMkernel queue, per SCSI command, during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.queue_read_latency_ms": {
+        "vsphere.disk_queue_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time spent in the VMkernel queue, per SCSI read command, during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.queue_write_latency_ms": {
+        "vsphere.disk_queue_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time spent in the VMkernel queue, per SCSI write command, during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.read_kbs": {
+        "vsphere.disk_read_kbs": {
           "type": "gauge",
           "description": "Average number of kilobytes read from the disk each second during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.total_latency_ms": {
+        "vsphere.disk_total_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time taken during the collection interval to process a SCSI command issued by the guest OS to the virtual machine.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.total_read_latency_ms": {
+        "vsphere.disk_total_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time taken during the collection interval to process a SCSI read command issued from the guest OS to the virtual machine.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.total_write_latency_ms": {
+        "vsphere.disk_total_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time taken during the collection interval to process a SCSI write command issued by the guest OS to the virtual machine.",
           "group": "disk",
           "default": false
         },
-        "vsphere.disk.usage_kbs": {
+        "vsphere.disk_usage_kbs": {
           "type": "gauge",
           "description": "Aggregated disk I/O rate.",
           "group": "disk",
-          "default": false
+          "default": true
         },
-        "vsphere.disk.write_kbs": {
+        "vsphere.disk_write_kbs": {
           "type": "gauge",
           "description": "Average number of kilobytes written to disk each second during the collection interval.",
           "group": "disk",
           "default": false
         },
-        "vsphere.hbr.hbr_net_rx_kbs": {
+        "vsphere.hbr_net_rx_kbs": {
           "type": "gauge",
           "description": "Kilobytes per second of outgoing host-based replication network traffic (for this virtual machine or host).",
           "group": "hbr",
           "default": false
         },
-        "vsphere.hbr.hbr_net_tx_kbs": {
+        "vsphere.hbr_net_tx_kbs": {
           "type": "gauge",
           "description": "Average amount of data transmitted per second.",
           "group": "hbr",
           "default": false
         },
-        "vsphere.hbr.hbr_num_vms": {
+        "vsphere.hbr_num_vms": {
           "type": "gauge",
           "description": "Number of powered-on virtual machines running on this host that currently have host-based replication protection enabled.",
           "group": "hbr",
           "default": false
         },
-        "vsphere.mem.active_kb": {
+        "vsphere.mem_active_kb": {
           "type": "gauge",
           "description": "Amount of memory that is actively used, as estimated by VMkernel based on recently touched memory pages.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.activewrite_kb": {
+        "vsphere.mem_activewrite_kb": {
           "type": "gauge",
           "description": "Estimate for the amount of memory actively being written to by the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.compressed_kb": {
+        "vsphere.mem_compressed_kb": {
           "type": "gauge",
           "description": "Amount of memory reserved by userworlds.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.compression_rate_kbs": {
+        "vsphere.mem_compression_rate_kbs": {
           "type": "gauge",
           "description": "Rate of memory compression for the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.consumed_kb": {
+        "vsphere.mem_consumed_kb": {
           "type": "gauge",
           "description": "Amount of host physical memory consumed by a virtual machine, host, or cluster.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.decompression_rate_kbs": {
+        "vsphere.mem_decompression_rate_kbs": {
           "type": "gauge",
           "description": "Rate of memory decompression for the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.entitlement_kb": {
+        "vsphere.mem_entitlement_kb": {
           "type": "gauge",
           "description": "Amount of host physical memory the virtual machine is entitled to, as determined by the ESX scheduler.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.granted_kb": {
+        "vsphere.mem_granted_kb": {
           "type": "gauge",
           "description": "Amount of host physical memory or physical memory that is mapped for a virtual machine or a host.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.heap_kb": {
+        "vsphere.mem_heap_kb": {
           "type": "gauge",
           "description": "VMkernel virtual address space dedicated to VMkernel main heap and related data.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.heapfree_kb": {
+        "vsphere.mem_heapfree_kb": {
           "type": "gauge",
           "description": "Free address space in the VMkernel main heap.Varies based on number of physical devices and configuration options.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.latency_percent": {
+        "vsphere.mem_latency_percent": {
           "type": "gauge",
           "description": "Percentage of time the virtual machine is waiting to access swapped or compressed memory.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.ll_swap_in_kb": {
+        "vsphere.mem_ll_swap_in_kb": {
           "type": "gauge",
           "description": "Amount of memory swapped-in from host cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.ll_swap_in_rate_kbs": {
+        "vsphere.mem_ll_swap_in_rate_kbs": {
           "type": "gauge",
           "description": "Rate at which memory is being swapped from host cache into active memory.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.ll_swap_out_kb": {
+        "vsphere.mem_ll_swap_out_kb": {
           "type": "gauge",
           "description": "Amount of memory swapped-out to host cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.ll_swap_out_rate_kbs": {
+        "vsphere.mem_ll_swap_out_rate_kbs": {
           "type": "gauge",
           "description": "Rate at which memory is being swapped from active memory to host cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.ll_swap_used_kb": {
+        "vsphere.mem_ll_swap_used_kb": {
           "type": "gauge",
           "description": "Space used for caching swapped pages in the host cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.lowfreethreshold_kb": {
+        "vsphere.mem_lowfreethreshold_kb": {
           "type": "gauge",
           "description": "Threshold of free host physical memory below which ESX/ESXi will begin reclaiming memory from virtual machines through ballooning and swapping.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.overhead_kb": {
+        "vsphere.mem_overhead_kb": {
           "type": "gauge",
           "description": "Host physical memory (KB) consumed by the virtualization infrastructure for running the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.overhead_max_kb": {
+        "vsphere.mem_overhead_max_kb": {
           "type": "gauge",
           "description": "Host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.overhead_touched_kb": {
+        "vsphere.mem_overhead_touched_kb": {
           "type": "gauge",
           "description": "Actively touched overhead host physical memory (KB) reserved for use as the virtualization overhead for the virtual machine.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.reserved_capacity_mb": {
+        "vsphere.mem_reserved_capacity_mb": {
           "type": "gauge",
           "description": "Total amount of memory reservation used by powered-on virtual machines and vSphere services on the host.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.shared_kb": {
+        "vsphere.mem_shared_kb": {
           "type": "gauge",
           "description": "Amount of guest physical memory that is shared with other virtual machines, relative to a single virtual machine or to all powered-on virtual machines on a host.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.sharedcommon_kb": {
+        "vsphere.mem_sharedcommon_kb": {
           "type": "gauge",
           "description": "Amount of machine memory that is shared by all powered-on virtual machines and vSphere services on the host.Subtract this metric from the shared metric to gauge how much machine memory is saved due to sharing -- shared - sharedcommon = machine memory (host memory) savings (KB).",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.state": {
+        "vsphere.mem_state": {
           "type": "gauge",
           "description": "One of four threshold levels representing the percentage of free memory on the host. The counter value determines swapping and ballooning behavior for memory reclamation.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.swapin_kb": {
+        "vsphere.mem_swapin_kb": {
           "type": "gauge",
           "description": "Amount swapped-in to memory from disk.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.swapin_rate_kbs": {
+        "vsphere.mem_swapin_rate_kbs": {
           "type": "gauge",
           "description": "Rate at which memory is swapped from disk into active memory during the interval.",
           "group": "mem",
-          "default": false
+          "default": true
         },
-        "vsphere.mem.swapout_kb": {
+        "vsphere.mem_swapout_kb": {
           "type": "gauge",
           "description": "Amount of memory swapped-out to disk.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.swapout_rate_kbs": {
+        "vsphere.mem_swapout_rate_kbs": {
           "type": "gauge",
           "description": "Rate at which memory is being swapped from active memory to disk during the current interval.",
           "group": "mem",
-          "default": false
+          "default": true
         },
-        "vsphere.mem.swapped_kb": {
+        "vsphere.mem_swapped_kb": {
           "type": "gauge",
           "description": "Current amount of guest physical memory swapped out to the virtual machine swap file by the VMkernel.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.swaptarget_kb": {
+        "vsphere.mem_swaptarget_kb": {
           "type": "gauge",
           "description": "Target size for the virtual machine swap file.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.swapused_kb": {
+        "vsphere.mem_swapused_kb": {
           "type": "gauge",
           "description": "Amount of memory that is used by swap.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.sys_usage_kb": {
+        "vsphere.mem_sys_usage_kb": {
           "type": "gauge",
           "description": "Amount of host physical memory used by VMkernel for core functionality, such as device drivers and other internal uses.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.total_capacity_mb": {
+        "vsphere.mem_total_capacity_mb": {
           "type": "gauge",
           "description": "Total amount of memory reservation used by and available for powered-on virtual machines and vSphere services on the host.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.unreserved_kb": {
+        "vsphere.mem_unreserved_kb": {
           "type": "gauge",
           "description": "Amount of memory that is unreserved.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.usage_percent": {
+        "vsphere.mem_usage_percent": {
           "type": "gauge",
           "description": "Percentage of host physical memory that has been consumed.",
           "group": "mem",
-          "default": false
+          "default": true
         },
-        "vsphere.mem.vmfs_pbc_cap_miss_ratio_percent": {
+        "vsphere.mem_vmfs_pbc_cap_miss_ratio_percent": {
           "type": "gauge",
           "description": "Trailing average of the ratio of capacity misses to compulsory misses for the VMFS PB Cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmfs_pbc_overhead_kb": {
+        "vsphere.mem_vmfs_pbc_overhead_kb": {
           "type": "gauge",
           "description": "Amount of VMFS heap used by the VMFS PB Cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmfs_pbc_size_max_mb": {
+        "vsphere.mem_vmfs_pbc_size_max_mb": {
           "type": "gauge",
           "description": "Maximum size the VMFS Pointer Block Cache can grow to.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmfs_pbc_size_mb": {
+        "vsphere.mem_vmfs_pbc_size_mb": {
           "type": "gauge",
           "description": "Space used for holding VMFS Pointer Blocks in memory.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmfs_pbc_working_set_max_tb": {
+        "vsphere.mem_vmfs_pbc_working_set_max_tb": {
           "type": "gauge",
           "description": "Maximum amount of file blocks whose addresses are cached in the VMFS PB Cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmfs_pbc_working_set_tb": {
+        "vsphere.mem_vmfs_pbc_working_set_tb": {
           "type": "gauge",
           "description": "Amount of file blocks whose addresses are cached in the VMFS PB Cache.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmmemctl_kb": {
+        "vsphere.mem_vmmemctl_kb": {
           "type": "gauge",
           "description": "Amount of memory allocated by the virtual machine memory control driver.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.vmmemctltarget_kb": {
+        "vsphere.mem_vmmemctltarget_kb": {
           "type": "gauge",
           "description": "Target value set by VMkernal for the virtual machine's memory balloon size.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.zero_kb": {
+        "vsphere.mem_zero_kb": {
           "type": "gauge",
           "description": "Memory that contains 0s only.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.zip_saved_kb": {
+        "vsphere.mem_zip_saved_kb": {
           "type": "gauge",
           "description": "Memory (KB) saved due to memory zipping.",
           "group": "mem",
           "default": false
         },
-        "vsphere.mem.zipped_kb": {
+        "vsphere.mem_zipped_kb": {
           "type": "gauge",
           "description": "Memory (KB) zipped.",
           "group": "mem",
           "default": false
         },
-        "vsphere.net.broadcast_rx": {
+        "vsphere.net_broadcast_rx": {
           "type": "counter",
           "description": "Number of broadcast packets received during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.broadcast_tx": {
+        "vsphere.net_broadcast_tx": {
           "type": "counter",
           "description": "Number of broadcast packets transmitted during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.bytes_rx_kbs": {
+        "vsphere.net_bytes_rx_kbs": {
           "type": "gauge",
           "description": "Average amount of data received per second.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.bytes_tx_kbs": {
+        "vsphere.net_bytes_tx_kbs": {
           "type": "gauge",
           "description": "Average amount of data transmitted per second.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.dropped_rx": {
+        "vsphere.net_dropped_rx": {
           "type": "counter",
           "description": "Number of received packets dropped during the collection interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.dropped_tx": {
+        "vsphere.net_dropped_tx": {
           "type": "counter",
           "description": "Number of transmitted packets dropped during the collection interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.errors_rx": {
+        "vsphere.net_errors_rx": {
           "type": "counter",
           "description": "Number of packets with errors received during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.errors_tx": {
+        "vsphere.net_errors_tx": {
           "type": "counter",
           "description": "Number of packets with errors transmitted during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.multicast_rx": {
+        "vsphere.net_multicast_rx": {
           "type": "counter",
           "description": "Number of multicast packets received during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.multicast_tx": {
+        "vsphere.net_multicast_tx": {
           "type": "counter",
           "description": "Number of multicast packets transmitted during the sampling interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.packets_rx": {
+        "vsphere.net_packets_rx": {
           "type": "counter",
           "description": "Number of packets received during the interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.packets_tx": {
+        "vsphere.net_packets_tx": {
           "type": "counter",
           "description": "Number of packets transmitted during the interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.net.received_kbs": {
+        "vsphere.net_received_kbs": {
           "type": "gauge",
           "description": "Average rate at which data was received during the interval.",
           "group": "net",
-          "default": false
+          "default": true
         },
-        "vsphere.net.transmitted_kbs": {
+        "vsphere.net_transmitted_kbs": {
           "type": "gauge",
           "description": "Average rate at which data was transmitted during the interval. This represents the bandwidth of the network.",
           "group": "net",
-          "default": false
+          "default": true
         },
-        "vsphere.net.unknown_protos": {
+        "vsphere.net_unknown_protos": {
           "type": "counter",
           "description": "Number of frames with unknown protocol received during the sampling interval",
           "group": "net",
           "default": false
         },
-        "vsphere.net.usage_kbs": {
+        "vsphere.net_usage_kbs": {
           "type": "gauge",
           "description": "Network utilization (combined transmit- and receive-rates) during the interval.",
           "group": "net",
           "default": false
         },
-        "vsphere.power.energy_joules": {
-          "type": "counter",
-          "description": "Total energy used since last stats reset.",
-          "group": "power",
-          "default": false
-        },
-        "vsphere.power.power_cap_watts": {
+        "vsphere.power_cap_watts": {
           "type": "gauge",
           "description": "Maximum allowed power usage.",
           "group": "power",
           "default": false
         },
-        "vsphere.power.power_watts": {
+        "vsphere.power_energy_joules": {
+          "type": "counter",
+          "description": "Total energy used since last stats reset.",
+          "group": "power",
+          "default": false
+        },
+        "vsphere.power_watts": {
           "type": "gauge",
           "description": "Current power usage.",
           "group": "power",
           "default": false
         },
-        "vsphere.rescpu.actav1": {
+        "vsphere.rescpu_actav1": {
           "type": "gauge",
           "description": "CPU active average over 1 minute.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.actav15_percent": {
+        "vsphere.rescpu_actav15_percent": {
           "type": "gauge",
           "description": "CPU active average over 15 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.actav5_percent": {
+        "vsphere.rescpu_actav5_percent": {
           "type": "gauge",
           "description": "CPU active average over 5 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.actpk15_percent": {
+        "vsphere.rescpu_actpk15_percent": {
           "type": "gauge",
           "description": "CPU active peak over 15 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.actpk1_percent": {
+        "vsphere.rescpu_actpk1_percent": {
           "type": "gauge",
           "description": "CPU active peak over 1 minute.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.actpk5_percent": {
+        "vsphere.rescpu_actpk5_percent": {
           "type": "gauge",
           "description": "CPU active peak over 5 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.max_limited15_percent": {
+        "vsphere.rescpu_max_limited15_percent": {
           "type": "gauge",
           "description": "Amount of CPU resources over the limit that were refused, average over 15 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.max_limited1_percent": {
+        "vsphere.rescpu_max_limited1_percent": {
           "type": "gauge",
           "description": "Amount of CPU resources over the limit that were refused, average over 1 minute.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.max_limited5_percent": {
+        "vsphere.rescpu_max_limited5_percent": {
           "type": "gauge",
           "description": "Amount of CPU resources over the limit that were refused, average over 5 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runav15_percent": {
+        "vsphere.rescpu_runav15_percent": {
           "type": "gauge",
           "description": "CPU running average over 15 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runav1_percent": {
+        "vsphere.rescpu_runav1_percent": {
           "type": "gauge",
           "description": "CPU running average over 1 minute.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runav5_percent": {
+        "vsphere.rescpu_runav5_percent": {
           "type": "gauge",
           "description": "CPU running average over 5 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runpk15_percent": {
+        "vsphere.rescpu_runpk15_percent": {
           "type": "gauge",
           "description": "CPU running peak over 15 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runpk1_percent": {
+        "vsphere.rescpu_runpk1_percent": {
           "type": "gauge",
           "description": "CPU running peak over 1 minute.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.runpk5_percent": {
+        "vsphere.rescpu_runpk5_percent": {
           "type": "gauge",
           "description": "CPU running peak over 5 minutes.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.sample_count": {
+        "vsphere.rescpu_sample_count": {
           "type": "gauge",
           "description": "Group CPU sample count.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.rescpu.sample_period_ms": {
+        "vsphere.rescpu_sample_period_ms": {
           "type": "gauge",
           "description": "Group CPU sample period.",
           "group": "rescpu",
           "default": false
         },
-        "vsphere.storage_adapter.commands_averaged": {
+        "vsphere.storage_adapter_commands_averaged": {
           "type": "gauge",
           "description": "Average number of commands issued per second by the storage adapter during the collection interval.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.max_total_latency_ms": {
+        "vsphere.storage_adapter_max_total_latency_ms": {
           "type": "gauge",
           "description": "Highest latency value across all storage adapters used by the host.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.number_read_averaged": {
+        "vsphere.storage_adapter_number_read_averaged": {
           "type": "gauge",
           "description": "Average number of read commands issued per second by the storage adapter during the collection interval.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.number_write_averaged": {
+        "vsphere.storage_adapter_number_write_averaged": {
           "type": "gauge",
           "description": "Average number of write commands issued per second by the storage adapter during the collection interval.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.read_kbs": {
+        "vsphere.storage_adapter_read_kbs": {
           "type": "gauge",
           "description": "Rate of reading data by the storage adapter.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.total_read_latency_ms": {
+        "vsphere.storage_adapter_total_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time for a read operation by the storage adapter. Total latency = kernel latency + device latency.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.total_write_latency_ms": {
+        "vsphere.storage_adapter_total_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time for a write operation by the storage adapter. Total latency = kernel latency + device latency.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_adapter.write_kbs": {
+        "vsphere.storage_adapter_write_kbs": {
           "type": "gauge",
           "description": "Rate of writing data by the storage adapter.",
           "group": "storage_adapter",
           "default": false
         },
-        "vsphere.storage_path.commands_averaged": {
+        "vsphere.storage_path_commands_averaged": {
           "type": "gauge",
           "description": "Average number of commands issued per second on the storage path during the collection interval.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.max_total_latency_ms": {
+        "vsphere.storage_path_max_total_latency_ms": {
           "type": "gauge",
           "description": "Highest latency value across all storage paths used by the host.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.number_read_averaged": {
+        "vsphere.storage_path_number_read_averaged": {
           "type": "gauge",
           "description": "Average number of read commands issued per second on the storage path during the collection interval.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.number_write_averaged": {
+        "vsphere.storage_path_number_write_averaged": {
           "type": "gauge",
           "description": "Average number of write commands issued per second on the storage path during the collection interval.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.read_kbs": {
+        "vsphere.storage_path_read_kbs": {
           "type": "gauge",
           "description": "Rate of reading data on the storage path.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.total_read_latency_ms": {
+        "vsphere.storage_path_total_read_latency_ms": {
           "type": "gauge",
           "description": "The average time a read issued on the storage path takes.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.total_write_latency_ms": {
+        "vsphere.storage_path_total_write_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time for a write issued on the storage path. Total latency = kernel latency + device latency.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.storage_path.write_kbs": {
+        "vsphere.storage_path_write_kbs": {
           "type": "gauge",
           "description": "Rate of writing data on the storage path.",
           "group": "storage_path",
           "default": false
         },
-        "vsphere.sys.heartbeat": {
+        "vsphere.sys_heartbeat": {
           "type": "counter",
           "description": "Number of heartbeats issued per virtual machine during the interval.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.os_uptime_seconds": {
+        "vsphere.sys_os_uptime_seconds": {
           "type": "gauge",
           "description": "Total time elapsed, in seconds, since last operating system boot-up.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_act1_percent": {
+        "vsphere.sys_resource_cpu_act1_percent": {
           "type": "gauge",
           "description": "CPU active average over 1 minute of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_act5": {
+        "vsphere.sys_resource_cpu_act5": {
           "type": "gauge",
           "description": "CPU active average over 5 minutes of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_alloc_min_mhz": {
+        "vsphere.sys_resource_cpu_alloc_min_mhz": {
           "type": "gauge",
           "description": "CPU allocation reservation (in MHz) of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_alloc_shares": {
+        "vsphere.sys_resource_cpu_alloc_shares": {
           "type": "gauge",
           "description": "CPU allocation shares of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_max_limited1_percent": {
+        "vsphere.sys_resource_cpu_max_limited1_percent": {
           "type": "gauge",
           "description": "CPU maximum limited over 1 minute of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_max_limited5_percent": {
+        "vsphere.sys_resource_cpu_max_limited5_percent": {
           "type": "gauge",
           "description": "CPU maximum limited over 5 minutes of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_run1_percent": {
+        "vsphere.sys_resource_cpu_run1_percent": {
           "type": "gauge",
           "description": "CPU running average over 1 minute of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_run5_percent": {
+        "vsphere.sys_resource_cpu_run5_percent": {
           "type": "gauge",
           "description": "CPU running average over 5 minutes of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_cpu_usage_mhz": {
+        "vsphere.sys_resource_cpu_usage_mhz": {
           "type": "gauge",
           "description": "Amount of CPU used by the Service Console and other applications during the interval by the Service Console and other applications.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_fd_usage": {
+        "vsphere.sys_resource_fd_usage": {
           "type": "gauge",
           "description": "Number of file descriptors used by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_alloc_max_kb": {
+        "vsphere.sys_resource_mem_alloc_max_kb": {
           "type": "gauge",
           "description": "Memory allocation limit (in KB) of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_alloc_min_kb": {
+        "vsphere.sys_resource_mem_alloc_min_kb": {
           "type": "gauge",
           "description": "Memory allocation reservation (in KB) of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_alloc_shares": {
+        "vsphere.sys_resource_mem_alloc_shares": {
           "type": "gauge",
           "description": "Memory allocation shares of the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_consumed_kb": {
+        "vsphere.sys_resource_mem_consumed_kb": {
           "type": "gauge",
           "description": "Memory consumed by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_cow_kb": {
+        "vsphere.sys_resource_mem_cow_kb": {
           "type": "gauge",
           "description": "Memory shared by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_mapped_kb": {
+        "vsphere.sys_resource_mem_mapped_kb": {
           "type": "gauge",
           "description": "Memory mapped by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_overhead_kb": {
+        "vsphere.sys_resource_mem_overhead_kb": {
           "type": "gauge",
           "description": "Overhead memory consumed by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_shared_kb": {
+        "vsphere.sys_resource_mem_shared_kb": {
           "type": "gauge",
           "description": "Memory saved due to sharing by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_swapped_kb": {
+        "vsphere.sys_resource_mem_swapped_kb": {
           "type": "gauge",
           "description": "Memory swapped out by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_touched_kb": {
+        "vsphere.sys_resource_mem_touched_kb": {
           "type": "gauge",
           "description": "Memory touched by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.resource_mem_zero_kb": {
+        "vsphere.sys_resource_mem_zero_kb": {
           "type": "gauge",
           "description": "Zero filled memory used by the system resource group.",
           "group": "sys",
           "default": false
         },
-        "vsphere.sys.uptime_seconds": {
+        "vsphere.sys_uptime_seconds": {
           "type": "gauge",
           "description": "Total time elapsed, in seconds, since last system startup.",
           "group": "sys",
           "default": false
         },
-        "vsphere.virtual_disk.large_seeks": {
+        "vsphere.virtual_disk_large_seeks": {
           "type": "gauge",
           "description": "Number of seeks during the interval that were greater than 8192 LBNs apart.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.medium_seeks": {
+        "vsphere.virtual_disk_medium_seeks": {
           "type": "gauge",
           "description": "Number of seeks during the interval that were between 64 and 8192 LBNs apart.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.number_read_averaged": {
+        "vsphere.virtual_disk_number_read_averaged": {
           "type": "gauge",
           "description": "Average number of read commands issued per second to the virtual disk during the collection interval.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.number_write_averaged": {
+        "vsphere.virtual_disk_number_write_averaged": {
           "type": "gauge",
           "description": "Average number of write commands issued per second to the virtual disk during the collection interval.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.read_iosize": {
+        "vsphere.virtual_disk_read_iosize": {
           "type": "gauge",
           "description": "Average read request size in bytes.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.read_kbs": {
+        "vsphere.virtual_disk_read_kbs": {
           "type": "gauge",
           "description": "Rate of reading data from the virtual disk.",
           "group": "virtual_disk",
-          "default": false
+          "default": true
         },
-        "vsphere.virtual_disk.read_latency_us": {
+        "vsphere.virtual_disk_read_latency_us": {
           "type": "gauge",
           "description": "Read latency in microseconds.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.read_load_metric": {
+        "vsphere.virtual_disk_read_load_metric": {
           "type": "gauge",
           "description": "Storage DRS virtual disk metric for the read workload model.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.read_oio": {
+        "vsphere.virtual_disk_read_oio": {
           "type": "gauge",
           "description": "Average number of outstanding read requests to the virtual disk during the collection interval.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.small_seeks": {
+        "vsphere.virtual_disk_small_seeks": {
           "type": "gauge",
           "description": "Number of seeks during the interval that were less than 64 LBNs apart.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.total_read_latency_ms": {
+        "vsphere.virtual_disk_total_read_latency_ms": {
           "type": "gauge",
           "description": "Average amount of time for a read operation from the virtual disk. Total latency = kernel latency + device latency.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.total_write_latency_ms": {
+        "vsphere.virtual_disk_total_write_latency_ms": {
           "type": "gauge",
           "description": "The average time a write to the virtual disk takes.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.write_iosize": {
+        "vsphere.virtual_disk_write_iosize": {
           "type": "gauge",
           "description": "Average write request size in bytes.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.write_kbs": {
+        "vsphere.virtual_disk_write_kbs": {
           "type": "gauge",
           "description": "Rate of writing data to the virtual disk.",
           "group": "virtual_disk",
-          "default": false
+          "default": true
         },
-        "vsphere.virtual_disk.write_latency_us": {
+        "vsphere.virtual_disk_write_latency_us": {
           "type": "gauge",
           "description": "Write latency in microseconds.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.write_load_metric": {
+        "vsphere.virtual_disk_write_load_metric": {
           "type": "gauge",
           "description": "Storage DRS virtual disk metric for the write workload model.",
           "group": "virtual_disk",
           "default": false
         },
-        "vsphere.virtual_disk.write_oio": {
+        "vsphere.virtual_disk_write_oio": {
           "type": "gauge",
           "description": "Average number of outstanding write requests to the virtual disk during the collection interval.",
           "group": "virtual_disk",
-          "default": false
-        },
-        "vsphere_cpu_latency_percent": {
-          "type": "gauge",
-          "description": "Percent of time the virtual machine is unable to run because it is contending for access to the physical CPU(s).",
-          "group": "cpu",
           "default": false
         }
       },


### PR DESCRIPTION
* Fix minor problems and flag default metrics in metadata.yaml
* Rename ESX IP dimension 'esx_ip' from 'host_name'
* Remove extraneous 'os_type' dimension from ESX metrics
* Apply 'esx_ip' dimension to VM metrics
* Add OS info as dimensions to VM metrics
* Add vCenter IP dimension to all metrics to support multiple vCenters

This is in support of new vSphere built in content:
Issue: https://signalfuse.atlassian.net/browse/INT-1717