### PR TITLE
Add log error msg when there are errors sending spans

### DIFF
--- a/pkg/core/writer/spans.go
+++ b/pkg/core/writer/spans.go
@@ -18,8 +18,18 @@ func (sw *SignalFxWriter) sendSpans(ctx context.Context, spans []*trace.Span) er
 		sw.serviceTracker.AddSpans(sw.ctx, spans)
 	}
 
-	// This sends synchronously
-	return sw.client.AddSpans(context.Background(), spans)
+	// This sends synchonously
+	err := sw.client.AddSpans(context.Background(), spans)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Error("Error shipping spans to SignalFx")
+		// If there is an error sending spans then just forget about them.
+		return err
+	}
+	log.Debugf("Sent %d spans out of the agent", len(spans))
+
+	return nil
 }
 
 // Mutates span tags in place to add global span tags.  Also


### PR DESCRIPTION
This was done symmetrically to what is done for SFx datapoints, see https://github.com/signalfx/signalfx-agent/blob/3d1c91ba28c7921fcec1dc264b39464bb69f5d37/pkg/core/writer/writer.go#L266-L282