### PR TITLE
force import key

### DIFF
--- a/deployments/installer/install.sh
+++ b/deployments/installer/install.sh
@@ -277,6 +277,7 @@ install_with_zypper() {
     version_flag="-${package_version}"
   fi
 
+  rpm --import $yum_gpg_key_url
   zypper -n --gpg-auto-import-keys refresh
   zypper install -y -l libcap2 libcap-progs libpcap1 shadow
   local tmpdir=$(mktemp -d)


### PR DESCRIPTION
`Zypper` option `--gpg-auto-import-keys` is not importing the key. 
This force importing the key explicitlly.
Tested on suse 12 and 15

cc: @jchengsfx 

Signed-off-by: Dani Louca <dlouca@splunk.com>