### PR TITLE
Allow to output the logs as json

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -21,6 +21,7 @@ data:
 
     logging:
       level: info
+      format: text
 
     globalDimensions:
       kubernetes_cluster: MY-CLUSTER

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -40,7 +40,6 @@ data:
       level: {{ .Values.logLevel | default "info" }}
       format: {{ .Values.logFormat | default "text" }}
 
-
     globalDimensions:
       kubernetes_cluster: {{ .Values.kubernetesClusterName | default .Values.clusterName }}
       {{- range $k, $v := .Values.globalDimensions }}

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -38,6 +38,8 @@ data:
 
     logging:
       level: {{ .Values.logLevel | default "info" }}
+      format: {{ .Values.logFormat | default "text" }}
+
 
     globalDimensions:
       kubernetes_cluster: {{ .Values.kubernetesClusterName | default .Values.clusterName }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -119,6 +119,10 @@ metricIntervalSeconds: 10
 # may dump sensitive values in the provided configuration so use with care.
 logLevel: info
 
+# The log format of the agent.  Valid values are 'text' and 'json'
+# The agent will emit logs in either an unstructed text (default) or JSON format. 
+logFormat: text
+
 # Whether to ignore TLS validation issue when connecting to the main K8s API
 # server.  This should almost never need to be set to true since the CA cert is
 # provided with the service account token automatically by K8s.


### PR DESCRIPTION
Allow to output the logs from the signalfx agent as json when using the helm chart.
