### PR TITLE
Add ability to add globalDimensions as span tags in writer

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -166,6 +166,7 @@ The **nested** `writer` config object has the following fields:
 | `logTraceSpans` | no | bool | The analogue of `logDatapoints` for trace spans. (**default:** `false`) |
 | `logDimensionUpdates` | no | bool | If `true`, dimension updates will be logged at the INFO level. (**default:** `false`) |
 | `logDroppedDatapoints` | no | bool | If true, and the log level is `debug`, filtered out datapoints will be logged. (**default:** `false`) |
+| `addGlobalDimensionsAsSpanTags` | no | bool | If true, the dimensions specified in the top-level `globalDimensions` configuration will be added to the tag set of all spans that are emitted by the writer.  If this is false, only the "host id" dimensions such as `host`, `AwsUniqueId`, etc. are added to the span tags. (**default:** `false`) |
 | `sendTraceHostCorrelationMetrics` | no | bool | Whether to send host correlation metrics to correlation traced services with the underlying host (**default:** `true`) |
 | `staleServiceTimeout` | no | int64 | How long to wait after a trace span's service name is last seen to continue sending the correlation datapoints for that service.  This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if `sendTraceHostCorrelationMetrics` is false. (**default:** `"5m"`) |
 | `traceHostCorrelationMetricsInterval` | no | int64 | How frequently to send host correlation metrics that are generated from the service name seen in trace spans sent through or by the agent.  This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration.  This option is irrelvant if `sendTraceHostCorrelationMetrics` is false. (**default:** `"1m"`) |
@@ -408,6 +409,7 @@ where applicable:
     logTraceSpans: false
     logDimensionUpdates: false
     logDroppedDatapoints: false
+    addGlobalDimensionsAsSpanTags: false
     sendTraceHostCorrelationMetrics: true
     staleServiceTimeout: "5m"
     traceHostCorrelationMetricsInterval: "1m"

--- a/pkg/core/config/writer.go
+++ b/pkg/core/config/writer.go
@@ -69,6 +69,11 @@ type WriterConfig struct {
 	// If true, and the log level is `debug`, filtered out datapoints will be
 	// logged.
 	LogDroppedDatapoints bool `yaml:"logDroppedDatapoints"`
+	// If true, the dimensions specified in the top-level `globalDimensions`
+	// configuration will be added to the tag set of all spans that are emitted
+	// by the writer.  If this is false, only the "host id" dimensions such as
+	// `host`, `AwsUniqueId`, etc. are added to the span tags.
+	AddGlobalDimensionsAsSpanTags bool `yaml:"addGlobalDimensionsAsSpanTags"`
 	// Whether to send host correlation metrics to correlation traced services
 	// with the underlying host
 	SendTraceHostCorrelationMetrics *bool `yaml:"sendTraceHostCorrelationMetrics" default:"true"`

--- a/pkg/core/writer/spans.go
+++ b/pkg/core/writer/spans.go
@@ -35,6 +35,10 @@ func (sw *SignalFxWriter) preprocessSpan(span *trace.Span) bool {
 
 	sw.spanSourceTracker.AddSourceTagsToSpan(span)
 
+	if sw.conf.AddGlobalDimensionsAsSpanTags {
+		sw.addGlobalDims(span.Tags)
+	}
+
 	// adding smart agent version as a tag
 	span.Tags["signalfx.smartagent.version"] = constants.Version
 	if sw.conf.LogTraceSpans {

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -50388,6 +50388,14 @@
               "elementKind": ""
             },
             {
+              "yamlName": "addGlobalDimensionsAsSpanTags",
+              "doc": "If true, the dimensions specified in the top-level `globalDimensions` configuration will be added to the tag set of all spans that are emitted by the writer.  If this is false, only the \"host id\" dimensions such as `host`, `AwsUniqueId`, etc. are added to the span tags.",
+              "default": false,
+              "required": false,
+              "type": "bool",
+              "elementKind": ""
+            },
+            {
               "yamlName": "sendTraceHostCorrelationMetrics",
               "doc": "Whether to send host correlation metrics to correlation traced services with the underlying host",
               "default": true,


### PR DESCRIPTION
This will help with certain sidecar models of agent deployment.