### PR TITLE
Make Helm monitor config easier to override

### DIFF
--- a/deployments/k8s/README.md
+++ b/deployments/k8s/README.md
@@ -8,7 +8,7 @@ are generated from our [Helm](https://github.com/kubernetes/helm) chart, which
 is available in a SignalFx Helm repository -- see [SignalFx Agent Helm Chart
 Use](./helm/signalfx-agent#use) for more information.
 
-A few things to do before deploying these directly (when not using Helm):
+A few things to do before deploying these directly (when **not using Helm**):
 
  1. Make sure you change the `kubernetes_cluster` global dimension *and* the
 	`cluster` config option to something specific to your cluster in the

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: signalfx-agent
+  name: signalfx-agent-v5
   labels:
     app: signalfx-agent
 data:
@@ -14,6 +14,8 @@ data:
 
     etcPath: /hostfs/etc
     procPath: /hostfs/proc
+
+    enableBuiltInFiltering: true
 
     intervalSeconds: 10
 
@@ -66,69 +68,6 @@ data:
         io.kubernetes.pod.name: kubernetes_pod_name
         io.kubernetes.pod.uid: kubernetes_pod_uid
         io.kubernetes.pod.namespace: kubernetes_namespace
-
-    - type: collectd/activemq
-      discoveryRule: container_image =~ "activemq" && private_port == 1099
-
-    - type: collectd/apache
-      discoveryRule: container_image =~ "apache" && private_port == 80
-
-    - type: collectd/cassandra
-      discoveryRule: container_image =~ "cassandra" && private_port == 7199
-
-    - type: collectd/consul
-      discoveryRule: container_image =~ "consul" && private_port == 8500
-
-    - type: elasticsearch
-      discoveryRule: container_image =~ "elasticsearch" && port == 9200
-
-    - type: collectd/etcd
-      discoveryRule: container_image =~ "etcd" && port == 2379
-      clusterName: my-cluster
-
-    - type: haproxy
-      discoveryRule: container_image =~ "haproxy" && port == 9000
-
-    - type: collectd/kafka
-      discoveryRule: container_image =~ "kafka" && private_port == 9092
-
-    - type: collectd/memcached
-      discoveryRule: container_image =~ "memcache" && private_port == 11211
-
-    - type: collectd/mongodb
-      discoveryRule: container_image =~ "mongo" && private_port == 27017
-      databases:
-      - mydatabase
-
-    - type: collectd/mysql
-      discoveryRule: container_image =~ "mysql" && private_port == 3306
-      databases:
-      - name: mydb
-      username: admin
-
-    - type: collectd/nginx
-      discoveryRule: container_image =~ "nginx" && private_port == 80
-
-    - type: collectd/rabbitmq
-      discoveryRule: container_image =~ "rabbitmq" && private_port == 15672
-
-    - type: collectd/redis
-      discoveryRule: container_image =~ "redis" && private_port == 6379
-
-    - type: collectd/spark
-      discoveryRule: container_image =~ "spark" && private_port == 8080
-      clusterType: Standalone
-      collectApplicationMetrics: true
-      isMaster: true
-
-    - type: collectd/spark
-      discoveryRule: container_image =~ "spark" && private_port >= 8081
-      clusterType: Standalone
-      isMaster: false
-
-    - type: collectd/zookeeper
-      discoveryRule: container_image =~ "zookeeper" && private_port == 2181
-
 
 
     collectd:

--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 4.20.2
+    version: 5.0.0
 spec:
   selector:
     matchLabels:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 4.20.2
+        version: 5.0.0
 
       annotations:
         {}
@@ -41,7 +41,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:4.20.2"
+        image: "quay.io/signalfx/signalfx-agent:5.0.0"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent
@@ -86,7 +86,7 @@ spec:
       volumes:
       - name: config
         configMap:
-          name: signalfx-agent
+          name: signalfx-agent-v5
       - name: hostfs
         hostPath:
           path: /

--- a/deployments/k8s/helm/signalfx-agent/Chart.yaml
+++ b/deployments/k8s/helm/signalfx-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: The SignalFx Smart Agent
 name: signalfx-agent
-appVersion: 4.20.2
-version: 0.7.1
+appVersion: 5.0.0
+version: 1.0.0
 keywords:
 - monitoring
 - alerting

--- a/deployments/k8s/helm/signalfx-agent/README.md
+++ b/deployments/k8s/helm/signalfx-agent/README.md
@@ -34,17 +34,26 @@ not in this realm, you will need to explicitly set the `signalFxRealm` option
 in the agent configuration. To determine if you are in a different realm,
 check your profile page in the SignalFx web application.
 
+### Values
+
 See the [values.yaml](./values.yaml) file for more information on how to
 configure releases.
 
-There are two **required** config options to run this chart: `signalFxAccessToken`
-and `clusterName` (if not overridding the agent config template and providing your own cluster name).
+There are two **required** config options to run this chart:
+`signalFxAccessToken` and `clusterName` (if not overridding the agent config
+template and providing your own cluster name).
 
-It is also **recommended** that you explicitly specify `agentVersion` when deploying a release so that the agent will not be unintentionally updated based on updates of the helm chart from the repo.
+It is also **recommended** that you explicitly specify `agentVersion` when
+deploying a release so that the agent will not be unintentionally updated based
+on updates of the helm chart from the repo.
+
+We also highly recommend that you pin the Helm chart version that you are using
+(with the `--version` flag to `helm install/upgrade`) so that you do not
+receive inadvertant updates to resources that you don't want.
 
 For example, a basic command line install setting these values would be:
 
-`$ helm install --set signalFxAccessToken=<YOUR_ACCESS_TOKEN> --set clusterName=<YOUR_CLUSTER_NAME> --set agentVersion=<VERSION_NUMBER> --set signalFxRealm=<YOUR_SIGNALFX_REALM> signalfx/signalfx-agent`
+`$ helm install --version <HELM CHART VERSION> --set signalFxAccessToken=<YOUR_ACCESS_TOKEN> --set clusterName=<YOUR_CLUSTER_NAME> --set agentVersion=<VERSION_NUMBER> --set signalFxRealm=<YOUR_SIGNALFX_REALM> signalfx/signalfx-agent`
 
 If you want to provide your own agent configuration, you can do so with the
 `agentConfig` value.  Otherwise, you can do a great deal of customization to
@@ -53,4 +62,4 @@ the provided config template using values.
 If you are using OpenShift set `kubernetesDistro` to `openshift` to get
 OpenShift-specific functionality:
 
-`$ helm install --set signalFxAccessToken=<YOUR_ACCESS_TOKEN> --set clusterName=<YOUR_CLUSTER_NAME> --set agentVersion=<VERSION_NUMBER> --set signalFxRealm=<YOUR_SIGNALFX_REALM> signalfx/signalfx-agent --set kubernetesDistro=openshift`
+`$ helm install --version <HELM_CHART_VERSION> --set signalFxAccessToken=<YOUR_ACCESS_TOKEN> --set clusterName=<YOUR_CLUSTER_NAME> --set agentVersion=<VERSION_NUMBER> --set signalFxRealm=<YOUR_SIGNALFX_REALM> signalfx/signalfx-agent --set kubernetesDistro=openshift`

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -32,9 +32,16 @@ data:
     etcPath: {{ .Values.etcPath }}
     procPath: {{ .Values.procPath }}
 
+    enableBuiltInFiltering: true
+
     intervalSeconds: {{ .Values.metricIntervalSeconds }}
 
     cluster: {{ required ".Values.clusterName is required" .Values.clusterName }}
+
+{{- $major_version := .Values.agentVersion | default "0.0.0" | splitList "." | first | atoi -}}
+{{- if lt $major_version 5 }}
+    sendMachineID: false
+{{- end }}
 
     logging:
       level: {{ .Values.logLevel | default "info" }}
@@ -54,6 +61,8 @@ data:
       {{- end }}
 
     monitors:
+{{- if .Values.configureStandardMonitors }}
+{{- if ge $major_version 5 }}
     - type: cpu
     - type: filesystems
       hostFSPath: {{ .Values.hostFSPath }}
@@ -64,6 +73,23 @@ data:
     - type: host-metadata
     - type: processlist
     - type: vmem
+{{- else }}
+    - type: collectd/cpu
+    - type: collectd/cpufreq
+    - type: collectd/df
+      hostFSPath: /hostfs
+    - type: disk-io
+    - type: collectd/interface
+    - type: load
+    - type: collectd/memory
+    - type: collectd/protocols
+    - type: collectd/signalfx-metadata
+      omitProcessInfo: true
+    - type: host-metadata
+    - type: processlist
+    - type: collectd/uptime
+    - type: collectd/vmem
+{{- end }}
 
     - type: kubelet-stats
       {{- if .Values.containerStatsIntervalSeconds }}
@@ -85,6 +111,9 @@ data:
     {{ if .Values.gatherClusterMetrics -}}
     # Collects k8s cluster-level metrics
     - type: {{.Values.kubernetesDistro}}-cluster
+{{- if lt $major_version 5 }}
+      useNodeName: true
+{{- end }}
     {{- end }}
 
     {{ if .Values.gatherDockerMetrics -}}
@@ -99,7 +128,7 @@ data:
         io.kubernetes.pod.uid: kubernetes_pod_uid
         io.kubernetes.pod.namespace: kubernetes_namespace
     {{- end }}
-
+{{- end }}
     {{ range .Values.monitors -}}
     - type: {{ .type }}
       {{- with .discoveryRule }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -1,6 +1,6 @@
 # Version of the signalfx-agent to deploy.  This will be the default for the
 # docker image tag if not overridden with imageTag
-agentVersion: 4.20.2
+agentVersion: 5.0.0
 
 # The access token for SignalFx. (REQUIRED if signalFxAccessTokenSecretName not set)
 signalFxAccessToken: ""
@@ -135,13 +135,14 @@ logFormat: text
 
 # Whether to ignore TLS validation issue when connecting to the main K8s API
 # server.  This should almost never need to be set to true since the CA cert is
-# provided with the service account token automatically by K8s.
+# provided with the service account token automatically by K8s. Has no effect
+# if `configureStandardMonitors: false`.
 apiServerSkipVerify: false
 
 # Additional options for connecting to the Kubelet.  These options are
 # equivalent to what is under the 'kubeletAPI' key of the 'kubelet-stats'
 # monitor.  By default, the agent tries to use its service account if kubelet
-# authentication is required.
+# authentication is required.  Has no effect if `configureStandardMonitors: false`.
 kubeletAPI:
   authType: serviceAccount
   # Replace the above with the following if using GKE/PKE or any
@@ -155,23 +156,24 @@ kubeletAPI:
 collectd: {}
 
 # How often to send cAdvisor-based container metrics.  Defaults to whatever is
-# in metricIntervalSeconds.
+# in metricIntervalSeconds. Has no effect if `configureStandardMonitors: false`.
 containerStatsIntervalSeconds:
 
 # Kubernetes distribution. Can be one either `kubernetes` or `openshift`. Defaults to
-# `kubernetes`.
+# `kubernetes`. Has no effect if `configureStandardMonitors: false`.
 kubernetesDistro: kubernetes
 
 # If true, K8s cluster-level metrics will be collected (e.g. pod counts,
 # deployment status, etc).  The agents will decide amongst themselves which
-# instance should send the metrics so that they are only sent once.
+# instance should send the metrics so that they are only sent once.  Has no
+# effect if `configureStandardMonitors: false`.
 gatherClusterMetrics: true
 
 # Enables the docker-container-stats monitor with some specific config that
 # causes it to send container stats from Docker with certain dimensions from
 # container labels that makes it easy to correlate metrics between cadvisor and
 # docker. Note that docker metrics are not sent for pause containers by
-# default.
+# default.  Has no effect if `configureStandardMonitors: false`.
 gatherDockerMetrics: true
 
 # A list of metric names that are collected by monitors but are not to be sent
@@ -195,73 +197,10 @@ procPath: /hostfs/proc
 # necessary to get filesystem usage information.
 hostFSPath: /hostfs
 
+# If true, a standard set of host infrastructure and Kubernetes cluster
+# monitors will be configured.
+configureStandardMonitors: true
+
 # A list of monitor configurations to include in the agent config.  These
 # values correspond exactly to what goes under 'monitors' in the agent config.
-# The following are a set of monitors with discovery rules that should cover
-# many standard deployments.  Most users will want to override this with their
-# own monitors and discovery rules.
 monitors:
-  - type: collectd/activemq
-    discoveryRule: container_image =~ "activemq" && private_port == 1099
-
-  - type: collectd/apache
-    discoveryRule: container_image =~ "apache" && private_port == 80
-
-  - type: collectd/cassandra
-    discoveryRule: container_image =~ "cassandra" && private_port == 7199
-
-  - type: collectd/consul
-    discoveryRule: container_image =~ "consul" && private_port == 8500
-
-  - type: elasticsearch
-    discoveryRule: container_image =~ "elasticsearch" && port == 9200
-
-  - type: collectd/etcd
-    discoveryRule: container_image =~ "etcd" && port == 2379
-    # REQUIRED
-    clusterName: my-cluster
-
-  - type: haproxy
-    discoveryRule: container_image =~ "haproxy" && port == 9000
-
-  - type: collectd/kafka
-    discoveryRule: container_image =~ "kafka" && private_port == 9092
-
-  - type: collectd/memcached
-    discoveryRule: container_image =~ "memcache" && private_port == 11211
-
-  - type: collectd/mongodb
-    discoveryRule: container_image =~ "mongo" && private_port == 27017
-    # REQUIRED
-    databases:
-    - mydatabase
-
-  - type: collectd/mysql
-    discoveryRule: container_image =~ "mysql" && private_port == 3306
-    # REQUIRED
-    username: admin
-    databases:
-    - name: mydb
-
-  - type: collectd/nginx
-    discoveryRule: container_image =~ "nginx" && private_port == 80
-
-  - type: collectd/rabbitmq
-    discoveryRule: container_image =~ "rabbitmq" && private_port == 15672
-
-  - type: collectd/redis
-    discoveryRule: container_image =~ "redis" && private_port == 6379
-
-  - type: collectd/spark
-    discoveryRule: container_image =~ "spark" && private_port == 8080
-    isMaster: true
-    collectApplicationMetrics: true
-    clusterType: Standalone
-
-  - type: collectd/spark
-    discoveryRule: container_image =~ "spark" && private_port >= 8081
-    isMaster: false
-    clusterType: Standalone
-
-  - type: collectd/zookeeper
-    discoveryRule: container_image =~ "zookeeper" && private_port == 2181


### PR DESCRIPTION
This adds a config option called 'configureStandardMonitoring' that defaults to
'true' that keeps the standard set of host + docker + K8s monitors.  If set to
'false', then the only monitors that will be added are the ones specified in the
'monitors' config option.

Removes all of the 'built-in' monitor configuration from the default value of
'montiors'.