### PR TITLE
k8s-apiserver: make apiserver_request_duration_seconds_bucket non-default

### DIFF
--- a/docs/monitors/kubernetes-apiserver.md
+++ b/docs/monitors/kubernetes-apiserver.md
@@ -169,7 +169,7 @@ the non-default metrics below can be turned on by adding `apiserver_request` to 
 monitor config option `extraGroups`:
  - ***`apiserver_request_count`*** (*cumulative*)<br>    (Deprecated) Counter of apiserver requests broken out for each verb, group, version, resource, scope, component, client, and HTTP response contentType and code.
  - `apiserver_request_duration_seconds` (*cumulative*)<br>    Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component. (sum)
- - ***`apiserver_request_duration_seconds_bucket`*** (*cumulative*)<br>    Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component. (bucket)
+ - `apiserver_request_duration_seconds_bucket` (*cumulative*)<br>    Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component. (bucket)
  - `apiserver_request_duration_seconds_count` (*cumulative*)<br>    Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component. (count)
  - `apiserver_request_latencies` (*cumulative*)<br>    (Deprecated) Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component. (sum)
  - `apiserver_request_latencies_bucket` (*cumulative*)<br>    (Deprecated) Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component. (bucket)

--- a/pkg/monitors/kubernetes/apiserver/genmetadata.go
+++ b/pkg/monitors/kubernetes/apiserver/genmetadata.go
@@ -578,11 +578,10 @@ var metricSet = map[string]monitors.MetricInfo{
 }
 
 var defaultMetrics = map[string]bool{
-	admissionQuotaControllerAdds:          true,
-	apiserverRequestCount:                 true,
-	apiserverRequestDurationSecondsBucket: true,
-	workqueueAddsTotal:                    true,
-	workqueueDepth:                        true,
+	admissionQuotaControllerAdds: true,
+	apiserverRequestCount:        true,
+	workqueueAddsTotal:           true,
+	workqueueDepth:               true,
 }
 
 var groupMetricsMap = map[string][]string{

--- a/pkg/monitors/kubernetes/apiserver/metadata.yaml
+++ b/pkg/monitors/kubernetes/apiserver/metadata.yaml
@@ -524,7 +524,7 @@ monitors:
       type: cumulative
       group: apiserver_request
     apiserver_request_duration_seconds_bucket:
-      default: true
+      default: false
       description: Response latency distribution in seconds for each verb, dry run
         value, group, version, resource, subresource, scope and component. (bucket)
       type: cumulative

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -34018,7 +34018,7 @@
           "type": "cumulative",
           "description": "Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component. (bucket)",
           "group": "apiserver_request",
-          "default": true
+          "default": false
         },
         "apiserver_request_duration_seconds_count": {
           "type": "cumulative",


### PR DESCRIPTION
The metric `apiserver_request_duration_seconds_bucket` is a high cardinality metric, as well as reports by default 40 different buckets, making it generate at least 40 MTSs per resource.

We do not use this metric in the SignalFx default content, so we should not enable it by default for users.