### PR TITLE
Fix Windows and Darwin memory

### DIFF
--- a/pkg/monitors/memory/memory.go
+++ b/pkg/monitors/memory/memory.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/mem"
-	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -39,15 +38,7 @@ func (m *Monitor) emitDatapoints() {
 		return
 	}
 
-	used := memInfo.Total - memInfo.Free - memInfo.Buffers - (memInfo.Cached - memInfo.SReclaimable) - memInfo.Slab
-
-	dps := []*datapoint.Datapoint{
-		datapoint.New("memory.utilization", nil, datapoint.NewFloatValue(float64(used)/float64(memInfo.Total)*100), datapoint.Gauge, time.Time{}),
-		datapoint.New("memory.used", nil, datapoint.NewIntValue(int64(used)), datapoint.Gauge, time.Time{}),
-	}
-
-	dps = append(dps, m.makeMemoryDatapoints(memInfo, nil)...)
-
+	dps := m.makeMemoryDatapoints(memInfo, nil)
 	m.Output.SendDatapoints(dps...)
 }
 

--- a/pkg/monitors/memory/memory_darwin.go
+++ b/pkg/monitors/memory/memory_darwin.go
@@ -9,6 +9,8 @@ import (
 
 func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
+		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.active", dimensions, datapoint.NewIntValue(int64(memInfo.Active)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.inactive", dimensions, datapoint.NewIntValue(int64(memInfo.Inactive)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.wired", dimensions, datapoint.NewIntValue(int64(memInfo.Wired)), datapoint.Gauge, time.Time{}),

--- a/pkg/monitors/memory/memory_linux.go
+++ b/pkg/monitors/memory/memory_linux.go
@@ -8,7 +8,11 @@ import (
 )
 
 func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+	used := memInfo.Total - memInfo.Free - memInfo.Buffers - (memInfo.Cached - memInfo.SReclaimable) - memInfo.Slab
+
 	return []*datapoint.Datapoint{
+		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(float64(used)/float64(memInfo.Total)*100), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(used)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.buffered", dimensions, datapoint.NewIntValue(int64(memInfo.Buffers)), datapoint.Gauge, time.Time{}),
 		// for some reason gopsutil decided to add slab_reclaimable to cached which collectd does not
 		datapoint.New("memory.cached", dimensions, datapoint.NewIntValue(int64(memInfo.Cached-memInfo.SReclaimable)), datapoint.Gauge, time.Time{}),

--- a/pkg/monitors/memory/memory_windows.go
+++ b/pkg/monitors/memory/memory_windows.go
@@ -9,6 +9,8 @@ import (
 
 func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
+		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.available", dimensions, datapoint.NewIntValue(int64(memInfo.Available)), datapoint.Gauge, time.Time{}),
 	}
 }


### PR DESCRIPTION
For windows and darwin , `github.com/shirou/gopsutil/mem` does not set the following fields:
```
memInfo.Free 
memInfo.Buffers 
memInfo.Cached 
memInfo.SReclaimable
memInfo.Slab
```

this PR keeps the behavior introduced in https://github.com/signalfx/signalfx-agent/commit/eeb82567607c1773343ba902ed05a53d03b6041c#diff-47542688be93f824eaf4eda336288e52 to Linux only.

Signed-off-by: Dani Louca <dlouca@splunk.com>