### PR TITLE
Update golangci-lint to v1.23.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -462,7 +462,7 @@ COPY --from=agent-builder /go $GOPATH
 RUN go get -u golang.org/x/lint/golint &&\
     if [ `uname -m` != "aarch64" ]; then go get github.com/derekparker/delve/cmd/dlv; fi &&\
     go get github.com/tebeka/go2xunit &&\
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.20.0
+    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
 
 COPY ./ ./
 


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

match the dev image version with the ci version 