### PR TITLE
kubernetes-cluster monitor bug fix for job metrics

### DIFF
--- a/pkg/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/jobs.go
@@ -18,38 +18,53 @@ func datapointsForJob(job *batchv1.Job) []*datapoint.Datapoint {
 		"kubernetes_name":      job.Name,
 	}
 
-	return []*datapoint.Datapoint{
-		datapoint.New(
-			"kubernetes.job.completions",
-			dimensions,
-			datapoint.NewIntValue(int64(*job.Spec.Completions)),
-			datapoint.Gauge,
-			time.Time{}),
-		datapoint.New(
-			"kubernetes.job.parallelism",
-			dimensions,
-			datapoint.NewIntValue(int64(*job.Spec.Parallelism)),
-			datapoint.Gauge,
-			time.Time{}),
+	var dps []*datapoint.Datapoint
+
+	if job.Spec.Completions != nil {
+		dps = append(dps,
+			datapoint.New(
+				"kubernetes.job.completions",
+				dimensions,
+				datapoint.NewIntValue(int64(*job.Spec.Completions)),
+				datapoint.Gauge,
+				time.Time{}))
+	}
+
+	if job.Spec.Parallelism != nil {
+		dps = append(dps,
+			datapoint.New(
+				"kubernetes.job.parallelism",
+				dimensions,
+				datapoint.NewIntValue(int64(*job.Spec.Parallelism)),
+				datapoint.Gauge,
+				time.Time{}))
+	}
+
+	dps = append(dps,
 		datapoint.New(
 			"kubernetes.job.active",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Active)),
 			datapoint.Gauge,
-			time.Time{}),
+			time.Time{}))
+
+	dps = append(dps,
 		datapoint.New(
 			"kubernetes.job.failed",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Failed)),
 			datapoint.Counter,
-			time.Time{}),
+			time.Time{}))
+
+	dps = append(dps,
 		datapoint.New(
 			"kubernetes.job.succeeded",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Succeeded)),
 			datapoint.Counter,
-			time.Time{}),
-	}
+			time.Time{}))
+
+	return dps
 }
 
 func dimensionForJob(job *batchv1.Job) *atypes.Dimension {

--- a/tests/monitors/kubernetes_cluster/job-no-completions.yaml
+++ b/tests/monitors/kubernetes_cluster/job-no-completions.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pi-no-completions
+spec:
+  parallelism: 1
+  activeDeadlineSeconds: 300
+  template:
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+      imagePullPolicy: Always
+  backoffLimit: 4


### PR DESCRIPTION
To address user reported https://github.com/signalfx/signalfx-agent/issues/1151

The `kubernetes.job.completions` and `kubernetes.job.paralellism` metrics
may be unset, resulting in null pointer errors.
This commit adds checks for existence of each attribute, as well as a
new test for checking their lack of existence.