### PR TITLE
Convert haproxy, conviva, ecs, logstash, expvar to use httpconfig

### DIFF
--- a/docs/monitors/conviva.md
+++ b/docs/monitors/conviva.md
@@ -149,9 +149,14 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
-| `pulseUsername` | **yes** | `string` | Conviva Pulse username required with each API request. |
-| `pulsePassword` | **yes** | `string` | Conviva Pulse password required with each API request. |
-| `timeoutSeconds` | no | `integer` |  (**default:** `10`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
+| `username` | no | `string` | Basic Auth username to use on each request, if any. |
+| `password` | no | `string` | Basic Auth password to use on each request, if any. |
+| `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
+| `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
+| `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
+| `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `metricConfigs` | no | `list of objects (see below)` | Conviva metrics to fetch. The default is quality_metriclens metric with the "All Traffic" filter applied and all quality_metriclens dimensions. |
 
 

--- a/docs/monitors/ecs-metadata.md
+++ b/docs/monitors/ecs-metadata.md
@@ -37,9 +37,16 @@ Configuration](../monitor-config.md#common-configuration).**
 | `enableExtraCPUMetrics` | no | `bool` | Whether it will send all extra CPU metrics as well. (**default:** `false`) |
 | `enableExtraMemoryMetrics` | no | `bool` | Whether it will send all extra memory metrics as well. (**default:** `false`) |
 | `enableExtraNetworkMetrics` | no | `bool` | Whether it will send all extra network metrics as well. (**default:** `false`) |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
+| `username` | no | `string` | Basic Auth username to use on each request, if any. |
+| `password` | no | `string` | Basic Auth password to use on each request, if any. |
+| `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
+| `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
+| `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
+| `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `metadataEndpoint` | no | `string` | The URL of the ECS task metadata. Default is http://169.254.170.2/v2/metadata, which is hardcoded by AWS for version 2. (**default:** `http://169.254.170.2/v2/metadata`) |
 | `statsEndpoint` | no | `string` | The URL of the ECS container stats. Default is http://169.254.170.2/v2/stats, which is hardcoded by AWS for version 2. (**default:** `http://169.254.170.2/v2/stats`) |
-| `timeoutSeconds` | no | `integer` | The maximum amount of time to wait for API requests (**default:** `5`) |
 | `labelsToDimensions` | no | `map of strings` | A mapping of container label names to dimension names. The corresponding label values will become the dimension value for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a dimension called `container_spec_name` that has the value of the `io.kubernetes.container.name` container label. |
 | `excludedImages` | no | `list of strings` | A list of filters of images to exclude.  Supports literals, globs, and regex. |
 

--- a/docs/monitors/expvar.md
+++ b/docs/monitors/expvar.md
@@ -239,8 +239,6 @@ Configuration](../monitor-config.md#common-configuration).**
 | `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `host` | **yes** | `string` | Host of the expvar endpoint |
 | `port` | **yes** | `integer` | Port of the expvar endpoint |
-| `useHTTPS` | no | `bool` | If true, the agent will connect to the host using HTTPS instead of plain HTTP. (**default:** `false`) |
-| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the host's TLS cert will not be verified. (**default:** `false`) |
 | `path` | no | `string` | Path to the expvar endpoint, usually `/debug/vars` (the default). (**default:** `/debug/vars`) |
 | `enhancedMetrics` | no | `bool` | If true, sends metrics memstats.alloc, memstats.by_size.size, memstats.by_size.mallocs and memstats.by_size.frees (**default:** `false`) |
 | `metrics` | no | `list of objects (see below)` | Metrics configurations |

--- a/docs/monitors/expvar.md
+++ b/docs/monitors/expvar.md
@@ -229,6 +229,14 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
+| `username` | no | `string` | Basic Auth username to use on each request, if any. |
+| `password` | no | `string` | Basic Auth password to use on each request, if any. |
+| `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
+| `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
+| `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
+| `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `host` | **yes** | `string` | Host of the expvar endpoint |
 | `port` | **yes** | `integer` | Port of the expvar endpoint |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the host using HTTPS instead of plain HTTP. (**default:** `false`) |

--- a/docs/monitors/haproxy.md
+++ b/docs/monitors/haproxy.md
@@ -73,16 +73,20 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
+| `username` | no | `string` | Basic Auth username to use on each request, if any. |
+| `password` | no | `string` | Basic Auth password to use on each request, if any. |
+| `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
+| `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
+| `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
+| `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `host` | no | `string` | The host/ip address of the HAProxy instance. This is used to construct the `url` option if not provided. |
 | `port` | no | `integer` | The port of the HAProxy instance's stats endpoint (if using HTTP). This is used to construct the `url` option if not provided. (**default:** `0`) |
 | `path` | no | `string` | The path to HAProxy stats. The default is `stats?stats;csv`. This is used to construct the `url` option if not provided. (**default:** `stats?stats;csv`) |
-| `useHTTPS` | no | `bool` | Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`. (**default:** `false`) |
-| `url` | no | `string` | URL on which to scrape HAProxy. Scheme `http://` for http-type and `unix://` socket-type urls. If this is not provided, it will be derive from the `host`, `port`, `path`, and `useHTTPS` options. |
-| `username` | no | `string` | Basic Auth username to use on each request, if any. |
-| `password` | no | `string` | Basic Auth password to use on each request, if any. |
-| `sslVerify` | no | `bool` | Flag that enables SSL certificate verification for the scrape URL. (**default:** `true`) |
-| `timeout` | no | `int64` | Timeout for trying to get stats from HAProxy. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `5s`) |
+| `url` | no | `string` | Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`. |
 | `proxies` | no | `list of strings` | A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported. |
+| `unixTimeout` | no | `int64` | Timeout when communicating over Unix sockets (**default:** `10s`) |
 
 
 ## Metrics

--- a/docs/monitors/haproxy.md
+++ b/docs/monitors/haproxy.md
@@ -84,7 +84,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `host` | no | `string` | The host/ip address of the HAProxy instance. This is used to construct the `url` option if not provided. |
 | `port` | no | `integer` | The port of the HAProxy instance's stats endpoint (if using HTTP). This is used to construct the `url` option if not provided. (**default:** `0`) |
 | `path` | no | `string` | The path to HAProxy stats. The default is `stats?stats;csv`. This is used to construct the `url` option if not provided. (**default:** `stats?stats;csv`) |
-| `url` | no | `string` | Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`. |
+| `url` | no | `string` | URL including the scheme which can be http, http, or unix. If you want to use a Unix socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`. |
 | `proxies` | no | `list of strings` | A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported. |
 | `unixTimeout` | no | `int64` | Timeout when communicating over Unix sockets (**default:** `10s`) |
 

--- a/docs/monitors/logstash.md
+++ b/docs/monitors/logstash.md
@@ -31,10 +31,16 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
+| `httpTimeout` | no | `int64` | HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `10s`) |
+| `username` | no | `string` | Basic Auth username to use on each request, if any. |
+| `password` | no | `string` | Basic Auth password to use on each request, if any. |
+| `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
+| `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
+| `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |
+| `clientKeyPath` | no | `string` | Path to the client TLS key to use for TLS required connections |
 | `host` | no | `string` | The hostname of Logstash monitoring API (**default:** `127.0.0.1`) |
 | `port` | no | `integer` | The port number of Logstash monitoring API (**default:** `9600`) |
-| `useHTTPS` | no | `bool` | If true, the agent will connect to the host using HTTPS instead of plain HTTP. (**default:** `false`) |
-| `timeoutSeconds` | no | `integer` | The maximum amount of time to wait for API requests (**default:** `5`) |
 
 
 ## Metrics

--- a/pkg/core/common/httpclient/http.go
+++ b/pkg/core/common/httpclient/http.go
@@ -4,9 +4,8 @@ import (
 	"crypto/tls"
 	"net/http"
 
-	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // HTTPConfig can be embedded inside a monitor config.

--- a/pkg/core/common/httpclient/http_test.go
+++ b/pkg/core/common/httpclient/http_test.go
@@ -176,3 +176,21 @@ func TestHttpConfig_Scheme(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPConfig_BuildCustomizeTransport(t *testing.T) {
+	req := require.New(t)
+	h1 := &HTTPConfig{}
+	client, err := h1.BuildCustomizeTransport(func(t *http.Transport) {
+		t.MaxIdleConns = 999
+	})
+	req.NoError(err)
+	req.Equal(999, client.Transport.(*http.Transport).MaxIdleConns)
+
+	// test auth because it wraps the transport
+	h2 := &HTTPConfig{Username: "bob", Password: "password"}
+	client, err = h2.BuildCustomizeTransport(func(t *http.Transport) {
+		t.MaxIdleConns = 999
+	})
+	req.NoError(err)
+	req.Equal(999, client.Transport.(*auth.TransportWithBasicAuth).RoundTripper.(*http.Transport).MaxIdleConns)
+}

--- a/pkg/monitors/conviva/client.go
+++ b/pkg/monitors/conviva/client.go
@@ -22,28 +22,22 @@ type httpClient interface {
 }
 
 type convivaHTTPClient struct {
-	client   *http.Client
-	username string
-	password string
+	client *http.Client
 }
 
 // newConvivaClient factory function for creating HTTPClientt
-func newConvivaClient(client *http.Client, username string, password string) httpClient {
+func newConvivaClient(client *http.Client) httpClient {
 	return &convivaHTTPClient{
-		client:   client,
-		username: username,
-		password: password,
+		client: client,
 	}
 }
 
 // Get method for Conviva API specific gets
 func (c *convivaHTTPClient) get(ctx context.Context, v interface{}, url string) (int, error) {
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return 0, err
 	}
-	req = req.WithContext(ctx)
-	req.SetBasicAuth(c.username, c.password)
 	res, err := c.client.Do(req)
 	if err != nil {
 		return 0, err

--- a/pkg/monitors/conviva/conviva.go
+++ b/pkg/monitors/conviva/conviva.go
@@ -54,7 +54,7 @@ func init() {
 // Configure monitor
 func (m *Monitor) Configure(conf *Config) error {
 	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
-	m.timeout = conf.HTTPTimeout
+	m.timeout = conf.HTTPTimeout.AsDuration()
 
 	httpClient, err := conf.BuildCustomizeTransport(func(t *http.Transport) {
 		t.MaxIdleConnsPerHost = 100

--- a/pkg/monitors/ecs/ecs.go
+++ b/pkg/monitors/ecs/ecs.go
@@ -62,7 +62,6 @@ type Monitor struct {
 	client         *http.Client
 	conf           *Config
 	ctx            context.Context
-	timeout        time.Duration
 	taskDimensions map[string]string
 	containers     map[string]ecs.Container
 	// shouldIgnore - key : container docker id, tells if stats for the container should be ignored.

--- a/pkg/monitors/expvar/config.go
+++ b/pkg/monitors/expvar/config.go
@@ -5,13 +5,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/signalfx/signalfx-agent/pkg/utils"
-
-	"github.com/signalfx/signalfx-agent/pkg/core/config/validation"
-
 	"github.com/signalfx/golib/v3/datapoint"
-
+	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/core/config/validation"
+	"github.com/signalfx/signalfx-agent/pkg/utils"
 )
 
 const (
@@ -20,7 +18,9 @@ const (
 
 // Config for monitor configuration
 type Config struct {
-	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
+	config.MonitorConfig  `yaml:",inline" acceptsEndpoints:"true"`
+	httpclient.HTTPConfig `yaml:",inline"`
+
 	// Host of the expvar endpoint
 	Host string `yaml:"host" validate:"required"`
 	// Port of the expvar endpoint

--- a/pkg/monitors/expvar/config.go
+++ b/pkg/monitors/expvar/config.go
@@ -25,10 +25,6 @@ type Config struct {
 	Host string `yaml:"host" validate:"required"`
 	// Port of the expvar endpoint
 	Port uint16 `yaml:"port" validate:"required"`
-	// If true, the agent will connect to the host using HTTPS instead of plain HTTP.
-	UseHTTPS bool `yaml:"useHTTPS"`
-	// If useHTTPS is true and this option is also true, the host's TLS cert will not be verified.
-	SkipVerify bool `yaml:"skipVerify"`
 	// Path to the expvar endpoint, usually `/debug/vars` (the default).
 	Path string `yaml:"path" default:"/debug/vars"`
 	// If true, sends metrics memstats.alloc, memstats.by_size.size, memstats.by_size.mallocs and memstats.by_size.frees

--- a/pkg/monitors/expvar/expvar.go
+++ b/pkg/monitors/expvar/expvar.go
@@ -55,11 +55,11 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 		conf.EnhancedMetrics = true
 	}
 	m.ctx, m.cancel = context.WithCancel(context.Background())
-	m.client = &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConnsPerHost: 10,
-		},
-		Timeout: 300 * time.Millisecond,
+	m.client, err = conf.BuildCustomizeTransport(func(t *http.Transport) {
+		t.MaxIdleConnsPerHost = 10
+	})
+	if err != nil {
+		return err
 	}
 
 	url := conf.getURL()

--- a/pkg/monitors/haproxy/config.go
+++ b/pkg/monitors/haproxy/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // Config is the config for this monitor.
@@ -22,6 +23,8 @@ type Config struct {
 	URL string `yaml:"url"`
 	// A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported.
 	Proxies []string `yaml:"proxies"`
+	// Timeout when communicating over Unix sockets
+	UnixTimeout timeutil.Duration `yaml:"unixTimeout" default:"10s"`
 }
 
 func (c *Config) ScrapeURL() string {

--- a/pkg/monitors/haproxy/config.go
+++ b/pkg/monitors/haproxy/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	Port uint16 `yaml:"port"`
 	// The path to HAProxy stats. The default is `stats?stats;csv`. This is used to construct the `url` option if not provided.
 	Path string `yaml:"path" default:"stats?stats;csv"`
-	// Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.
+	// URL including the scheme which can be http, http, or unix. If you want to use a Unix socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.
 	URL string `yaml:"url"`
 	// A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported.
 	Proxies []string `yaml:"proxies"`

--- a/pkg/monitors/haproxy/config.go
+++ b/pkg/monitors/haproxy/config.go
@@ -3,13 +3,15 @@ package haproxy
 import (
 	"fmt"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
-	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // Config is the config for this monitor.
 type Config struct {
-	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
+	config.MonitorConfig  `yaml:",inline" acceptsEndpoints:"true"`
+	httpclient.HTTPConfig `yaml:",inline"`
+
 	// The host/ip address of the HAProxy instance. This is used to construct the `url` option if not provided.
 	Host string `yaml:"host"`
 	// The port of the HAProxy instance's stats endpoint (if using HTTP). This is used to construct the `url` option if not provided.
@@ -17,17 +19,7 @@ type Config struct {
 	// The path to HAProxy stats. The default is `stats?stats;csv`. This is used to construct the `url` option if not provided.
 	Path string `yaml:"path" default:"stats?stats;csv"`
 	// Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.
-	UseHTTPS bool `yaml:"useHTTPS"`
-	// URL on which to scrape HAProxy. Scheme `http://` for http-type and `unix://` socket-type urls. If this is not provided, it will be derive from the `host`, `port`, `path`, and `useHTTPS` options.
 	URL string `yaml:"url"`
-	// Basic Auth username to use on each request, if any.
-	Username string `yaml:"username"`
-	// Basic Auth password to use on each request, if any.
-	Password string `yaml:"password" neverLog:"true"`
-	// Flag that enables SSL certificate verification for the scrape URL.
-	SSLVerify bool `yaml:"sslVerify" default:"true"`
-	// Timeout for trying to get stats from HAProxy. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
-	Timeout timeutil.Duration `yaml:"timeout" default:"5s"`
 	// A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported.
 	Proxies []string `yaml:"proxies"`
 }
@@ -36,9 +28,5 @@ func (c *Config) ScrapeURL() string {
 	if c.URL != "" {
 		return c.URL
 	}
-	scheme := "http"
-	if c.UseHTTPS {
-		scheme = "https"
-	}
-	return fmt.Sprintf("%s://%s:%d/%s", scheme, c.Host, c.Port, c.Path)
+	return fmt.Sprintf("%s://%s:%d/%s", c.Scheme(), c.Host, c.Port, c.Path)
 }

--- a/pkg/monitors/haproxy/helpers.go
+++ b/pkg/monitors/haproxy/helpers.go
@@ -288,11 +288,11 @@ func socketReader(conf *Config, cmd string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse url %s status. %v", conf.ScrapeURL(), err)
 	}
-	f, err := net.DialTimeout("unix", u.Path, conf.HTTPTimeout.AsDuration())
+	f, err := net.DialTimeout("unix", u.Path, conf.UnixTimeout.AsDuration())
 	if err != nil {
 		return nil, err
 	}
-	if err := f.SetDeadline(time.Now().Add(conf.HTTPTimeout.AsDuration())); err != nil {
+	if err := f.SetDeadline(time.Now().Add(conf.UnixTimeout.AsDuration())); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/pkg/monitors/logstash/logstash/config.go
+++ b/pkg/monitors/logstash/logstash/config.go
@@ -2,20 +2,19 @@ package logstash
 
 import (
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 )
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true" singleInstance:"false"`
+	config.MonitorConfig  `yaml:",inline" acceptsEndpoints:"true" singleInstance:"false"`
+	httpclient.HTTPConfig `yaml:",inline"`
+
 	// The hostname of Logstash monitoring API
 	Host string `yaml:"host" default:"127.0.0.1"`
 	// The port number of Logstash monitoring API
 	Port uint16 `yaml:"port" default:"9600"`
-	// If true, the agent will connect to the host using HTTPS instead of plain HTTP.
-	UseHTTPS bool `yaml:"useHTTPS"`
-	// The maximum amount of time to wait for API requests
-	TimeoutSeconds int `yaml:"timeoutSeconds" default:"5"`
 }
 
 func (c *Config) getMetricTypeMap() map[string]datapoint.MetricType {

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -35391,6 +35391,70 @@
         "package": "pkg/monitors/logstash/logstash",
         "fields": [
           {
+            "yamlName": "httpTimeout",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "username",
+            "doc": "Basic Auth username to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "password",
+            "doc": "Basic Auth password to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the agent will connect to the exporter using HTTPS instead of plain HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "skipVerify",
+            "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "caCertPath",
+            "doc": "Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientCertPath",
+            "doc": "Path to the client TLS cert to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientKeyPath",
+            "doc": "Path to the client TLS key to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "host",
             "doc": "The hostname of Logstash monitoring API",
             "default": "127.0.0.1",
@@ -35404,22 +35468,6 @@
             "default": 9600,
             "required": false,
             "type": "uint16",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "useHTTPS",
-            "doc": "If true, the agent will connect to the host using HTTPS instead of plain HTTP.",
-            "default": false,
-            "required": false,
-            "type": "bool",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "timeoutSeconds",
-            "doc": "The maximum amount of time to wait for API requests",
-            "default": 5,
-            "required": false,
-            "type": "int",
             "elementKind": ""
           }
         ]

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -25858,7 +25858,7 @@
           },
           {
             "yamlName": "url",
-            "doc": "Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.",
+            "doc": "URL including the scheme which can be http, http, or unix. If you want to use a Unix socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.",
             "default": "",
             "required": false,
             "type": "string",

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -17526,27 +17526,67 @@
         "package": "pkg/monitors/conviva",
         "fields": [
           {
-            "yamlName": "pulseUsername",
-            "doc": "Conviva Pulse username required with each API request.",
-            "default": null,
-            "required": true,
-            "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "pulsePassword",
-            "doc": "Conviva Pulse password required with each API request.",
-            "default": null,
-            "required": true,
-            "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "timeoutSeconds",
-            "doc": "",
-            "default": 10,
+            "yamlName": "httpTimeout",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+            "default": "10s",
             "required": false,
-            "type": "int",
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "username",
+            "doc": "Basic Auth username to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "password",
+            "doc": "Basic Auth password to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the agent will connect to the exporter using HTTPS instead of plain HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "skipVerify",
+            "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "caCertPath",
+            "doc": "Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientCertPath",
+            "doc": "Path to the client TLS cert to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientKeyPath",
+            "doc": "Path to the client TLS key to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
             "elementKind": ""
           },
           {
@@ -25625,6 +25665,70 @@
         "package": "pkg/monitors/haproxy",
         "fields": [
           {
+            "yamlName": "httpTimeout",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "username",
+            "doc": "Basic Auth username to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "password",
+            "doc": "Basic Auth password to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the agent will connect to the exporter using HTTPS instead of plain HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "skipVerify",
+            "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "caCertPath",
+            "doc": "Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientCertPath",
+            "doc": "Path to the client TLS cert to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientKeyPath",
+            "doc": "Path to the client TLS key to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "host",
             "doc": "The host/ip address of the HAProxy instance. This is used to construct the `url` option if not provided.",
             "default": "",
@@ -25649,51 +25753,11 @@
             "elementKind": ""
           },
           {
-            "yamlName": "useHTTPS",
-            "doc": "Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.",
-            "default": false,
-            "required": false,
-            "type": "bool",
-            "elementKind": ""
-          },
-          {
             "yamlName": "url",
-            "doc": "URL on which to scrape HAProxy. Scheme `http://` for http-type and `unix://` socket-type urls. If this is not provided, it will be derive from the `host`, `port`, `path`, and `useHTTPS` options.",
+            "doc": "Whether to connect on HTTPS or HTTP. If you want to use a UNIX socket, then specify the `url` config option with the format `unix://...` and omit `host`, `port` and `useHTTPS`.",
             "default": "",
             "required": false,
             "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "username",
-            "doc": "Basic Auth username to use on each request, if any.",
-            "default": "",
-            "required": false,
-            "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "password",
-            "doc": "Basic Auth password to use on each request, if any.",
-            "default": "",
-            "required": false,
-            "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "sslVerify",
-            "doc": "Flag that enables SSL certificate verification for the scrape URL.",
-            "default": true,
-            "required": false,
-            "type": "bool",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "timeout",
-            "doc": "Timeout for trying to get stats from HAProxy. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
-            "default": "5s",
-            "required": false,
-            "type": "int64",
             "elementKind": ""
           },
           {
@@ -25703,6 +25767,14 @@
             "required": false,
             "type": "slice",
             "elementKind": "string"
+          },
+          {
+            "yamlName": "unixTimeout",
+            "doc": "Timeout when communicating over Unix sockets",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
           }
         ]
       },

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -23123,22 +23123,6 @@
             "elementKind": ""
           },
           {
-            "yamlName": "useHTTPS",
-            "doc": "If true, the agent will connect to the host using HTTPS instead of plain HTTP.",
-            "default": false,
-            "required": false,
-            "type": "bool",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "skipVerify",
-            "doc": "If useHTTPS is true and this option is also true, the host's TLS cert will not be verified.",
-            "default": false,
-            "required": false,
-            "type": "bool",
-            "elementKind": ""
-          },
-          {
             "yamlName": "path",
             "doc": "Path to the expvar endpoint, usually `/debug/vars` (the default).",
             "default": "/debug/vars",

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -19569,6 +19569,70 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpTimeout",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "username",
+            "doc": "Basic Auth username to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "password",
+            "doc": "Basic Auth password to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the agent will connect to the exporter using HTTPS instead of plain HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "skipVerify",
+            "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "caCertPath",
+            "doc": "Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientCertPath",
+            "doc": "Path to the client TLS cert to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientKeyPath",
+            "doc": "Path to the client TLS key to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "metadataEndpoint",
             "doc": "The URL of the ECS task metadata. Default is http://169.254.170.2/v2/metadata, which is hardcoded by AWS for version 2.",
             "default": "http://169.254.170.2/v2/metadata",
@@ -19582,14 +19646,6 @@
             "default": "http://169.254.170.2/v2/stats",
             "required": false,
             "type": "string",
-            "elementKind": ""
-          },
-          {
-            "yamlName": "timeoutSeconds",
-            "doc": "The maximum amount of time to wait for API requests",
-            "default": 5,
-            "required": false,
-            "type": "int",
             "elementKind": ""
           },
           {

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -23043,6 +23043,70 @@
         "package": "pkg/monitors/expvar",
         "fields": [
           {
+            "yamlName": "httpTimeout",
+            "doc": "HTTP timeout duration for both read and writes. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+            "default": "10s",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "username",
+            "doc": "Basic Auth username to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "password",
+            "doc": "Basic Auth password to use on each request, if any.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the agent will connect to the exporter using HTTPS instead of plain HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "skipVerify",
+            "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "caCertPath",
+            "doc": "Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientCertPath",
+            "doc": "Path to the client TLS cert to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "clientKeyPath",
+            "doc": "Path to the client TLS key to use for TLS required connections",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "host",
             "doc": "Host of the expvar endpoint",
             "default": null,


### PR DESCRIPTION
# 5.0 release notes
These monitors have been updated to have standard HTTP/HTTPS configuration options:

* haproxy
* conviva
* ecs
* logstash
* expvar

These include options to enable HTTPS as well as configure TLS certificates and timeouts.

Note that if the monitor had an option like `timeoutSeconds: 5` before the option is now `httpTimeout: 5` or `httpTimeout: 5s` (note the `s`). The durations can be explicitly specified as part of the value using Go's [ParseDuration syntax](https://golang.org/pkg/time/#ParseDuration). If the duration is left off it will be interpreted as seconds.

## conviva
`pulseUsername` option is now `username`

## haproxy
`sslVerify` which defaulted tor `true` is now `skipVerify` which defaults to `false`. The defaults are equivalent but if you had the option set the value is now inverse.