### PR TITLE
Don't average by CPU by default on load monitor

### DIFF
--- a/docs/monitors/load.md
+++ b/docs/monitors/load.md
@@ -14,6 +14,9 @@ Monitors process load on the host. Process load is the average number of
 running or waiting processes over a certain time period (1, 5, and 15
 minutes).
 
+See http://www.brendangregg.com/blog/2017-08-08/linux-load-averages.html
+for a good explanation of load on Linux.
+
 This monitor is only available on Linux.
 
 
@@ -32,7 +35,11 @@ monitors:  # All monitor config goes under this key
 Configuration](../monitor-config.md#common-configuration).**
 
 
-This monitor has no configuration options.
+| Config option | Required | Type | Description |
+| --- | --- | --- | --- |
+| `perCPU` | no | `bool` |  (**default:** `false`) |
+
+
 ## Metrics
 
 These are the metrics available for this monitor.
@@ -41,9 +48,9 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
- - ***`load.longterm`*** (*gauge*)<br>    Average CPU load per core over the last 15 minutes
- - ***`load.midterm`*** (*gauge*)<br>    Average CPU load per core over the last five minutes
- - ***`load.shortterm`*** (*gauge*)<br>    Average CPU load per core over the last one minute
+ - ***`load.longterm`*** (*gauge*)<br>    Average CPU load of the system over the last 15 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.
+ - ***`load.midterm`*** (*gauge*)<br>    Average CPU load of the system over the last 5 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.
+ - ***`load.shortterm`*** (*gauge*)<br>    Average CPU load of the system over the last minute.  If the `perCPU` config option is `true`, this will be the average load per CPU.
 
 ### Non-default metrics (version 4.7.0+)
 

--- a/pkg/monitors/load/load.go
+++ b/pkg/monitors/load/load.go
@@ -24,6 +24,7 @@ func init() {
 // Config for this monitor
 type Config struct {
 	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	PerCPU               bool `yaml:"perCPU" default:"false"`
 }
 
 // Monitor for load
@@ -50,12 +51,15 @@ func (m *Monitor) Configure(conf *Config) error {
 			return
 		}
 
-		numCPUs := float64(runtime.NumCPU())
+		divisor := 1.0
+		if conf.PerCPU {
+			divisor = float64(runtime.NumCPU())
+		}
 
 		m.Output.SendDatapoints([]*datapoint.Datapoint{
-			datapoint.New(loadLongterm, nil, datapoint.NewFloatValue(avgLoad.Load15/numCPUs), datapoint.Gauge, time.Time{}),
-			datapoint.New(loadMidterm, nil, datapoint.NewFloatValue(avgLoad.Load5/numCPUs), datapoint.Gauge, time.Time{}),
-			datapoint.New(loadShortterm, nil, datapoint.NewFloatValue(avgLoad.Load1/numCPUs), datapoint.Gauge, time.Time{}),
+			datapoint.New(loadLongterm, nil, datapoint.NewFloatValue(avgLoad.Load15/divisor), datapoint.Gauge, time.Time{}),
+			datapoint.New(loadMidterm, nil, datapoint.NewFloatValue(avgLoad.Load5/divisor), datapoint.Gauge, time.Time{}),
+			datapoint.New(loadShortterm, nil, datapoint.NewFloatValue(avgLoad.Load1/divisor), datapoint.Gauge, time.Time{}),
 		}...)
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 

--- a/pkg/monitors/load/metadata.yaml
+++ b/pkg/monitors/load/metadata.yaml
@@ -5,19 +5,22 @@ monitors:
     running or waiting processes over a certain time period (1, 5, and 15
     minutes).
 
+    See http://www.brendangregg.com/blog/2017-08-08/linux-load-averages.html
+    for a good explanation of load on Linux.
+
     This monitor is only available on Linux.
 
   metrics:
     load.longterm:
-      description: Average CPU load per core over the last 15 minutes
+      description: Average CPU load of the system over the last 15 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.
       default: true
       type: gauge
     load.midterm:
-      description: Average CPU load per core over the last five minutes
+      description: Average CPU load of the system over the last 5 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.
       default: true
       type: gauge
     load.shortterm:
-      description: Average CPU load per core over the last one minute
+      description: Average CPU load of the system over the last minute.  If the `perCPU` config option is `true`, this will be the average load per CPU.
       default: true
       type: gauge
   monitorType: load

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -35509,7 +35509,7 @@
       "monitorType": "load",
       "sendAll": false,
       "dimensions": null,
-      "doc": "Monitors process load on the host. Process load is the average number of\nrunning or waiting processes over a certain time period (1, 5, and 15\nminutes).\n\nThis monitor is only available on Linux.\n",
+      "doc": "Monitors process load on the host. Process load is the average number of\nrunning or waiting processes over a certain time period (1, 5, and 15\nminutes).\n\nSee http://www.brendangregg.com/blog/2017-08-08/linux-load-averages.html\nfor a good explanation of load on Linux.\n\nThis monitor is only available on Linux.\n",
       "groups": {
         "": {
           "description": "",
@@ -35523,19 +35523,19 @@
       "metrics": {
         "load.longterm": {
           "type": "gauge",
-          "description": "Average CPU load per core over the last 15 minutes",
+          "description": "Average CPU load of the system over the last 15 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.",
           "group": null,
           "default": true
         },
         "load.midterm": {
           "type": "gauge",
-          "description": "Average CPU load per core over the last five minutes",
+          "description": "Average CPU load of the system over the last 5 minutes.  If the `perCPU` config option is `true`, this will be the average load per CPU.",
           "group": null,
           "default": true
         },
         "load.shortterm": {
           "type": "gauge",
-          "description": "Average CPU load per core over the last one minute",
+          "description": "Average CPU load of the system over the last minute.  If the `perCPU` config option is `true`, this will be the average load per CPU.",
           "group": null,
           "default": true
         }
@@ -35546,7 +35546,16 @@
         "name": "Config",
         "doc": "Config for this monitor",
         "package": "pkg/monitors/load",
-        "fields": []
+        "fields": [
+          {
+            "yamlName": "perCPU",
+            "doc": "",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          }
+        ]
       },
       "acceptsEndpoints": false,
       "singleInstance": true


### PR DESCRIPTION
This was mistakenly done due to an erroneous doc in the collectd/load monitor
that implied that the cpu averaging was done by default.

This will be treated as a bug fix and not a breaking change.