### PR TITLE
Upgrade Go to 1.14

### DIFF
--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -16,7 +16,7 @@ variables:
   GOBIN: '$(GOPATH)/bin'
   SANIC_NO_UVLOOP: 'true'
   TEST_SERVICES_DIR: '$(Build.SourcesDirectory)\test-services'
-  GOVERSION: "1.13.1"
+  GOVERSION: "1.14"
   GOMOD_HASH: ""
   GOSUM_HASH: ""
 
@@ -30,7 +30,7 @@ jobs:
   - script: |
       set -euo pipefail
 
-      lintver="1.20.0"
+      lintver="1.23.8"
       curl -sfL https://github.com/golangci/golangci-lint/releases/download/v${lintver}/golangci-lint-${lintver}-linux-amd64.tar.gz > /tmp/golangci-lint.tar.gz
       tar -xf /tmp/golangci-lint.tar.gz -C /tmp
       chmod +x /tmp/golangci-lint-${lintver}-linux-amd64/golangci-lint

--- a/.azure-pipelines/templates/install-go.yml
+++ b/.azure-pipelines/templates/install-go.yml
@@ -1,6 +1,6 @@
 parameters:
   packages: ''
-  version: '1.13.1'
+  version: '1.14'
 
 steps:
 - task: GoTool@0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ executors:
   goexecutor:
     working_directory: /code
     docker:
-      - image: golang:1.13.1-alpine
+      - image: golang:1.14.0-alpine
         environment:
           CGO_ENABLED: 0
           AGENT_BIN: /code/signalfx-agent
@@ -73,8 +73,8 @@ commands:
 
             # Machine image only has Go 1.9 installed
             cd /tmp
-            wget https://dl.google.com/go/go1.13.1.linux-amd64.tar.gz
-            sudo tar -C /usr/local -xzf go1.13.1.linux-amd64.tar.gz
+            wget https://dl.google.com/go/go1.14.linux-amd64.tar.gz
+            sudo tar -C /usr/local -xzf go1.14.linux-amd64.tar.gz
       - save_cache:
           key: v1-pytest-<< parameters.python_version >>-{{ checksum "tests/requirements.txt" }}
           paths:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,11 @@ linters:
     # There are many legitimate uses of globals
     - gochecknoglobals
     - godox
+    # An analyzer to detect magic numbers.
+    - gomnd
+    # Checks whether Err of rows is checked successfully
+    # Re-enable when this false positive is fixed https://github.com/golangci/golangci-lint/issues/943
+    - rowserrcheck
     # Too many of these errors to fix in a reasonable amount of time.
     - wsl
     # TODO: reenable this one after a fix up of the existing code base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.13.1
+ARG GO_VERSION=1.14
 
 ###### Agent Build Image ########
 FROM ubuntu:16.04 as agent-builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/signalfx/signalfx-agent
 
-go 1.13
+go 1.14
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
 

--- a/pkg/core/common/auth/tls.go
+++ b/pkg/core/common/auth/tls.go
@@ -53,7 +53,6 @@ func TLSConfig(tlsConfig *tls.Config, caCertPath string, clientCertPath string, 
 
 	tlsConfig.Certificates = clientCerts
 	tlsConfig.RootCAs = certs
-	tlsConfig.BuildNameToCertificate()
 
 	return tlsConfig, nil
 }

--- a/scripts/windows/vagrant/common/3_golang.ps1
+++ b/scripts/windows/vagrant/common/3_golang.ps1
@@ -1,5 +1,5 @@
 # TODO: centralize these
-$goVersion = "1.13.1"
+$goVersion = "1.14"
 
 # ensure choco in path
 $env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);

--- a/test-services/fakek8s/Dockerfile
+++ b/test-services/fakek8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.4-alpine
+FROM golang:1.14.0-alpine
 
 CMD ["./fakek8s", "-httptest.serve=0.0.0.0:8443"]
 EXPOSE 8443

--- a/tests/helpers/profiling.py
+++ b/tests/helpers/profiling.py
@@ -69,7 +69,8 @@ class PProfClient:
         assert lines.pop(0).split() == ["flat", "flat%", "sum%", "cum", "cum%"], "unexpected pprof header line"
 
         nodes = [
-            Node(*[float(c.strip(string.ascii_letters + "%")) for c in li.split()[:5]], *li.split()[5:]) for li in lines
+            Node(*[float(c.strip(string.ascii_letters + "%")) for c in li.split()[:5]], *li.split()[5:7])
+            for li in lines
         ]
 
         return Profile(


### PR DESCRIPTION
In addition to moving to Go 1.14, I upgraded golangci-lint
Disabled 2 linters: 
- gomnd
- rowserrcheck (this was needed due to the linter throwing a false positive, same as in https://github.com/golangci/golangci-lint/issues/943)
While on it, I modified `determineDatabases` to close rows and log the appropriate messages @keitwb if you can double check

Finally, addressed a deprecated TLS function:
```
// BuildNameToCertificate parses c.Certificates and builds c.NameToCertificate
// from the CommonName and SubjectAlternateName fields of each of the leaf
// certificates.
//
// Deprecated: NameToCertificate only allows associating a single certificate
// with a given name. Leave that field nil to let the library select the first
// compatible chain from Certificates.
func (c *Config) BuildNameToCertificate() {
```

Signed-off-by: Dani Louca <dlouca@splunk.com>