### PR TITLE
Clean up redundent time.Now() calls in kubernetes-cluster monitor

### DIFF
--- a/pkg/monitors/kubernetes/cluster/metrics/containers.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/containers.go
@@ -17,13 +17,13 @@ func datapointsForContainerStatus(cs v1.ContainerStatus, contDims map[string]str
 			contDims,
 			datapoint.NewIntValue(int64(cs.RestartCount)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.container_ready",
 			contDims,
 			datapoint.NewIntValue(int64(utils.BoolToInt(cs.Ready))),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 
 	return dps
@@ -39,7 +39,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	if val, ok := c.Resources.Limits[v1.ResourceCPU]; ok {
@@ -49,7 +49,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	if val, ok := c.Resources.Requests[v1.ResourceMemory]; ok {
@@ -59,7 +59,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	if val, ok := c.Resources.Limits[v1.ResourceMemory]; ok {
@@ -69,7 +69,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	if val, ok := c.Resources.Requests[v1.ResourceEphemeralStorage]; ok {
@@ -79,7 +79,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	if val, ok := c.Resources.Limits[v1.ResourceEphemeralStorage]; ok {
@@ -89,7 +89,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 				contDims,
 				datapoint.NewIntValue(val.Value()),
 				datapoint.Gauge,
-				time.Now()))
+				time.Time{}))
 	}
 
 	return dps

--- a/pkg/monitors/kubernetes/cluster/metrics/cronjobs.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/cronjobs.go
@@ -24,7 +24,7 @@ func datapointsForCronJob(cj *batchv1beta1.CronJob) []*datapoint.Datapoint {
 			dimensions,
 			datapoint.NewIntValue(int64(len(cj.Status.Active))),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 }
 

--- a/pkg/monitors/kubernetes/cluster/metrics/daemonsets.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/daemonsets.go
@@ -24,25 +24,25 @@ func datapointsForDaemonSet(ds *appsv1.DaemonSet) []*datapoint.Datapoint {
 			dimensions,
 			datapoint.NewIntValue(int64(ds.Status.CurrentNumberScheduled)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.daemon_set.desired_scheduled",
 			dimensions,
 			datapoint.NewIntValue(int64(ds.Status.DesiredNumberScheduled)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.daemon_set.misscheduled",
 			dimensions,
 			datapoint.NewIntValue(int64(ds.Status.NumberMisscheduled)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.daemon_set.ready",
 			dimensions,
 			datapoint.NewIntValue(int64(ds.Status.NumberReady)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 }
 

--- a/pkg/monitors/kubernetes/cluster/metrics/hpa.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/hpa.go
@@ -27,25 +27,25 @@ func datapointsForHpa(hpa *v2beta1.HorizontalPodAutoscaler) []*datapoint.Datapoi
 			dimensions,
 			datapoint.NewIntValue(int64(hpa.Spec.MaxReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			meta.KubernetesHpaSpecMinReplicas,
 			dimensions,
 			datapoint.NewIntValue(int64(*hpa.Spec.MinReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			meta.KubernetesHpaStatusCurrentReplicas,
 			dimensions,
 			datapoint.NewIntValue(int64(hpa.Status.CurrentReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			meta.KubernetesHpaStatusDesiredReplicas,
 			dimensions,
 			datapoint.NewIntValue(int64(hpa.Status.DesiredReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}, newStatusDatapoints(hpa, dimensions)...)
 }
 
@@ -74,7 +74,7 @@ func newStatusDatapoints(hpa *v2beta1.HorizontalPodAutoscaler, dimensions map[st
 			logger.WithError(err).Errorf("Could not create hpa status datapoint")
 			continue
 		}
-		dps = append(dps, datapoint.New(metric, dimensions, value, datapoint.Gauge, time.Now()))
+		dps = append(dps, datapoint.New(metric, dimensions, value, datapoint.Gauge, time.Time{}))
 	}
 	return dps
 }

--- a/pkg/monitors/kubernetes/cluster/metrics/jobs.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/jobs.go
@@ -24,31 +24,31 @@ func datapointsForJob(job *batchv1.Job) []*datapoint.Datapoint {
 			dimensions,
 			datapoint.NewIntValue(int64(*job.Spec.Completions)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.job.parallelism",
 			dimensions,
 			datapoint.NewIntValue(int64(*job.Spec.Parallelism)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.job.active",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Active)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.job.failed",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Failed)),
 			datapoint.Counter,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.job.succeeded",
 			dimensions,
 			datapoint.NewIntValue(int64(job.Status.Succeeded)),
 			datapoint.Counter,
-			time.Now()),
+			time.Time{}),
 	}
 }
 

--- a/pkg/monitors/kubernetes/cluster/metrics/openshiftquotas.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/openshiftquotas.go
@@ -55,7 +55,7 @@ func buildDatapoints(metricPrefix string, dimensions map[string]string,
 					dimensions,
 					datapoint.NewIntValue(quantity.Value()),
 					datapoint.Gauge,
-					time.Now()))
+					time.Time{}))
 		}
 
 		if quantity, ok := used[resource]; ok {
@@ -65,7 +65,7 @@ func buildDatapoints(metricPrefix string, dimensions map[string]string,
 					dimensions,
 					datapoint.NewIntValue(quantity.Value()),
 					datapoint.Gauge,
-					time.Now()))
+					time.Time{}))
 		}
 	}
 	return dps

--- a/pkg/monitors/kubernetes/cluster/metrics/pods.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/pods.go
@@ -29,7 +29,7 @@ func datapointsForPod(pod *v1.Pod) []*datapoint.Datapoint {
 			dimensions,
 			datapoint.NewIntValue(phaseToInt(pod.Status.Phase)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 
 	containersInPodByName := make(map[string]map[string]string)

--- a/pkg/monitors/kubernetes/cluster/metrics/replica.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/replica.go
@@ -14,12 +14,12 @@ func makeReplicaDPs(resource string, dimensions map[string]string, desired, avai
 			dimensions,
 			datapoint.NewIntValue(int64(desired)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			fmt.Sprintf("kubernetes.%s.available", resource),
 			dimensions,
 			datapoint.NewIntValue(int64(available)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 }

--- a/pkg/monitors/kubernetes/cluster/metrics/statefulsets.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/statefulsets.go
@@ -29,25 +29,25 @@ func datapointsForStatefulSet(ss *appsv1.StatefulSet) []*datapoint.Datapoint {
 			dimensions,
 			datapoint.NewIntValue(int64(*ss.Spec.Replicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.stateful_set.ready",
 			dimensions,
 			datapoint.NewIntValue(int64(ss.Status.ReadyReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.stateful_set.current",
 			dimensions,
 			datapoint.NewIntValue(int64(ss.Status.CurrentReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 		datapoint.New(
 			"kubernetes.stateful_set.updated",
 			dimensions,
 			datapoint.NewIntValue(int64(ss.Status.UpdatedReplicas)),
 			datapoint.Gauge,
-			time.Now()),
+			time.Time{}),
 	}
 }
 


### PR DESCRIPTION
These timestamps are set later higher up in the monitor.