### PR TITLE
Fix versioning for windows agent build

### DIFF
--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -57,7 +57,7 @@ jobs:
       } else {
           $env:AGENT_VERSION = "$(Build.SourceVersion)"
       }
-      & ./scripts/windows/make.ps1 signalfx-agent
+      & ./scripts/windows/make.ps1 signalfx-agent -AGENT_VERSION "$env:AGENT_VERSION"
     displayName: 'Run go build'
   - task: PublishBuildArtifacts@1
     inputs:

--- a/scripts/windows/make.ps1
+++ b/scripts/windows/make.ps1
@@ -125,14 +125,14 @@ function bundle (
     if ($ZIP_BUNDLE -And !$ONLY_BUILD_AGENT) {
         # clean up empty directories
         remove_empty_directories -buildDir $buildDir
-        zip_file -src "$buildDir\$AGENT_NAME" -dest "$buildDir\$AGENT_NAME-$AGENT_VERSION-win64.zip"
+        zip_file -src "$buildDir\$AGENT_NAME" -dest "$buildDir\$AGENT_NAME-$env:AGENT_VERSION-win64.zip"
     }
     # remove latest.txt if it already exists
     if (Test-Path -Path "$buildDir\latest.txt"){
         Remove-Item "$buildDir\latest.txt"
     }
     # generate latest.txt file with agent version/tag
-    Add-Content -NoNewline -Path "$buildDir\latest.txt" -Value $AGENT_VERSION
+    Add-Content -NoNewline -Path "$buildDir\latest.txt" -Value $env:AGENT_VERSION
 }
 
 function lint() {


### PR DESCRIPTION
Particularly fixes the versioning for the bundle built in
azure-pipelines (currently builds as "SignalFxAgent--win64.zip").