### PR TITLE
Add the agent pod annotations as values of the Helm chart

### DIFF
--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -22,6 +22,8 @@ spec:
         app: signalfx-agent
         version: 4.20.0
 
+      annotations:
+        {}
     spec:
       # Use host network so we can access kubelet directly
       hostNetwork: true

--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -30,6 +30,8 @@ spec:
         {{ with .Values.extraPodLabels -}}
         {{ toYaml . | indent 8 | trim }}
         {{- end }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
     spec:
       # Use host network so we can access kubelet directly
       hostNetwork: true

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -71,6 +71,9 @@ runOnMaster: true
 # creates.
 tolerations: []
 
+## Annotations for signalfx-agent pods
+podAnnotations: {}
+
 # Extra labels to put on agent pods.  Values must be strings per the k8s label
 # schema.
 extraPodLabels: {}
@@ -120,7 +123,7 @@ metricIntervalSeconds: 10
 logLevel: info
 
 # The log format of the agent.  Valid values are 'text' and 'json'
-# The agent will emit logs in either an unstructed text (default) or JSON format. 
+# The agent will emit logs in either an unstructed text (default) or JSON format.
 logFormat: text
 
 # Whether to ignore TLS validation issue when connecting to the main K8s API


### PR DESCRIPTION
It is fairly commonplace to let users change these values in helm charts.

Fixes #1129.