### PR TITLE
Fix genmetadata.tmpl for Go 1.14 - (4-dev branch)

### DIFF
--- a/cmd/monitorcodegen/genmetadata.tmpl
+++ b/cmd/monitorcodegen/genmetadata.tmpl
@@ -9,7 +9,7 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 )
 
-{{if (len .monitors) eq 1 }}
+{{if eq (len .monitors) 1 }}
 const {{"monitorType" | formatVariable}} = "{{(index .monitors 0).MonitorType}}"
 {{end}}
 

--- a/pkg/monitors/cadvisor/genmetadata.go
+++ b/pkg/monitors/cadvisor/genmetadata.go
@@ -7,8 +7,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 )
 
-const monitorType = "cadvisor"
-
 const (
 	groupPodEphemeralStats = "podEphemeralStats"
 )

--- a/pkg/monitors/gitlab/genmetadata.go
+++ b/pkg/monitors/gitlab/genmetadata.go
@@ -7,8 +7,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 )
 
-const monitorType = "gitlab"
-
 var groupSet = map[string]bool{}
 
 const (

--- a/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
+++ b/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
@@ -7,8 +7,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 )
 
-const MonitorType = "kubernetes-cluster"
-
 const (
 	GroupHpa = "hpa"
 )

--- a/pkg/monitors/kubernetes/cluster/monitor.go
+++ b/pkg/monitors/kubernetes/cluster/monitor.go
@@ -39,6 +39,11 @@ const (
 	OpenShift
 )
 
+var distributionToMonitorType = map[KubernetesDistribution]string{
+	Generic:   meta.KubernetesClusterMonitorMetadata.MonitorType,
+	OpenShift: meta.OpenshiftClusterMonitorMetadata.MonitorType,
+}
+
 // Config for the K8s monitor
 type Config struct {
 	config.MonitorConfig
@@ -89,7 +94,7 @@ func init() {
 // Configure is called by the plugin framework when configuration changes
 func (m *Monitor) Configure(config *Config) error {
 	var err error
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": meta.MonitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": distributionToMonitorType[m.distribution]})
 
 	m.config = config
 


### PR DESCRIPTION
Bringing fix from master into 4-dev
Make kubernetes-cluster monitor set the monitor type on the logger properly.