### PR TITLE
Add JSONPath remote config post-processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,6 +290,8 @@ jobs:
           paths:
             - image.tar
             - signalfx-agent-latest.tar.gz
+      - store_artifacts:
+          path: /tmp/workspace/signalfx-agent-latest.tar.gz
 
   modules_and_generate:
     executor: goexecutor

--- a/docs/remote-config.md
+++ b/docs/remote-config.md
@@ -157,6 +157,23 @@ and defaults, which are not possible with the `${}` syntax.
 The env var remote config source does not pick up changes to envvars that
 happen after the initial source resolution.
 
+## JSONPath
+
+You can further process the remote config values by using the `jsonPath: "<json
+path expression>"` option on the remote config `#from` object.  This will
+treat each of the values that the path resolves to as JSON and will pull out
+the value(s) expressed by the JSON Path expression.  For more information on
+JSONPath syntax, see https://goessner.net/articles/JsonPath/.
+
+For example, if you had the environment variable `SYSTEM_INFO` with the value
+`{"host": "foobar.com", "os": "linux", "env": "prod1"}` and wanted to set a
+global dimension on the agent with the value of the `env` key, you could use the
+following agent config:
+
+```yaml
+hostname: {"#from": "env:SYSTEM_INFO", jsonPath: "$.env"}
+```
+
 ## Other
 
 If you need more sophisticated interpolation of config values from KV stores,

--- a/go.mod
+++ b/go.mod
@@ -141,6 +141,7 @@ require (
 	github.com/vjeantet/grok v1.0.0 // indirect
 	github.com/vmware/govmomi v0.21.0
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2
+	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.etcd.io/etcd v0.0.0-20190321122103-41f7142ff986
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd

--- a/go.sum
+++ b/go.sum
@@ -891,6 +891,8 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7V
 github.com/xanzy/ssh-agent v0.2.0/go.mod h1:0NyE30eGUDliuLEHJgYte/zncp2zdTStcOnWhgSqHD8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 h1:6fRhSjgLCkTD3JnJxvaJ4Sj+TYblw757bqYgZaOq5ZY=
+github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
 github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yudai/pp v2.0.1+incompatible/go.mod h1:PuxR/8QJ7cyCkFp/aUDS+JY727OFEZkTdatxwunjIkc=

--- a/pkg/core/config/sources/spec.go
+++ b/pkg/core/config/sources/spec.go
@@ -15,6 +15,7 @@ type dynamicValueSpec struct {
 	Optional bool        `yaml:"optional"`
 	Raw      bool        `yaml:"raw"`
 	Default  interface{} `yaml:"default"`
+	JSONPath string      `yaml:"jsonPath"`
 }
 
 type fromPath struct {


### PR DESCRIPTION
This will allow the use of nested JSON values within remote config.

This is primarily intended to support the CloudFoundry use case where container metadata is stored in envvars in JSON format.