### PR TITLE
Pin rubyzip for windows chef tests

### DIFF
--- a/tests/deployments/chef/chef_test.py
+++ b/tests/deployments/chef/chef_test.py
@@ -84,6 +84,8 @@ WIN_AGENT_COOKBOOK_SRC_DIR = os.path.join(WIN_REPO_ROOT_DIR, "deployments", "che
 WIN_AGENT_COOKBOOK_DEST_DIR = os.path.join(WIN_CHEF_COOKBOOKS_DIR, "signalfx_agent")
 WINDOWS_COOKBOOK_DIR = os.path.join(WIN_CHEF_COOKBOOKS_DIR, "windows")
 WINDOWS_COOKBOOK_URL = "https://supermarket.chef.io/cookbooks/windows/versions/6.0.0/download"
+WIN_GEM_BIN_DIR = r"C:\opscode\chef\embedded\bin"
+RUBYZIP_VERSION = "1.3.0"
 
 
 def run_chef_client(cont, chef_version, agent_version, stage):
@@ -192,6 +194,8 @@ def run_win_chef_setup(chef_version):
         run_win_command(f"choco upgrade -y -f chef-client --version {chef_version}")
     if WIN_CHEF_BIN_DIR not in os.environ.get("PATH"):
         os.environ["PATH"] = WIN_CHEF_BIN_DIR + ";" + os.environ.get("PATH")
+    if WIN_GEM_BIN_DIR not in os.environ.get("PATH"):
+        os.environ["PATH"] = WIN_GEM_BIN_DIR + ";" + os.environ.get("PATH")
     os.makedirs(WIN_CHEF_COOKBOOKS_DIR, exist_ok=True)
     if os.path.isdir(WIN_AGENT_COOKBOOK_DEST_DIR):
         shutil.rmtree(WIN_AGENT_COOKBOOK_DEST_DIR)
@@ -201,6 +205,7 @@ def run_win_chef_setup(chef_version):
             f'powershell -command "curl -outfile windows.tar.gz {WINDOWS_COOKBOOK_URL}"', cwd=WIN_CHEF_COOKBOOKS_DIR
         )
         run_win_command('powershell -command "tar -zxvf windows.tar.gz"', cwd=WIN_CHEF_COOKBOOKS_DIR)
+    run_win_command(f'powershell -command "gem install rubyzip -q -v "{RUBYZIP_VERSION}""')
 
 
 @pytest.mark.windows_only


### PR DESCRIPTION
Explicitly install rubyzip v1.3.0 for windows tests since the windows cookbook will download the latest rubyzip version if it does not already exist, which is unsupported on older versions of chef.