### PR TITLE
Add support for custom HTTP headers

### DIFF
--- a/docs/monitors/coredns.md
+++ b/docs/monitors/coredns.md
@@ -45,6 +45,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/elasticsearch-query.md
+++ b/docs/monitors/elasticsearch-query.md
@@ -272,6 +272,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/elasticsearch.md
+++ b/docs/monitors/elasticsearch.md
@@ -148,6 +148,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/etcd.md
+++ b/docs/monitors/etcd.md
@@ -56,6 +56,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab-gitaly.md
+++ b/docs/monitors/gitlab-gitaly.md
@@ -34,6 +34,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab-runner.md
+++ b/docs/monitors/gitlab-runner.md
@@ -45,6 +45,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab-sidekiq.md
+++ b/docs/monitors/gitlab-sidekiq.md
@@ -34,6 +34,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab-unicorn.md
+++ b/docs/monitors/gitlab-unicorn.md
@@ -53,6 +53,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab-workhorse.md
+++ b/docs/monitors/gitlab-workhorse.md
@@ -48,6 +48,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/gitlab.md
+++ b/docs/monitors/gitlab.md
@@ -172,6 +172,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/kube-controller-manager.md
+++ b/docs/monitors/kube-controller-manager.md
@@ -51,6 +51,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/kubernetes-apiserver.md
+++ b/docs/monitors/kubernetes-apiserver.md
@@ -46,6 +46,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/kubernetes-proxy.md
+++ b/docs/monitors/kubernetes-proxy.md
@@ -49,6 +49,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/kubernetes-scheduler.md
+++ b/docs/monitors/kubernetes-scheduler.md
@@ -34,6 +34,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-exporter.md
+++ b/docs/monitors/prometheus-exporter.md
@@ -100,6 +100,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-go.md
+++ b/docs/monitors/prometheus-go.md
@@ -40,6 +40,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-nginx-vts.md
+++ b/docs/monitors/prometheus-nginx-vts.md
@@ -38,6 +38,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-node.md
+++ b/docs/monitors/prometheus-node.md
@@ -38,6 +38,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-postgres.md
+++ b/docs/monitors/prometheus-postgres.md
@@ -38,6 +38,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-prometheus.md
+++ b/docs/monitors/prometheus-prometheus.md
@@ -38,6 +38,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/prometheus-redis.md
+++ b/docs/monitors/prometheus-redis.md
@@ -38,6 +38,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/docs/monitors/traefik.md
+++ b/docs/monitors/traefik.md
@@ -86,6 +86,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `username` | no | `string` | Basic Auth username to use on each request, if any. |
 | `password` | no | `string` | Basic Auth password to use on each request, if any. |
 | `useHTTPS` | no | `bool` | If true, the agent will connect to the exporter using HTTPS instead of plain HTTP. (**default:** `false`) |
+| `httpHeaders` | no | `map of strings` | A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported. |
 | `skipVerify` | no | `bool` | If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified. (**default:** `false`) |
 | `caCertPath` | no | `string` | Path to the CA cert that has signed the TLS cert, unnecessary if `skipVerify` is set to false. |
 | `clientCertPath` | no | `string` | Path to the client TLS cert to use for TLS required connections |

--- a/pkg/core/common/httpclient/http_test.go
+++ b/pkg/core/common/httpclient/http_test.go
@@ -12,9 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +40,10 @@ func runServer(t *testing.T, h *HTTPConfig, cb func(host string)) {
 				_, _ = writer.Write([]byte("unauthorized"))
 				return
 			}
+		}
+
+		for configHeader, configValue := range h.HTTPHeaders {
+			assert.Equal(t, configValue, request.Header.Get(configHeader))
 		}
 
 		writer.WriteHeader(http.StatusOK)
@@ -175,4 +180,14 @@ func TestHttpConfig_Scheme(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHttpHeaders(t *testing.T) {
+	h := &HTTPConfig{
+		HTTPHeaders: map[string]string{
+			"HeaderOne": "ValueOne, ValueTwo",
+			"HeaderTwo": "ValueThree",
+		},
+	}
+	runServer(t, h, verify(t, h))
 }

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -18890,6 +18890,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -21716,6 +21724,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -21968,6 +21984,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -23541,6 +23565,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -24613,6 +24645,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -24834,6 +24874,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -25039,6 +25087,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -25302,6 +25358,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -25644,6 +25708,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -25954,6 +26026,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -30716,6 +30796,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -33198,6 +33286,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -34401,6 +34497,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -35355,6 +35459,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -37544,6 +37656,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -37933,6 +38053,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -38187,6 +38315,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -39423,6 +39559,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -41242,6 +41386,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -42366,6 +42518,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
+          },
+          {
             "yamlName": "skipVerify",
             "doc": "If useHTTPS is true and this option is also true, the exporter's TLS cert will not be verified.",
             "default": false,
@@ -42907,6 +43067,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",
@@ -46172,6 +46340,14 @@
             "required": false,
             "type": "bool",
             "elementKind": ""
+          },
+          {
+            "yamlName": "httpHeaders",
+            "doc": "A map of key=message-header and value=header-value. Comma separated multiple values for the same message-header is supported.",
+            "default": null,
+            "required": false,
+            "type": "map",
+            "elementKind": "string"
           },
           {
             "yamlName": "skipVerify",


### PR DESCRIPTION
This PR adds support to custom HTTP Headers.
The client will pick up users defined custom headers.

example YAML:
```
httpHeaders:
  Proxy-Authenticate: basic
  Accept: application/vnd.api+json, image/png
```
Signed-off-by: Dani Louca <dlouca@splunk.com>