### PR TITLE
Add disk_op.total metric and don't send all

### DIFF
--- a/docs/monitors/disk-io.md
+++ b/docs/monitors/disk-io.md
@@ -48,28 +48,54 @@ Configuration](../monitor-config.md#common-configuration).**
 ## Metrics
 
 These are the metrics available for this monitor.
-This monitor emits all metrics by default; however, **none are categorized as
+Metrics that are categorized as
 [container/host](https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics)
--- they are all custom**.
+(*default*) are ***in bold and italics*** in the list below.
 
 
-
- - ***`disk_merged.read`*** (*cumulative*)<br>    (Linux Only) The number of disk reads merged into single physical disk access operations.
- - ***`disk_merged.write`*** (*cumulative*)<br>    (Linux Only) The number of disk writes merged into single physical disk access operations.
- - ***`disk_octets.avg_read`*** (*gauge*)<br>    (Windows Only) The average number of octets (bytes) read.
- - ***`disk_octets.avg_write`*** (*gauge*)<br>    (Windows Only) The average number of octets (bytes) written.
- - ***`disk_octets.read`*** (*cumulative*)<br>    (Linux Only) The number of bytes (octets) read from a disk.
- - ***`disk_octets.write`*** (*cumulative*)<br>    (Linux Only) The number of bytes (octets) written to a disk.
+ - `disk_merged.read` (*cumulative*)<br>    (Linux Only) The number of disk reads merged into single physical disk access operations.
+ - `disk_merged.write` (*cumulative*)<br>    (Linux Only) The number of disk writes merged into single physical disk access operations.
+ - `disk_octets.avg_read` (*gauge*)<br>    (Windows Only) The average number of octets (bytes) read.
+ - `disk_octets.avg_write` (*gauge*)<br>    (Windows Only) The average number of octets (bytes) written.
+ - `disk_octets.read` (*cumulative*)<br>    (Linux Only) The number of bytes (octets) read from a disk.
+ - `disk_octets.write` (*cumulative*)<br>    (Linux Only) The number of bytes (octets) written to a disk.
  - ***`disk_ops.avg_read`*** (*gauge*)<br>    (Windows Only) The average disk read queue length.
  - ***`disk_ops.avg_write`*** (*gauge*)<br>    (Windows Only) The average disk write queue length.
  - ***`disk_ops.read`*** (*cumulative*)<br>    (Linux Only) The number of disk read operations.
+ - ***`disk_ops.total`*** (*gauge*)<br>    (Linux Only) The number of both read and write disk operations across all disks in the last reporting interval.
  - ***`disk_ops.write`*** (*cumulative*)<br>    (Linux Only) The number of disk write operations.
- - ***`disk_time.avg_read`*** (*gauge*)<br>    (Windows Only) The average time spent reading from the disk.
- - ***`disk_time.avg_write`*** (*gauge*)<br>    (Windows Only) The average time spent writing to the disk
- - ***`disk_time.read`*** (*cumulative*)<br>    (Linux Only) The average amount of time it took to do a read operation.
- - ***`disk_time.write`*** (*cumulative*)<br>    (Linux Only) The average amount of time it took to do a write operation.
-The agent does not do any built-in filtering of metrics coming out of this
-monitor.
+ - `disk_time.avg_read` (*gauge*)<br>    (Windows Only) The average time spent reading from the disk.
+ - `disk_time.avg_write` (*gauge*)<br>    (Windows Only) The average time spent writing to the disk
+ - `disk_time.read` (*cumulative*)<br>    (Linux Only) The average amount of time it took to do a read operation.
+ - `disk_time.write` (*cumulative*)<br>    (Linux Only) The average amount of time it took to do a write operation.
+
+### Non-default metrics (version 4.7.0+)
+
+**The following information applies to the agent version 4.7.0+ that has
+`enableBuiltInFiltering: true` set on the top level of the agent config.**
+
+To emit metrics that are not _default_, you can add those metrics in the
+generic monitor-level `extraMetrics` config option.  Metrics that are derived
+from specific configuration options that do not appear in the above list of
+metrics do not need to be added to `extraMetrics`.
+
+To see a list of metrics that will be emitted you can run `agent-status
+monitors` after configuring this monitor in a running agent instance.
+
+### Legacy non-default metrics (version < 4.7.0)
+
+**The following information only applies to agent version older than 4.7.0. If
+you have a newer agent and have set `enableBuiltInFiltering: true` at the top
+level of your agent config, see the section above. See upgrade instructions in
+[Old-style whitelist filtering](../legacy-filtering.md#old-style-whitelist-filtering).**
+
+If you have a reference to the `whitelist.json` in your agent's top-level
+`metricsToExclude` config option, and you want to emit metrics that are not in
+that whitelist, then you need to add an item to the top-level
+`metricsToInclude` config option to override that whitelist (see [Inclusion
+filtering](../legacy-filtering.md#inclusion-filtering).  Or you can just
+copy the whitelist.json, modify it, and reference that in `metricsToExclude`.
+
 ## Dimensions
 
 The following dimensions may occur on metrics emitted by this monitor.  Some

--- a/pkg/monitors/diskio/genmetadata.go
+++ b/pkg/monitors/diskio/genmetadata.go
@@ -21,6 +21,7 @@ const (
 	diskOpsAvgRead     = "disk_ops.avg_read"
 	diskOpsAvgWrite    = "disk_ops.avg_write"
 	diskOpsRead        = "disk_ops.read"
+	diskOpsTotal       = "disk_ops.total"
 	diskOpsWrite       = "disk_ops.write"
 	diskTimeAvgRead    = "disk_time.avg_read"
 	diskTimeAvgWrite   = "disk_time.avg_write"
@@ -38,6 +39,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	diskOpsAvgRead:     {Type: datapoint.Gauge},
 	diskOpsAvgWrite:    {Type: datapoint.Gauge},
 	diskOpsRead:        {Type: datapoint.Counter},
+	diskOpsTotal:       {Type: datapoint.Gauge},
 	diskOpsWrite:       {Type: datapoint.Counter},
 	diskTimeAvgRead:    {Type: datapoint.Gauge},
 	diskTimeAvgWrite:   {Type: datapoint.Gauge},
@@ -46,8 +48,11 @@ var metricSet = map[string]monitors.MetricInfo{
 }
 
 var defaultMetrics = map[string]bool{
-	diskOpsRead:  true,
-	diskOpsWrite: true,
+	diskOpsAvgRead:  true,
+	diskOpsAvgWrite: true,
+	diskOpsRead:     true,
+	diskOpsTotal:    true,
+	diskOpsWrite:    true,
 }
 
 var groupMetricsMap = map[string][]string{}
@@ -59,5 +64,5 @@ var monitorMetadata = monitors.Metadata{
 	MetricsExhaustive: false,
 	Groups:            groupSet,
 	GroupMetricsMap:   groupMetricsMap,
-	SendAll:           true,
+	SendAll:           false,
 }

--- a/pkg/monitors/diskio/metadata.yaml
+++ b/pkg/monitors/diskio/metadata.yaml
@@ -14,7 +14,6 @@ monitors:
     monitors:
      - type: disk-io
     ```
-  sendAll: true
   metrics:
     disk_merged.read:
       description: (Linux Only) The number of disk reads merged into single physical
@@ -44,11 +43,11 @@ monitors:
       type: cumulative
     disk_ops.avg_read:
       description: (Windows Only) The average disk read queue length.
-      default: false
+      default: true
       type: gauge
     disk_ops.avg_write:
       description: (Windows Only) The average disk write queue length.
-      default: false
+      default: true
       type: gauge
     disk_ops.read:
       description: (Linux Only) The number of disk read operations.
@@ -58,6 +57,10 @@ monitors:
       description: (Linux Only) The number of disk write operations.
       default: true
       type: cumulative
+    disk_ops.total:
+      description: (Linux Only) The number of both read and write disk operations across all disks in the last reporting interval.
+      default: true
+      type: gauge
     disk_time.avg_read:
       description: (Windows Only) The average time spent reading from the disk.
       default: false

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -19007,7 +19007,7 @@
     },
     {
       "monitorType": "disk-io",
-      "sendAll": true,
+      "sendAll": false,
       "dimensions": {
         "disk": {
           "description": "The name of the disk that the metric describes"
@@ -19027,6 +19027,7 @@
             "disk_ops.avg_read",
             "disk_ops.avg_write",
             "disk_ops.read",
+            "disk_ops.total",
             "disk_ops.write",
             "disk_time.avg_read",
             "disk_time.avg_write",
@@ -19076,17 +19077,23 @@
           "type": "gauge",
           "description": "(Windows Only) The average disk read queue length.",
           "group": null,
-          "default": false
+          "default": true
         },
         "disk_ops.avg_write": {
           "type": "gauge",
           "description": "(Windows Only) The average disk write queue length.",
           "group": null,
-          "default": false
+          "default": true
         },
         "disk_ops.read": {
           "type": "cumulative",
           "description": "(Linux Only) The number of disk read operations.",
+          "group": null,
+          "default": true
+        },
+        "disk_ops.total": {
+          "type": "gauge",
+          "description": "(Linux Only) The number of both read and write disk operations across all disks in the last reporting interval.",
           "group": null,
           "default": true
         },


### PR DESCRIPTION
The disk_ops.total metric was generated by the signalfx-metadata monitor and was
not migrated over when the diskio monitor was made GA.

Also don't send all diskio metrics by default -- not sure why this was enabled before.
This will break anybody who was using non-default metrics but they should not have
been on in the first place.