### PR TITLE
Remove signalfx-metadata from default configs

### DIFF
--- a/deployments/ansible/README.md
+++ b/deployments/ansible/README.md
@@ -40,8 +40,6 @@ This role sources the following variables:
         - type: load
         - type: memory
         - type: vmem
-        - type: collectd/signalfx-metadata
-          omitProcessInfo: true
         - type: host-metadata
         - type: processlist
     ```

--- a/deployments/ansible/example-config.yml
+++ b/deployments/ansible/example-config.yml
@@ -8,8 +8,6 @@ sfx_agent_config:
     - type: net-io
     - type: load
     - type: memory
-    - type: collectd/signalfx-metadata
-      omitProcessInfo: true
     - type: host-metadata
     - type: processlist
     - type: vmem

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -54,7 +54,6 @@ node['signalfx_agent']['conf'] = {
     {type: "net-io"},
     {type: "load"},
     {type: "memory"},
-    {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},
     {type: "vmem"}
     {type: "host-metadata"},
     {type: "processlist"},

--- a/deployments/chef/example_attrs.json
+++ b/deployments/chef/example_attrs.json
@@ -13,7 +13,6 @@
       {"type": "net-io"},
       {"type": "load"},
       {"type": "memory"},
-      {"type": "collectd/signalfx-metadata", "omitProcessInfo": true},
       {"type": "vmem"},
       {"type": "host-metadata"}
       {"type": "processlist"}

--- a/deployments/docker/agent.yaml
+++ b/deployments/docker/agent.yaml
@@ -29,8 +29,6 @@ monitors:
   - type: load
   - type: memory
   - type: vmem
-  - type: collectd/signalfx-metadata
-    omitProcessInfo: true
   - type: host-metadata
   - type: processlist
   - type: docker-container-stats

--- a/deployments/ecs/agent.yaml
+++ b/deployments/ecs/agent.yaml
@@ -42,8 +42,6 @@ monitors:
   - type: net-io
   - type: load
   - type: memory
-  - type: collectd/signalfx-metadata
-    omitProcessInfo: true
   - type: host-metadata
   - type: processlist
   - type: vmem

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -24,8 +24,6 @@ monitors:
   - type: load
   - type: memory
   - type: collectd/protocols
-  - type: collectd/signalfx-metadata
-    omitProcessInfo: true
   - type: vmem
 
   - type: ecs-metadata

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -36,12 +36,8 @@ data:
     - type: net-io
     - type: load
     - type: memory
-    - type: collectd/protocols
-    - type: collectd/signalfx-metadata
-      omitProcessInfo: true
     - type: host-metadata
     - type: processlist
-    - type: collectd/uptime
     - type: vmem
 
     - type: kubelet-stats

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -60,12 +60,8 @@ data:
     - type: net-io
     - type: load
     - type: memory
-    - type: collectd/protocols
-    - type: collectd/signalfx-metadata
-      omitProcessInfo: true
     - type: host-metadata
     - type: processlist
-    - type: collectd/uptime
     - type: vmem
 
     - type: kubelet-stats

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -23,11 +23,8 @@ class accepts the following parameters:
         {type: "net-io"},
         {type: "load"},
         {type: "memory"},
-        {type: "collectd/protocols"},
-        {type: "collectd/signalfx-metadata", "omitProcessInfo": true},
         {type: "host-metadata"},
         {type: "processlist"},
-        {type: "collectd/uptime"},
         {type: "vmem"}
       ]
     }

--- a/deployments/salt/README.md
+++ b/deployments/salt/README.md
@@ -51,8 +51,6 @@ signalfx-agent:
       - type: load
       - type: memory
       - type: vmem
-      - type: collectd/signalfx-metadata
-        omitProcessInfo: true
       - type: host-metadata
       - type: processlist
 ```

--- a/deployments/salt/pillar.example
+++ b/deployments/salt/pillar.example
@@ -12,7 +12,5 @@ signalfx-agent:
       - type: net-io
       - type: load
       - type: memory
-      - type: collectd/signalfx-metadata
-        omitProcessInfo: true
       - type: vmem
       - type: processlist

--- a/packaging/etc/agent.yaml
+++ b/packaging/etc/agent.yaml
@@ -25,8 +25,6 @@ monitors:
   - type: net-io
   - type: load
   - type: memory
-  - type: collectd/signalfx-metadata
-    omitProcessInfo: true
   - type: vmem
 
 enableBuiltInFiltering: true


### PR DESCRIPTION
It is no longer necessary since we don't use it for utilization metrics, process list
generation, or host metadata anymore.

Also removing collectd/protocols and collectd/uptime monitors from defaults.