### PR TITLE
Make time.Duration safer in monitor configs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,11 @@ issues:
   max-per-linter: 0
   exclude-rules:
     # We use certain values repeatedly in different test cases. Using consts would only
+    # reduce clarity. Code is also sometimes repeated and factoring it would also
     # reduce clarity.
     - linters:
        - goconst
+       - dupl
       path: _test\.go
 
     # Test code can do weird things with context in BeforeEach

--- a/pkg/core/common/httpclient/http.go
+++ b/pkg/core/common/httpclient/http.go
@@ -74,7 +74,7 @@ func (h *HTTPConfig) Build() (*http.Client, error) {
 	}
 
 	return &http.Client{
-		Timeout:   h.HTTPTimeout.Get(),
+		Timeout:   h.HTTPTimeout.AsDuration(),
 		Transport: roundTripper,
 	}, nil
 }

--- a/pkg/core/common/httpclient/http.go
+++ b/pkg/core/common/httpclient/http.go
@@ -3,7 +3,8 @@ package httpclient
 import (
 	"crypto/tls"
 	"net/http"
-	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
 )
@@ -12,7 +13,7 @@ import (
 type HTTPConfig struct {
 	// HTTP timeout duration for both read and writes. This should be a
 	// duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
-	HTTPTimeout time.Duration `yaml:"httpTimeout" default:"10s"`
+	HTTPTimeout timeutil.Duration `yaml:"httpTimeout" default:"10s"`
 
 	// Basic Auth username to use on each request, if any.
 	Username string `yaml:"username"`
@@ -73,7 +74,7 @@ func (h *HTTPConfig) Build() (*http.Client, error) {
 	}
 
 	return &http.Client{
-		Timeout:   h.HTTPTimeout,
+		Timeout:   h.HTTPTimeout.Get(),
 		Transport: roundTripper,
 	}, nil
 }

--- a/pkg/core/common/httpclient/http_test.go
+++ b/pkg/core/common/httpclient/http_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
 	"github.com/stretchr/testify/require"
 )
@@ -130,7 +132,7 @@ func TestHttpBasicAuth(t *testing.T) {
 
 func TestHttpTimeout(t *testing.T) {
 	h := &HTTPConfig{
-		HTTPTimeout: 1 * time.Nanosecond,
+		HTTPTimeout: timeutil.Duration(1 * time.Nanosecond),
 	}
 	req := require.New(t)
 	runServer(t, h, func(host string) {

--- a/pkg/core/config/writer.go
+++ b/pkg/core/config/writer.go
@@ -3,7 +3,8 @@ package config
 import (
 	"net/url"
 	"strings"
-	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 
 	"github.com/mitchellh/hashstructure"
 	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
@@ -76,13 +77,13 @@ type WriterConfig struct {
 	// should be a duration string that is accepted by
 	// https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if
 	// `sendTraceHostCorrelationMetrics` is false.
-	StaleServiceTimeout time.Duration `yaml:"staleServiceTimeout" default:"5m"`
+	StaleServiceTimeout timeutil.Duration `yaml:"staleServiceTimeout" default:"5m"`
 	// How frequently to send host correlation metrics that are generated from
 	// the service name seen in trace spans sent through or by the agent.  This
 	// should be a duration string that is accepted by
 	// https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if
 	// `sendTraceHostCorrelationMetrics` is false.
-	TraceHostCorrelationMetricsInterval time.Duration `yaml:"traceHostCorrelationMetricsInterval" default:"1m"`
+	TraceHostCorrelationMetricsInterval timeutil.Duration `yaml:"traceHostCorrelationMetricsInterval" default:"1m"`
 	// How many trace spans are allowed to be in the process of sending.  While
 	// this number is exceeded, the oldest spans will be discarded to
 	// accommodate new spans generated to avoid memory exhaustion.  If you see

--- a/pkg/core/writer/spans.go
+++ b/pkg/core/writer/spans.go
@@ -46,7 +46,7 @@ func (sw *SignalFxWriter) preprocessSpan(span *trace.Span) bool {
 }
 
 func (sw *SignalFxWriter) startGeneratingHostCorrelationMetrics() *tracetracker.ActiveServiceTracker {
-	tracker := tracetracker.New(sw.conf.StaleServiceTimeout, func(dp *datapoint.Datapoint) {
+	tracker := tracetracker.New(sw.conf.StaleServiceTimeout.Get(), func(dp *datapoint.Datapoint) {
 		// Immediately send correlation datapoints when we first see a service
 		sw.dpChan <- []*datapoint.Datapoint{dp}
 	})
@@ -57,7 +57,7 @@ func (sw *SignalFxWriter) startGeneratingHostCorrelationMetrics() *tracetracker.
 		for _, dp := range tracker.CorrelationDatapoints() {
 			sw.dpChan <- []*datapoint.Datapoint{dp}
 		}
-	}, sw.conf.TraceHostCorrelationMetricsInterval)
+	}, sw.conf.TraceHostCorrelationMetricsInterval.Get())
 
 	return tracker
 }

--- a/pkg/core/writer/spans.go
+++ b/pkg/core/writer/spans.go
@@ -46,7 +46,7 @@ func (sw *SignalFxWriter) preprocessSpan(span *trace.Span) bool {
 }
 
 func (sw *SignalFxWriter) startGeneratingHostCorrelationMetrics() *tracetracker.ActiveServiceTracker {
-	tracker := tracetracker.New(sw.conf.StaleServiceTimeout.Get(), func(dp *datapoint.Datapoint) {
+	tracker := tracetracker.New(sw.conf.StaleServiceTimeout.AsDuration(), func(dp *datapoint.Datapoint) {
 		// Immediately send correlation datapoints when we first see a service
 		sw.dpChan <- []*datapoint.Datapoint{dp}
 	})
@@ -57,7 +57,7 @@ func (sw *SignalFxWriter) startGeneratingHostCorrelationMetrics() *tracetracker.
 		for _, dp := range tracker.CorrelationDatapoints() {
 			sw.dpChan <- []*datapoint.Datapoint{dp}
 		}
-	}, sw.conf.TraceHostCorrelationMetricsInterval.Get())
+	}, sw.conf.TraceHostCorrelationMetricsInterval.AsDuration())
 
 	return tracker
 }

--- a/pkg/core/writer/writer_test.go
+++ b/pkg/core/writer/writer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/stretchr/testify/require"
 )
@@ -12,8 +14,8 @@ var essentialWriterConfig = config.WriterConfig{
 	PropertiesHistorySize:               100,
 	PropertiesSendDelaySeconds:          1,
 	TraceExportFormat:                   "zipkin",
-	TraceHostCorrelationMetricsInterval: 1 * time.Second,
-	StaleServiceTimeout:                 1 * time.Second,
+	TraceHostCorrelationMetricsInterval: timeutil.Duration(1 * time.Second),
+	StaleServiceTimeout:                 timeutil.Duration(1 * time.Second),
 	EventSendIntervalSeconds:            1,
 }
 

--- a/pkg/monitors/aspdotnet/aspdotnet.go
+++ b/pkg/monitors/aspdotnet/aspdotnet.go
@@ -1,11 +1,10 @@
 package aspdotnet
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 func init() {
@@ -17,7 +16,7 @@ type Config struct {
 	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This is used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/monitors/diskio/diskio.go
+++ b/pkg/monitors/diskio/diskio.go
@@ -1,10 +1,9 @@
 package diskio
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -23,7 +22,7 @@ type Config struct {
 	// (Windows Only) The frequency that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	// This is expressed as a duration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/monitors/dotnet/dotnet.go
+++ b/pkg/monitors/dotnet/dotnet.go
@@ -1,11 +1,10 @@
 package dotnet
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 func init() {
@@ -17,7 +16,7 @@ type Config struct {
 	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/monitors/forwarder/monitor.go
+++ b/pkg/monitors/forwarder/monitor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+
 	"github.com/pkg/errors"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
@@ -29,7 +31,7 @@ type Config struct {
 	ListenAddress string `yaml:"listenAddress" default:"127.0.0.1:9080"`
 	// HTTP timeout duration for both read and writes. This should be a
 	// duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
-	ServerTimeout time.Duration `yaml:"serverTimeout" default:"5s"`
+	ServerTimeout timeutil.Duration `yaml:"serverTimeout" default:"5s"`
 	// Whether to emit internal metrics about the HTTP listener
 	SendInternalMetrics *bool `yaml:"sendInternalMetrics" default:"false"`
 }
@@ -46,7 +48,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	ctx, m.cancel = context.WithCancel(context.Background())
 
 	sink := &outputSink{Output: m.Output}
-	listenerMetrics, err := startListening(ctx, conf.ListenAddress, conf.ServerTimeout, sink)
+	listenerMetrics, err := startListening(ctx, conf.ListenAddress, conf.ServerTimeout.Get(), sink)
 	if err != nil {
 		return errors.WithMessage(err, "could not start forwarder listener")
 	}

--- a/pkg/monitors/forwarder/monitor.go
+++ b/pkg/monitors/forwarder/monitor.go
@@ -48,7 +48,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	ctx, m.cancel = context.WithCancel(context.Background())
 
 	sink := &outputSink{Output: m.Output}
-	listenerMetrics, err := startListening(ctx, conf.ListenAddress, conf.ServerTimeout.Get(), sink)
+	listenerMetrics, err := startListening(ctx, conf.ListenAddress, conf.ServerTimeout.AsDuration(), sink)
 	if err != nil {
 		return errors.WithMessage(err, "could not start forwarder listener")
 	}

--- a/pkg/monitors/haproxy/config.go
+++ b/pkg/monitors/haproxy/config.go
@@ -2,9 +2,9 @@ package haproxy
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // Config is the config for this monitor.
@@ -27,7 +27,7 @@ type Config struct {
 	// Flag that enables SSL certificate verification for the scrape URL.
 	SSLVerify bool `yaml:"sslVerify" default:"true"`
 	// Timeout for trying to get stats from HAProxy. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
-	Timeout time.Duration `yaml:"timeout" default:"5s"`
+	Timeout timeutil.Duration `yaml:"timeout" default:"5s"`
 	// A list of the pxname(s) and svname(s) to monitor (e.g. `["http-in", "server1", "backend"]`). If empty then metrics for all proxies will be reported.
 	Proxies []string `yaml:"proxies"`
 }

--- a/pkg/monitors/haproxy/helpers.go
+++ b/pkg/monitors/haproxy/helpers.go
@@ -263,7 +263,7 @@ func parseStatusField(v string) int64 {
 
 func httpReader(conf *Config, method string) (io.ReadCloser, error) {
 	client := http.Client{
-		Timeout:   conf.Timeout.Get(),
+		Timeout:   conf.Timeout.AsDuration(),
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !conf.SSLVerify}},
 	}
 	req, err := http.NewRequest(method, conf.ScrapeURL(), nil)
@@ -287,11 +287,11 @@ func socketReader(conf *Config, cmd string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse url %s status. %v", conf.ScrapeURL(), err)
 	}
-	f, err := net.DialTimeout("unix", u.Path, conf.Timeout.Get())
+	f, err := net.DialTimeout("unix", u.Path, conf.Timeout.AsDuration())
 	if err != nil {
 		return nil, err
 	}
-	if err := f.SetDeadline(time.Now().Add(conf.Timeout.Get())); err != nil {
+	if err := f.SetDeadline(time.Now().Add(conf.Timeout.AsDuration())); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/pkg/monitors/haproxy/helpers.go
+++ b/pkg/monitors/haproxy/helpers.go
@@ -263,7 +263,7 @@ func parseStatusField(v string) int64 {
 
 func httpReader(conf *Config, method string) (io.ReadCloser, error) {
 	client := http.Client{
-		Timeout:   conf.Timeout,
+		Timeout:   conf.Timeout.Get(),
 		Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: !conf.SSLVerify}},
 	}
 	req, err := http.NewRequest(method, conf.ScrapeURL(), nil)
@@ -287,11 +287,11 @@ func socketReader(conf *Config, cmd string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse url %s status. %v", conf.ScrapeURL(), err)
 	}
-	f, err := net.DialTimeout("unix", u.Path, conf.Timeout)
+	f, err := net.DialTimeout("unix", u.Path, conf.Timeout.Get())
 	if err != nil {
 		return nil, err
 	}
-	if err := f.SetDeadline(time.Now().Add(conf.Timeout)); err != nil {
+	if err := f.SetDeadline(time.Now().Add(conf.Timeout.Get())); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/pkg/monitors/logstash/tcp/monitor.go
+++ b/pkg/monitors/logstash/tcp/monitor.go
@@ -96,7 +96,7 @@ OUTER:
 				"host": host,
 				"port": port,
 			}).Error("Could not listen for Logstash events")
-			time.Sleep(m.conf.ReconnectDelay.Get())
+			time.Sleep(m.conf.ReconnectDelay.AsDuration())
 			continue
 		}
 
@@ -107,7 +107,7 @@ OUTER:
 			if err != nil {
 				logger.WithError(err).Error("Could not accept Logstash connections")
 				listener.Close()
-				time.Sleep(m.conf.ReconnectDelay.Get())
+				time.Sleep(m.conf.ReconnectDelay.AsDuration())
 				continue OUTER
 			}
 
@@ -132,7 +132,7 @@ func (m *Monitor) keepReadingFromServer(host string, port uint16) {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", host, port))
 		if err != nil {
 			logger.WithError(err).Error("Logstash TCP output connection failed")
-			time.Sleep(m.conf.ReconnectDelay.Get())
+			time.Sleep(m.conf.ReconnectDelay.AsDuration())
 			continue
 		}
 
@@ -142,7 +142,7 @@ func (m *Monitor) keepReadingFromServer(host string, port uint16) {
 				return
 			}
 			logger.WithError(err).Error("Logstash receive failed")
-			time.Sleep(m.conf.ReconnectDelay.Get())
+			time.Sleep(m.conf.ReconnectDelay.AsDuration())
 			continue
 		}
 	}

--- a/pkg/monitors/logstash/tcp/monitor.go
+++ b/pkg/monitors/logstash/tcp/monitor.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+
 	"github.com/davecgh/go-spew/spew"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
@@ -45,7 +47,7 @@ type Config struct {
 	DesiredTimerFields []string `yaml:"desiredTimerFields" default:"[\"mean\",\"max\",\"p99\",\"count\"]"`
 	// How long to wait before reconnecting if the TCP connection cannot be
 	// made or after it gets broken.
-	ReconnectDelay time.Duration `yaml:"reconnectDelay" default:"5s"`
+	ReconnectDelay timeutil.Duration `yaml:"reconnectDelay" default:"5s"`
 	// If true, events received from Logstash will be dumped to the agent's
 	// stdout in deserialized form
 	DebugEvents bool `yaml:"debugEvents"`
@@ -94,7 +96,7 @@ OUTER:
 				"host": host,
 				"port": port,
 			}).Error("Could not listen for Logstash events")
-			time.Sleep(m.conf.ReconnectDelay)
+			time.Sleep(m.conf.ReconnectDelay.Get())
 			continue
 		}
 
@@ -105,7 +107,7 @@ OUTER:
 			if err != nil {
 				logger.WithError(err).Error("Could not accept Logstash connections")
 				listener.Close()
-				time.Sleep(m.conf.ReconnectDelay)
+				time.Sleep(m.conf.ReconnectDelay.Get())
 				continue OUTER
 			}
 
@@ -130,7 +132,7 @@ func (m *Monitor) keepReadingFromServer(host string, port uint16) {
 		conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", host, port))
 		if err != nil {
 			logger.WithError(err).Error("Logstash TCP output connection failed")
-			time.Sleep(m.conf.ReconnectDelay)
+			time.Sleep(m.conf.ReconnectDelay.Get())
 			continue
 		}
 
@@ -140,7 +142,7 @@ func (m *Monitor) keepReadingFromServer(host string, port uint16) {
 				return
 			}
 			logger.WithError(err).Error("Logstash receive failed")
-			time.Sleep(m.conf.ReconnectDelay)
+			time.Sleep(m.conf.ReconnectDelay.Get())
 			continue
 		}
 	}

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
@@ -2,7 +2,8 @@ package winperfcounters
 
 import (
 	"strings"
-	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 
 	"github.com/influxdata/telegraf"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
@@ -58,7 +59,7 @@ type Config struct {
 	// The frequency that counter paths should be expanded
 	// and how often to refresh counters from configuration.
 	// This is expressed as a duration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"5s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"5s"`
 	// If `true`, instance indexes will be included in instance names, and wildcards will
 	// be expanded and localized (if applicable).  If `false`, non partial wildcards will
 	// be expanded and instance names will not include instance indexes.

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
@@ -31,7 +31,7 @@ func GetPlugin(conf *Config) (*telegrafPlugin.Win_PerfCounters, error) {
 
 	// Telegraf has a struct wrapper around time.Duration, but it's defined
 	// in an internal package which the gocomplier won't compile from
-	plugin.CountersRefreshInterval.Duration = conf.CountersRefreshInterval.Get()
+	plugin.CountersRefreshInterval.Duration = conf.CountersRefreshInterval.AsDuration()
 
 	// copy nested perf objects
 	for _, perfobj := range conf.Object {

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters_windows.go
@@ -31,7 +31,7 @@ func GetPlugin(conf *Config) (*telegrafPlugin.Win_PerfCounters, error) {
 
 	// Telegraf has a struct wrapper around time.Duration, but it's defined
 	// in an internal package which the gocomplier won't compile from
-	plugin.CountersRefreshInterval.Duration = conf.CountersRefreshInterval * time.Millisecond
+	plugin.CountersRefreshInterval.Duration = conf.CountersRefreshInterval.Get()
 
 	// copy nested perf objects
 	for _, perfobj := range conf.Object {

--- a/pkg/monitors/vmem/vmem.go
+++ b/pkg/monitors/vmem/vmem.go
@@ -1,11 +1,10 @@
 package vmem
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -19,7 +18,7 @@ type Config struct {
 	// (Windows Only) The frequency that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	// This is expressed as a duration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/monitors/vsphere/model/model.go
+++ b/pkg/monitors/vsphere/model/model.go
@@ -1,9 +1,8 @@
 package model
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -30,7 +29,7 @@ type Config struct {
 	// Whether we verify the server's certificate chain and host name
 	InsecureSkipVerify bool `yaml:"insecureSkipVerify"`
 	// How often to reload the inventory and inventory metrics
-	InventoryRefreshInterval time.Duration `yaml:"inventoryRefreshInterval" default:"60s"`
+	InventoryRefreshInterval timeutil.Duration `yaml:"inventoryRefreshInterval" default:"60s"`
 
 	// Path to the ca file
 	TLSCACertPath string `yaml:"tlsCACertPath"`

--- a/pkg/monitors/vsphere/runner.go
+++ b/pkg/monitors/vsphere/runner.go
@@ -17,7 +17,7 @@ type runner struct {
 }
 
 func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monitor *Monitor) runner {
-	vsphereReloadInterval := int(conf.InventoryRefreshInterval.Seconds())
+	vsphereReloadInterval := int(conf.InventoryRefreshInterval.Get().Seconds())
 	vsm := newVsphereMonitor(log)
 	return runner{
 		ctx:                   ctx,

--- a/pkg/monitors/vsphere/runner.go
+++ b/pkg/monitors/vsphere/runner.go
@@ -17,7 +17,7 @@ type runner struct {
 }
 
 func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monitor *Monitor) runner {
-	vsphereReloadInterval := int(conf.InventoryRefreshInterval.Get().Seconds())
+	vsphereReloadInterval := int(conf.InventoryRefreshInterval.AsDuration().Seconds())
 	vsm := newVsphereMonitor(log)
 	return runner{
 		ctx:                   ctx,

--- a/pkg/monitors/windowsiis/windowsiis.go
+++ b/pkg/monitors/windowsiis/windowsiis.go
@@ -1,7 +1,7 @@
 package windowsiis
 
 import (
-	"time"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
@@ -17,7 +17,7 @@ type Config struct {
 	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/monitors/windowslegacy/windowslegacy.go
+++ b/pkg/monitors/windowslegacy/windowslegacy.go
@@ -1,11 +1,10 @@
 package windowslegacy
 
 import (
-	"time"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 func init() {
@@ -17,7 +16,7 @@ type Config struct {
 	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
-	CountersRefreshInterval time.Duration `yaml:"counterRefreshInterval" default:"60s"`
+	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`
 	// (Windows Only) Print out the configurations that match available
 	// performance counters.  This used for debugging.
 	PrintValid bool `yaml:"printValid"`

--- a/pkg/utils/timeutil/duration.go
+++ b/pkg/utils/timeutil/duration.go
@@ -16,8 +16,8 @@ type Duration time.Duration
 // ErrInvalidDuration is returned when the duration can't be interpreted
 var ErrInvalidDuration = errors.New("the duration must be a string with time unit specified or an integer as seconds")
 
-// Get returns the underlying time.Duration type
-func (d Duration) Get() time.Duration {
+// AsDuration returns the the type cast to time.Duration
+func (d Duration) AsDuration() time.Duration {
 	return time.Duration(d)
 }
 

--- a/pkg/utils/timeutil/duration.go
+++ b/pkg/utils/timeutil/duration.go
@@ -1,0 +1,68 @@
+package timeutil
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Duration is a wrapped time.Duration that supports durations as integers
+// or a ParseDuration string. If it's an integer it is interpreted in seconds instead
+// of being directly cast to time.Duration which would normally make it in nanoseconds.
+type Duration time.Duration
+
+// ErrInvalidDuration is returned when the duration can't be interpreted
+var ErrInvalidDuration = errors.New("the duration must be a string with time unit specified or an integer as seconds")
+
+// Get returns the underlying time.Duration type
+func (d Duration) Get() time.Duration {
+	return time.Duration(d)
+}
+
+// IsZero returns true if the duration is 0, otherwise true.
+func (d Duration) IsZero() bool {
+	return time.Duration(d) == 0
+}
+
+// UnmarshalJSON unmarshals Duration
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	return d.UnmarshalYAML(func(i interface{}) error {
+		return json.Unmarshal(data, i)
+	})
+}
+
+// UnmarshalYAML unmarshals Duration
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// First check if it's an integer. Interpret it as seconds.
+	var i int64
+	if err := unmarshal(&i); err == nil {
+		*d = Duration(time.Duration(i) * time.Second)
+		return nil
+	}
+
+	var s string
+
+	if err := unmarshal(&s); err == nil {
+		// If it's a string but parses as an integer interpret it as seconds.
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			*d = Duration(time.Duration(i) * time.Second)
+			return nil
+		}
+
+		// If here it's hopefully a string with ParseDuration syntax.
+		parsed, err := time.ParseDuration(s)
+		if err != nil {
+			return fmt.Errorf("%v: %v", ErrInvalidDuration, err)
+		}
+		*d = Duration(parsed)
+		return nil
+	}
+
+	return ErrInvalidDuration
+}
+
+func (d Duration) IntSeconds() int64 {
+	return int64(d.Get().Seconds())
+}

--- a/pkg/utils/timeutil/duration.go
+++ b/pkg/utils/timeutil/duration.go
@@ -62,7 +62,3 @@ func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	return ErrInvalidDuration
 }
-
-func (d Duration) IntSeconds() int64 {
-	return int64(d.Get().Seconds())
-}

--- a/pkg/utils/timeutil/duration_test.go
+++ b/pkg/utils/timeutil/duration_test.go
@@ -1,0 +1,102 @@
+package timeutil
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/signalfx/defaults"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestSecondsOrDuration_UnmarshalYAML(t *testing.T) {
+	type args struct {
+		yml string
+	}
+	tests := []struct {
+		name    string
+		d       time.Duration
+		args    args
+		wantErr bool
+	}{
+		{"5 seconds as integer", 5 * time.Second, args{"time: 5"}, false},
+		{"10 seconds as string", 10 * time.Second, args{"time: '10'"}, false},
+		{"15 seconds as duration", 15 * time.Second, args{"time: '15s'"}, false},
+		{"invalid syntax", 0, args{"time: invalid"}, true},
+		{"empty string", 0, args{"time:''"}, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var out map[string]Duration
+			if err := yaml.Unmarshal([]byte(tt.args.yml), &out); (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if out["time"].Get() != tt.d {
+				t.Fatalf("got %v, wanted %v", out["time"], tt.d)
+			}
+		})
+	}
+}
+
+func TestSecondsOrDuration_Defaults(t *testing.T) {
+	type args struct {
+		yml string
+	}
+	tests := []struct {
+		name    string
+		d       time.Duration
+		args    args
+		wantErr bool
+	}{
+		{"5 seconds as integer", 5 * time.Second, args{"{}"}, false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var out struct {
+				Interval Duration `yaml:"interval" default:"5s"`
+			}
+			if err := yaml.Unmarshal([]byte(tt.args.yml), &out); (err != nil) != tt.wantErr {
+				t.Fatalf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err := defaults.Set(&out); err != nil {
+				t.Fatal(err)
+			}
+			if out.Interval.Get() != tt.d {
+				t.Errorf("got %v, wanted %v", out.Interval, tt.d)
+			}
+		})
+	}
+}
+
+func TestDuration_UnmarshalJSON(t *testing.T) {
+	type args struct {
+		json string
+	}
+	tests := []struct {
+		name    string
+		d       time.Duration
+		args    args
+		wantErr bool
+	}{
+		{"5 seconds as integer", 5 * time.Second, args{`{"time": 5}`}, false},
+		{"10 seconds as string", 10 * time.Second, args{`{"time": "10"}`}, false},
+		{"15 seconds as duration", 15 * time.Second, args{`{"time": "15s"}`}, false},
+		{"invalid syntax", 0, args{`{"time": "invalid"}`}, true},
+		{"empty string", 0, args{"time:''"}, true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var out map[string]Duration
+			if err := json.Unmarshal([]byte(tt.args.json), &out); (err != nil) != tt.wantErr {
+				t.Fatalf("json.Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if out["time"].Get() != tt.d {
+				t.Fatalf("got %v, wanted %v", out["time"], tt.d)
+			}
+		})
+	}
+}

--- a/pkg/utils/timeutil/duration_test.go
+++ b/pkg/utils/timeutil/duration_test.go
@@ -33,7 +33,7 @@ func TestSecondsOrDuration_UnmarshalYAML(t *testing.T) {
 			if err := yaml.Unmarshal([]byte(tt.args.yml), &out); (err != nil) != tt.wantErr {
 				t.Fatalf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if out["time"].Get() != tt.d {
+			if out["time"].AsDuration() != tt.d {
 				t.Fatalf("got %v, wanted %v", out["time"], tt.d)
 			}
 		})
@@ -64,7 +64,7 @@ func TestSecondsOrDuration_Defaults(t *testing.T) {
 			if err := defaults.Set(&out); err != nil {
 				t.Fatal(err)
 			}
-			if out.Interval.Get() != tt.d {
+			if out.Interval.AsDuration() != tt.d {
 				t.Errorf("got %v, wanted %v", out.Interval, tt.d)
 			}
 		})
@@ -94,7 +94,7 @@ func TestDuration_UnmarshalJSON(t *testing.T) {
 			if err := json.Unmarshal([]byte(tt.args.json), &out); (err != nil) != tt.wantErr {
 				t.Fatalf("json.Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if out["time"].Get() != tt.d {
+			if out["time"].AsDuration() != tt.d {
 				t.Fatalf("got %v, wanted %v", out["time"], tt.d)
 			}
 		})


### PR DESCRIPTION
This makes current usage of time.Duration in monitor configs safer as before
if the user specified an integer it'd be interpreted as an nanoseconds which
is unlikely what people want.

Instead of using time.Duration in a monitor config the developer should use
timeutil.Duration. An integer will be interpreted as seconds (instead of
nanoseconds) and if it's a string it'll be parsed via ParseDuration. Also
if it's a string but it is able to be parsed as an integer we also interpret
it as seconds.