### PR TITLE
Add service owner option for puppet

### DIFF
--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -58,7 +58,14 @@ class accepts the following parameters:
  - `$installation_directory`: Valid only on Windows. The path where the SignalFx
    Agent should be downloaded to. (**default:** 'C:\\Program Files\\SignalFx\\')
 
+ - `$service_user` and `$service_group`: Valid only on Linux. Set the user/group
+   ownership for the signalfx-agent service. The user/group will be created if
+   they do not exist. (**default:** 'signalfx-agent')
+
 ## Dependencies
+On Linux-based systems, the
+[puppetlabs/stdlib](https://forge.puppet.com/puppetlabs/stdlib) module is
+required.
 
 On Debian-based systems, the
 [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module is required to

--- a/deployments/puppet/lib/facter/local_groups.rb
+++ b/deployments/puppet/lib/facter/local_groups.rb
@@ -1,0 +1,15 @@
+# This custom fact pulls out all local groups from the /etc/group file
+# and returns the collection as a comma-separated list.
+
+Facter.add(:local_groups) do
+  setcode do
+    groups = Array.new
+    if File.exists?("/etc/group")
+      File.open("/etc/group").each do |line|
+        next if line.match(/^\s|^#|^$/)
+        groups << line.split(':').first
+      end
+    end
+    groups.join(',')
+  end
+end

--- a/deployments/puppet/lib/facter/local_users.rb
+++ b/deployments/puppet/lib/facter/local_users.rb
@@ -1,0 +1,15 @@
+# This custom fact pulls out all local users from the /etc/passwd file
+# and returns the collection as a comma-separated list.
+
+Facter.add(:local_users) do
+  setcode do
+    users = Array.new
+    if File.exists?("/etc/passwd")
+      File.open("/etc/passwd").each do |line|
+        next if line.match(/^\s|^#|^$/)
+        users << line.split(':').first
+      end
+    end
+    users.join(',')
+  end
+end

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -7,11 +7,13 @@ class signalfx_agent (
     'debian'  => '/etc/signalfx/agent.yaml',
     'redhat'  => '/etc/signalfx/agent.yaml',
     'windows' => 'C:\\ProgramData\\SignalFxAgent\\agent.yaml',
-    'default' => '/etc/signalfx/agent.yaml'
+    default   => '/etc/signalfx/agent.yaml'
   },
   $agent_version          = '',
   $package_version        = '',
   $installation_directory = 'C:\\Program Files\\SignalFx',
+  $service_user           = 'signalfx-agent',  # linux only
+  $service_group          = 'signalfx-agent',  # linux only
 ) {
 
   $service_name = 'signalfx-agent'
@@ -90,6 +92,14 @@ class signalfx_agent (
   -> service { $service_name:
     ensure => true,
     enable => true,
+  }
+
+  if $::osfamily != 'windows' {
+    class { 'signalfx_agent::service_owner':
+      service_name  => $service_name,
+      service_user  => $service_user,
+      service_group => $service_group,
+    }
   }
 
   file { $config_parent_directory_path:

--- a/deployments/puppet/manifests/service_owner.pp
+++ b/deployments/puppet/manifests/service_owner.pp
@@ -1,0 +1,154 @@
+# Sets the user/group for the signalfx-agent service.
+# If the user or group does not exist, they will be created.
+class signalfx_agent::service_owner ($service_name, $service_user, $service_group) {
+
+  if $service_group == 'signalfx-agent' or $service_group in split($::local_groups, ',') {
+    group { $service_group:
+      noop => true,
+    }
+  }
+  else {
+    group { $service_group:
+      ensure => present,
+      system => true,
+    }
+  }
+
+  if $service_user == 'signalfx-agent' or $service_user in split($::local_users, ',') {
+    user { $service_user:
+      noop => true,
+    }
+  }
+  else {
+    $shell = $::osfamily ? {
+      'debian' => '/usr/sbin/nologin',
+      default  => '/sbin/nologin',
+    }
+    user { $service_user:
+      ensure => present,
+      system => true,
+      shell  => $shell,
+      groups => $service_group,
+    }
+  }
+
+  case $::service_provider {
+    'systemd': {
+      $tmpfile_path = "/etc/tmpfiles.d/${service_name}.conf"
+      $tmpfile_dir = $tmpfile_path.split('/')[0, - 2].join('/')
+
+      $override_path = "/etc/systemd/system/${service_name}.service.d/service-owner.conf"
+      $override_dir = $override_path.split('/')[0, - 2].join('/')
+
+      Package[$service_name] ~> Group[$service_group] ~> User[$service_user]
+
+      ~> exec { 'systemctl stop signalfx-agent':
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+        refreshonly => true,
+      }
+
+      ~> file { [$tmpfile_dir, $override_dir]:
+        ensure => directory,
+      }
+
+      ~> file {
+        $tmpfile_path:
+          ensure  => file,
+          content => "D /run/${service_name} 0755 ${service_user} ${service_group} - -",
+        ;
+        $override_path:
+          ensure => file,
+        ;
+      }
+
+      ~> file_line {
+        $override_path:
+          path  => $override_path,
+          line  => '[Service]',
+          match => '^[Service]',
+        ;
+        'set-service-user':
+          path    => $override_path,
+          line    => "User=${service_user}",
+          match   => '^User=',
+          after   => '^[Service]',
+          require => File_Line[$override_path],
+        ;
+        'set-service-group':
+          path    => $override_path,
+          line    => "Group=${service_group}",
+          match   => '^Group=',
+          after   => '^User=',
+          require => File_Line['set-service-user'],
+        ;
+      }
+
+      ~> exec { ["systemd-tmpfiles --create --remove ${tmpfile_path}", 'systemctl daemon-reload']:
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+        returns     => [0],
+        refreshonly => true,
+      }
+
+      ~> Service[$service_name]
+    }
+    default: {
+      $initd_path = "/etc/init.d/${service_name}"
+      $default_path = "/etc/default/${service_name}"
+      $run_path = "/var/run/${service_name}"
+      $log_path = "/var/log/${service_name}.log"
+
+      Package[$service_name] ~> Group[$service_group] ~> User[$service_user]
+
+      ~> exec { 'service signalfx-agent stop':
+        path        => '/bin:/sbin:/usr/bin:/usr/sbin',
+        refreshonly => true,
+      }
+
+      ~> file {
+        $initd_path:
+          ensure => file,
+        ;
+        $default_path:
+          ensure => file,
+        ;
+        $run_path:
+          ensure  => directory,
+          owner   => $service_user,
+          recurse => true,
+        ;
+        $log_path:
+          ensure => file,
+          owner  => $service_user,
+        ;
+      }
+
+      ~> file_line {
+        # Update old service scripts to source vars from $default_path.
+        'patch-initd-service-1':
+          path  => $initd_path,
+          line  => "[ -r ${default_path} ] && . ${default_path}",
+          after => '^logfile=',
+        ;
+        'set-service-user':
+          path  => $default_path,
+          line  => "user=${service_user}",
+          match => '^user=',
+        ;
+        'set-service-group':
+          path  => $default_path,
+          line  => "group=${service_group}",
+          match => '^group=',
+        ;
+      }
+
+      # Update old service scripts that explicitly set file ownership.
+      ~> exec { 'patch-initd-service-2':
+        path    => '/bin:/sbin:/usr/bin:/usr/sbin',
+        command => "sed -i 's/chown\\(.*\\)signalfx-agent/chown\\1\$user/' ${initd_path}",
+        onlyif  => "test -f ${initd_path} && grep 'chown.*signalfx-agent' ${initd_path}",
+      }
+
+      ~> Service[$service_name]
+    }
+  }
+}

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-signalfx_agent",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "SignalFx, Inc.",
   "summary": "This module installs the SignalFx SmartAgent via distro packages and configures it.",
   "license": "Apache-2.0",

--- a/deployments/puppet/spec/classes/init_spec.rb
+++ b/deployments/puppet/spec/classes/init_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 describe 'signalfx_agent' do
   let(:title) { 'signalfx_agent' }
   let(:params) { { 'config' => {} } }
-  let (:facts) { { :osfamily => 'redhat'} }
 
   it "fails without access token" do
     is_expected.to compile.and_raise_error(/signalFxAccessToken/)

--- a/deployments/puppet/spec/spec_helper.rb
+++ b/deployments/puppet/spec/spec_helper.rb
@@ -11,4 +11,5 @@ RSpec.configure do |c|
   c.manifest_dir    = File.join(fixture_path, 'manifests')
   c.manifest        = File.join(fixture_path, 'manifests', 'site.pp')
   c.environmentpath = File.join(Dir.pwd, 'spec')
+  c.default_facts   = { :osfamily => 'redhat', :service_provider => 'systemd' }
 end

--- a/packaging/etc/init.d/signalfx-agent.debian
+++ b/packaging/etc/init.d/signalfx-agent.debian
@@ -47,11 +47,11 @@ case "$1" in
         echo "Starting $name"
 
         mkdir -p "$rundir"
-        chown -R signalfx-agent "$rundir"
+        chown -R $user "$rundir"
         chmod 0755 "$rundir"
 
         touch $logfile
-        chown signalfx-agent $logfile
+        chown $user $logfile
 
         start-stop-daemon --start \
           --startas /bin/sh \

--- a/packaging/etc/init.d/signalfx-agent.rhel
+++ b/packaging/etc/init.d/signalfx-agent.rhel
@@ -46,21 +46,21 @@ case "$1" in
       echo "Starting $name"
 
       mkdir -p "$rundir"
-      chown -R signalfx-agent "$rundir"
+      chown -R $user "$rundir"
       chmod 0755 "$rundir"
 
       touch $logfile
-      chown signalfx-agent $logfile
+      chown $user $logfile
 
-      nohup su -s /bin/sh -c 'exec "$0" "$@"' $user -- $cmd >> /var/log/signalfx-agent.log 2>&1 &
+      nohup su -s /bin/sh -c 'exec "$0" "$@"' $user -- $cmd >> $logfile 2>&1 &
       pid=$!
 
       if [ $? -eq 0 ]; then
-        echo "Started.  Logs will go to /var/log/signalfx-agent.log"
+        echo "Started.  Logs will go to $logfile"
         echo -n $pid > $pidfile
         exit 0
       else
-        echo "Failed to start, see /var/log/signalfx-agent.log"
+        echo "Failed to start, see $logfile"
         exit 1
       fi
     fi

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -204,8 +204,8 @@ def run_init_system_image(
 
 
 @retry_on_ebadf
-def is_agent_running_as_non_root(container):
-    code, output = container.exec_run("pgrep -u signalfx-agent signalfx-agent")
+def is_agent_running_as_non_root(container, user="signalfx-agent"):
+    code, output = container.exec_run(f"pgrep -u {user} signalfx-agent")
     print("pgrep check: %s" % output)
     return code == 0
 


### PR DESCRIPTION
- Add `puppetlabs/stdlib` dependency required for `service_provider` fact to determine the node's service manager.
- Add `local_users` and `local_groups` custom facts to get existing users/groups.
- Create user/group if they do not exist (existing users/groups will not be modified).
- Patch `/etc/init.d/signalfx-agent` on sysv/upstart systems for older agent versions that do not include https://github.com/signalfx/signalfx-agent/commit/60b9cea4e22110aa786d171cd81b7c8ef7600d3b or https://github.com/signalfx/signalfx-agent/pull/1271/commits/62f4f7676f3cb677023dcf0937464cea36d64227.
