### PR TITLE
Update installer script to install apt-transport-https

### DIFF
--- a/deployments/installer/install.sh
+++ b/deployments/installer/install.sh
@@ -223,6 +223,10 @@ install_debian_apt_source() {
   if [ "$stage" = "test" ]; then
     trusted_flag="[trusted=yes]"
   fi
+
+  apt-get -y update
+  apt-get -y install apt-transport-https
+
   echo "deb $trusted_flag $deb_repo_base $stage main" > /etc/apt/sources.list.d/signalfx-agent.list
 }
 

--- a/tests/packaging/images/Dockerfile.debian-8-jessie
+++ b/tests/packaging/images/Dockerfile.debian-8-jessie
@@ -1,7 +1,7 @@
 FROM debian:jessie-slim
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers
+    apt-get install -yq ca-certificates procps wget init-system-helpers
 
 COPY socat /bin/socat
 

--- a/tests/packaging/images/Dockerfile.debian-9-stretch
+++ b/tests/packaging/images/Dockerfile.debian-9-stretch
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https
+    apt-get install -yq ca-certificates procps systemd wget
 
 COPY socat /bin/socat
 

--- a/tests/packaging/images/Dockerfile.ubuntu1404
+++ b/tests/packaging/images/Dockerfile.ubuntu1404
@@ -4,7 +4,7 @@ FROM ubuntu:14.04
 
 RUN rm -f /etc/apt/sources.list.d/ubuntu-esm-infra-trusty.list && \
     apt update &&\
-    apt install -y ca-certificates procps wget apt-transport-https
+    apt install -y ca-certificates procps wget
 
 RUN rm /usr/sbin/policy-rc.d; \
 	rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl

--- a/tests/packaging/images/Dockerfile.ubuntu1604
+++ b/tests/packaging/images/Dockerfile.ubuntu1604
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps systemd wget apt-transport-https
+    apt-get install -yq ca-certificates procps systemd wget
 
 COPY socat /bin/socat
 

--- a/tests/packaging/images/Dockerfile.ubuntu1804
+++ b/tests/packaging/images/Dockerfile.ubuntu1804
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps systemd wget apt-transport-https libcap2-bin
+    apt-get install -yq ca-certificates procps systemd wget
 
 COPY socat /bin/socat
 


### PR DESCRIPTION
`apt-transport-https` is required by debian-based systems to use https repos (e.g. our smart agent repo).  Most production systems should already have this installed, but in the case that they don't, this change ensures that this package is always installed before enabling the smart agent debian repo.