### PR TITLE
support tokens that start with -

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ and use it on your hosts by running:
 
 ```sh
 curl -sSL https://dl.signalfx.com/signalfx-agent.sh > /tmp/signalfx-agent.sh
-sudo sh /tmp/signalfx-agent.sh YOUR_SIGNALFX_API_TOKEN --realm YOUR_SIGNALFX_REALM
+sudo sh /tmp/signalfx-agent.sh --realm YOUR_SIGNALFX_REALM -- YOUR_SIGNALFX_API_TOKEN
 ```
 
 ##### Windows

--- a/deployments/installer/install.sh
+++ b/deployments/installer/install.sh
@@ -52,6 +52,10 @@ parse_args_and_install() {
         package_version="$2"
         shift 1
         ;;
+      --)
+        access_token="$2"
+        shift 1
+        ;;
       -h|--help)
         usage
         exit 0
@@ -106,6 +110,7 @@ Options:
   --api-url <api url>         Base URL of the SignalFx API server
   --test                      Use the test package repo instead of the primary
   --beta                      Use the beta package repo instead of the primary
+  --                          Use -- if your access_token starts with -
 
 EOH
   exit 0

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -80,7 +80,7 @@ To install the Smart Agent on a single Linux host, enter:
 
 ```sh
 curl -sSL https://dl.signalfx.com/signalfx-agent.sh > /tmp/signalfx-agent.sh
-sudo sh /tmp/signalfx-agent.sh --realm YOUR_SIGNALFX_REALM YOUR_SIGNALFX_API_TOKEN
+sudo sh /tmp/signalfx-agent.sh --realm YOUR_SIGNALFX_REALM -- YOUR_SIGNALFX_API_TOKEN
 ```
 
 __Windows:__ Ensure that the following dependencies are installed:


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

The current logic in `parse_args_and_install` marks any argument that starts with `-` and not equal to `-h` (the help option) as invalid.
This causes tokens that start with `-` to fail the argument parser.

We have few options to address this behavior:
1) add a key option for `access_token` (--access_token) and either keep or remove the old way of passing the token value without any key 
2) use `--` key option which signals the end of options and disables further option processing

After discussing it with @jaysfx , it made sense to go with 2) as it's a standard way used by many shell commands and we can keep the current behavior intact. 

example from rm help:
```
To remove a file whose name starts with a '-', for example '-foo', use one of these commands:

rm -- -foo
```

I also changed the usage to inform user of this option. 

Note:
My test only covered the install.sh script and made sure that the token gets stored in the appropriate file