### PR TITLE
Improve performance of host observer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/influxdata/influxdb v1.7.4 // indirect
 	github.com/influxdata/platform v0.0.0-20190117200541-d500d3cf5589 // indirect
 	github.com/influxdata/tail v1.0.0 // indirect
-	github.com/influxdata/telegraf v0.10.2-0.20190319005412-5e88824c153e
+	github.com/influxdata/telegraf v0.10.2-0.20200121190823-6dad859d74c2
 	github.com/influxdata/toml v0.0.0-20180607005434-2a2e3012f7cf // indirect
 	github.com/influxdata/wlog v0.0.0-20160411224016-7c63b0a71ef8 // indirect
 	github.com/jaegertracing/jaeger v1.15.1
@@ -122,7 +122,7 @@ require (
 	github.com/prometheus/common v0.2.1-0.20190321124555-1ab4d74fc899
 	github.com/prometheus/procfs v0.0.9-0.20191209220459-fa4d6ce8c078
 	github.com/samuel/go-zookeeper v0.0.0-20190810000440-0ceca61e4d75
-	github.com/shirou/gopsutil v2.18.12+incompatible
+	github.com/shirou/gopsutil v2.19.12+incompatible
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190222193949-1fb69526e884
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/gateway v1.2.19-0.20191125135538-2c417b7ae0bd
@@ -130,7 +130,7 @@ require (
 	github.com/signalfx/signalfx-go v1.6.9-0.20191121015807-da8b1dfaab43
 	github.com/sirupsen/logrus v1.4.0
 	github.com/smartystreets/goconvey v1.6.4
-	github.com/soniah/gosnmp v0.0.0-20190220004421-68e8beac0db9 // indirect
+	github.com/soniah/gosnmp v1.22.0 // indirect
 	github.com/streadway/amqp v0.0.0-20190312223743-14f78b41ce6d // indirect
 	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/gjson v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -491,8 +491,8 @@ github.com/influxdata/platform v0.0.0-20190117200541-d500d3cf5589/go.mod h1:YVhy
 github.com/influxdata/tail v1.0.0 h1:RGikfjB/b5C/YP3p47YD48eE0WSsJyAVbBHNpoTHdX0=
 github.com/influxdata/tail v1.0.0/go.mod h1:xTFF2SILpIYc5N+Srb0d5qpx7d+f733nBrbasb13DtQ=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
-github.com/influxdata/telegraf v0.10.2-0.20190319005412-5e88824c153e h1:tfGPLDKE2X1PaU0TQn7H0ZkoNrcVW2a33CnSd8uSTi4=
-github.com/influxdata/telegraf v0.10.2-0.20190319005412-5e88824c153e/go.mod h1:HIOhVICa+3kYiBmzfDt9LEnDA++FNzRzf9eP0o365us=
+github.com/influxdata/telegraf v0.10.2-0.20200121190823-6dad859d74c2 h1:7+1SwH+Qw6NRc5SWThS5bkVjeG1T4yDBVpDAECWQmQ0=
+github.com/influxdata/telegraf v0.10.2-0.20200121190823-6dad859d74c2/go.mod h1:HIOhVICa+3kYiBmzfDt9LEnDA++FNzRzf9eP0o365us=
 github.com/influxdata/toml v0.0.0-20180607005434-2a2e3012f7cf h1:SDlFXYATjEbWThjvSTGdLmHyPozB8QsUFQs/LQ/bOcE=
 github.com/influxdata/toml v0.0.0-20180607005434-2a2e3012f7cf/go.mod h1:zApaNFpP/bTpQItGZNNUMISDMDAnTXu9UqJ4yT3ocz8=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
@@ -755,8 +755,8 @@ github.com/securego/gosec v0.0.0-20190306071850-2bd007e96860/go.mod h1:m3KbCTwh9
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
-github.com/shirou/gopsutil v2.18.12+incompatible h1:1eaJvGomDnH74/5cF4CTmTbLHAriGFsTZppLXDX93OM=
-github.com/shirou/gopsutil v2.18.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.19.12+incompatible h1:WRstheAymn1WOPesh+24+bZKFkqrdCR8JOc77v4xV3Q=
+github.com/shirou/gopsutil v2.19.12+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190222193949-1fb69526e884 h1:KgLGEw137KEUtQnWBGzneCetphBj4+kKHRnhpAkXJC0=
@@ -812,8 +812,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5-0.20181025144106-8a8ea3c53959 h1:AulKUH62UkjPFbbHAglo0sAFXvqr6HDybxRQnuVdPvE=
 github.com/soheilhy/cmux v0.1.5-0.20181025144106-8a8ea3c53959/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
-github.com/soniah/gosnmp v0.0.0-20190220004421-68e8beac0db9 h1:O4jq14rgUwG9Ssn0wZiRPl8Ya6q3a1h3xJzTAsBaRgo=
-github.com/soniah/gosnmp v0.0.0-20190220004421-68e8beac0db9/go.mod h1:DuEpAS0az51+DyVBQwITDsoq4++e3LTNckp2GoasF2I=
+github.com/soniah/gosnmp v1.22.0 h1:jVJi8+OGvR+JHIaZKMmnyNP0akJd2vEgNatybwhZvxg=
+github.com/soniah/gosnmp v1.22.0/go.mod h1:DuEpAS0az51+DyVBQwITDsoq4++e3LTNckp2GoasF2I=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/monitors/cpu/cpu.go
+++ b/pkg/monitors/cpu/cpu.go
@@ -240,8 +240,7 @@ func cpuTimeStatTototalUsed(t *cpu.TimesStat) *totalUsed {
 		t.Softirq +
 		t.Steal +
 		t.Guest +
-		t.GuestNice +
-		t.Stolen
+		t.GuestNice
 
 	return &totalUsed{
 		Total: total,

--- a/pkg/monitors/telegraf/common/accumulator/accumulator.go
+++ b/pkg/monitors/telegraf/common/accumulator/accumulator.go
@@ -67,7 +67,7 @@ func (ac *Accumulator) AddHistogram(measurement string, fields map[string]interf
 }
 
 // SetPrecision - SignalFx does not implement this
-func (ac *Accumulator) SetPrecision(precision, interval time.Duration) {
+func (ac *Accumulator) SetPrecision(precision time.Duration) {
 }
 
 // AddError - log an error returned by the plugin

--- a/pkg/monitors/telegraf/common/accumulator/accumulator_test.go
+++ b/pkg/monitors/telegraf/common/accumulator/accumulator_test.go
@@ -125,7 +125,7 @@ func TestAccumulator(t *testing.T) {
 	}
 	t.Run("SetPrecision()", func(t *testing.T) {
 		ac.emit = &testEmitter{}
-		ac.SetPrecision(time.Second*1, time.Second*1)
+		ac.SetPrecision(time.Second * 1)
 	})
 	t.Run("AddError()", func(t *testing.T) {
 		ac.emit = &testEmitter{}

--- a/pkg/monitors/telegraf/common/logging/logging.go
+++ b/pkg/monitors/telegraf/common/logging/logging.go
@@ -3,42 +3,42 @@ package logging
 import "github.com/sirupsen/logrus"
 
 // NewLogger creates a telegraf.Logger instance wrapper
-func NewLogger(log logrus.FieldLogger) *telegrafLogger {
-	return &telegrafLogger{log: log}
+func NewLogger(log logrus.FieldLogger) *TelegrafLogger {
+	return &TelegrafLogger{log: log}
 }
 
-type telegrafLogger struct {
+type TelegrafLogger struct {
 	log logrus.FieldLogger
 }
 
-func (t *telegrafLogger) Errorf(format string, args ...interface{}) {
+func (t *TelegrafLogger) Errorf(format string, args ...interface{}) {
 	t.log.Errorf(format, args...)
 }
 
-func (t *telegrafLogger) Error(args ...interface{}) {
+func (t *TelegrafLogger) Error(args ...interface{}) {
 	t.log.Error(args...)
 }
 
-func (t *telegrafLogger) Debugf(format string, args ...interface{}) {
+func (t *TelegrafLogger) Debugf(format string, args ...interface{}) {
 	t.log.Debugf(format, args...)
 }
 
-func (t *telegrafLogger) Debug(args ...interface{}) {
+func (t *TelegrafLogger) Debug(args ...interface{}) {
 	t.log.Debug(args...)
 }
 
-func (t *telegrafLogger) Warnf(format string, args ...interface{}) {
+func (t *TelegrafLogger) Warnf(format string, args ...interface{}) {
 	t.log.Warnf(format, args...)
 }
 
-func (t *telegrafLogger) Warn(args ...interface{}) {
+func (t *TelegrafLogger) Warn(args ...interface{}) {
 	t.log.Warn(args...)
 }
 
-func (t *telegrafLogger) Infof(format string, args ...interface{}) {
+func (t *TelegrafLogger) Infof(format string, args ...interface{}) {
 	t.log.Infof(format, args...)
 }
 
-func (t *telegrafLogger) Info(args ...interface{}) {
+func (t *TelegrafLogger) Info(args ...interface{}) {
 	t.log.Info(args...)
 }

--- a/pkg/monitors/telegraf/common/logging/logging.go
+++ b/pkg/monitors/telegraf/common/logging/logging.go
@@ -1,0 +1,44 @@
+package logging
+
+import "github.com/sirupsen/logrus"
+
+// NewLogger creates a telegraf.Logger instance wrapper
+func NewLogger(log logrus.FieldLogger) *telegrafLogger {
+	return &telegrafLogger{log: log}
+}
+
+type telegrafLogger struct {
+	log logrus.FieldLogger
+}
+
+func (t *telegrafLogger) Errorf(format string, args ...interface{}) {
+	t.log.Errorf(format, args...)
+}
+
+func (t *telegrafLogger) Error(args ...interface{}) {
+	t.log.Error(args...)
+}
+
+func (t *telegrafLogger) Debugf(format string, args ...interface{}) {
+	t.log.Debugf(format, args...)
+}
+
+func (t *telegrafLogger) Debug(args ...interface{}) {
+	t.log.Debug(args...)
+}
+
+func (t *telegrafLogger) Warnf(format string, args ...interface{}) {
+	t.log.Warnf(format, args...)
+}
+
+func (t *telegrafLogger) Warn(args ...interface{}) {
+	t.log.Warn(args...)
+}
+
+func (t *telegrafLogger) Infof(format string, args ...interface{}) {
+	t.log.Infof(format, args...)
+}
+
+func (t *telegrafLogger) Info(args ...interface{}) {
+	t.log.Info(args...)
+}

--- a/pkg/monitors/telegraf/monitors/tail/tail.go
+++ b/pkg/monitors/telegraf/monitors/tail/tail.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/logging"
+
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/tail"
 	telegrafParsers "github.com/influxdata/telegraf/plugins/parsers"
@@ -55,6 +57,7 @@ var factory = telegrafInputs.Inputs["tail"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.plugin = factory().(*telegrafPlugin.Tail)
+	m.plugin.Log = logging.NewLogger(logger)
 
 	// use the default config
 	if conf.TelegrafParser == nil {

--- a/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
+++ b/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/logging"
+
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/logparser"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
@@ -60,6 +62,7 @@ var factory = telegrafInputs.Inputs["logparser"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.plugin = factory().(*telegrafPlugin.LogParserPlugin)
+	m.plugin.Log = logging.NewLogger(logger)
 
 	// copy configurations to the plugin
 	if err = deepcopier.Copy(conf).To(m.plugin); err != nil {

--- a/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
+++ b/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/logging"
+
 	"github.com/ulule/deepcopier"
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
@@ -78,6 +80,7 @@ var factory = telegrafInputs.Inputs["statsd"]
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	m.plugin = factory().(*telegrafPlugin.Statsd)
+	m.plugin.Log = logging.NewLogger(logger)
 
 	// copy configurations to the plugin
 	if err = deepcopier.Copy(conf).To(m.plugin); err != nil {

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/logging"
+
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/win_perf_counters"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
@@ -23,6 +25,7 @@ var logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
 // (i.e. system utilization, windows iis)
 func GetPlugin(conf *Config) (*telegrafPlugin.Win_PerfCounters, error) {
 	plugin := telegrafInputs.Inputs["win_perf_counters"]().(*telegrafPlugin.Win_PerfCounters)
+	plugin.Log = logging.NewLogger(logger)
 
 	// copy top level struct fields
 	if err := deepcopier.Copy(conf).To(plugin); err != nil {

--- a/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
+++ b/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/logging"
+
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/win_services"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
@@ -20,6 +22,7 @@ var logger = logrus.WithField("monitorType", monitorType)
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
 	plugin := telegrafInputs.Inputs["win_services"]().(*telegrafPlugin.WinServices)
+	plugin.Log = logging.NewLogger(logger)
 
 	// create the emitter
 	em := baseemitter.NewEmitter(m.Output, logger)

--- a/tests/monitors/telegraf_statsd/telegraf_statsd_test.py
+++ b/tests/monitors/telegraf_statsd/telegraf_statsd_test.py
@@ -11,7 +11,7 @@ from tests.helpers.util import send_udp_message, wait_for
 pytestmark = [pytest.mark.windows, pytest.mark.telegraf_statsd, pytest.mark.telegraf]
 
 # regex used to scrape the address and port that dogstatsd is listening on
-STATSD_RE = re.compile(r"(?<=listener listening on:(?=(\s+)(?=(\d+.\d+.\d+.\d+)\:(\d+))))")
+STATSD_RE = re.compile(r'UDP listening on\s+\\"(\d+.\d+.\d+.\d+)\:(\d+)\\"')
 
 MONITOR_CONFIG = """
 monitors:
@@ -29,10 +29,8 @@ def test_telegraf_statsd():
         assert wait_for(p(regex_search_matches_output, agent.get_output, STATSD_RE.search))
 
         # scrape the host and port that the statsd plugin is listening on
-        regex_results = STATSD_RE.search(agent.output)
-
-        host = regex_results.groups()[1]
-        port = int(regex_results.groups()[2])
+        host, port = STATSD_RE.search(agent.output).groups()
+        port = int(port)
 
         # send datapoints to the statsd listener
         for _ in range(0, 10):


### PR DESCRIPTION
This skips the uid lookup since we don't use it. See upstream PRs
for some more background:

https://github.com/shirou/gopsutil/issues/784
https://github.com/shirou/gopsutil/pull/783

This requires upgrading gopsutil which changed some structs which in
turn requires upgrading telegraf. Apparently the `Stolen` field was never set
(https://github.com/shirou/gopsutil/pull/677)

Even with this change there are still some performance issues in the host
observer on machines with a large number of connections. Something like this
change would be required to deal with the remaining issues:

https://github.com/shirou/gopsutil/issues/695