### PR TITLE
Helm - Reading agent conf from a file

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -10,8 +10,14 @@ metadata:
     chart: {{ template "signalfx-agent.chart" . }}
 data:
   agent.yaml: |
-{{- if .Values.agentConfig }}
-{{ toYaml .Values.agentConfig | indent 4 }}
+{{ if .Values.agentConfig }}
+  {{- $agentConf := .Values.agentConfig }}
+  {{- $confType := printf "%T" $agentConf }}
+  {{- if eq $confType "string" }}
+    {{- $agentConf | indent 4 }}
+  {{ else }}
+    {{- toYaml $agentConf | indent 4 }}
+  {{ end }}
 {{- else }}
     signalFxAccessToken: ${SFX_ACCESS_TOKEN}
 


### PR DESCRIPTION
with this change, a user can deploy their custom agent conf file like this:

```
helm install --set-file agentConfig=./agent.yaml .
```
or using a mix of `values` and `agent conf`
```
helm install --set-file agentConfig=./agent.yaml --values=values.yaml .
```

cc: @jaysfx @mstumpfx 
Signed-off-by: Dani Louca <dlouca@splunk.com>