### PR TITLE
Fix installer test flakiness for rpm

### DIFF
--- a/.circleci/scripts/run-deployment-tests.sh
+++ b/.circleci/scripts/run-deployment-tests.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 
 mkdir -p ~/testresults
 if [ "$CIRCLE_BRANCH" != "master" ]; then
-    if ! scripts/changes-include-dir deployments/${DEPLOYMENT_TYPE} tests/deployments/${DEPLOYMENT_TYPE} ${BASH_SOURCE[0]}; then
+    if ! scripts/changes-include-dir deployments/${DEPLOYMENT_TYPE} tests/deployments/${DEPLOYMENT_TYPE} tests/packaging/common.py ${BASH_SOURCE[0]}; then
         echo "${DEPLOYMENT_TYPE} code has not changed, skipping tests!"
         touch ~/.skip
         exit 0

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -185,6 +185,10 @@ def run_init_system_image(
             container_options["command"] = command
 
         with run_container(image_id, wait_for_ip=True, **container_options) as cont:
+            # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1769831 which
+            # causes yum/dnf to exit with error code 141 when importing GPG keys.
+            cont.exec_run("mkdir -p /run/user/0")
+
             if with_socat:
                 # Proxy the backend calls through a fake HTTPS endpoint so that we
                 # don't have to change the default configuration default by the


### PR DESCRIPTION
Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1769831 which
causes yum/dnf to exit with error code 141 when importing GPG keys.