### PR TITLE
1293 agent python requirement

### DIFF
--- a/docs/advanced-install-options.md
+++ b/docs/advanced-install-options.md
@@ -77,11 +77,10 @@ By default, the Smart Agent logs only to stdout/err. If you want to persist logs
 
 If you don’t want to use the installer script, we offer a .zip that can be deployed to the target host. This bundle is available for download on the [Github Releases Page](https://github.com/signalfx/signalfx-agent/releases) for each new release.
 
-Before proceeding make sure the following requirements are installed.
+Before proceeding, you must install [.Net Framework 3.5 (Windows 8+)](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10).
 
-[.Net Framework 3.5 (Windows 8+)](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10)
-
-[Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
+As an optional step, if you want to run non-default monitors, specifically **exec**, then you must run [Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
+   
 
 To use the bundle:
 

--- a/docs/advanced-install-options.md
+++ b/docs/advanced-install-options.md
@@ -79,7 +79,7 @@ If you don’t want to use the installer script, we offer a .zip that can be dep
 
 Before proceeding, you must install [.Net Framework 3.5 (Windows 8+)](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10).
 
-As an optional step, if you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python 3.8.
+As an optional step, if you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python installed.
    
 To use the bundle:
 

--- a/docs/advanced-install-options.md
+++ b/docs/advanced-install-options.md
@@ -79,9 +79,8 @@ If you don’t want to use the installer script, we offer a .zip that can be dep
 
 Before proceeding, you must install [.Net Framework 3.5 (Windows 8+)](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10).
 
-As an optional step, if you want to run non-default monitors, specifically **exec**, then you must run [Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
+As an optional step, if you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python 3.8.
    
-
 To use the bundle:
 
 1. Unzip it to a directory of your choice on the target system.

--- a/docs/advanced-install-options.md
+++ b/docs/advanced-install-options.md
@@ -77,7 +77,7 @@ By default, the Smart Agent logs only to stdout/err. If you want to persist logs
 
 If you don’t want to use the installer script, we offer a .zip that can be deployed to the target host. This bundle is available for download on the [Github Releases Page](https://github.com/signalfx/signalfx-agent/releases) for each new release.
 
-Before proceeding, you must install [.Net Framework 3.5 (Windows 8+)](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10).
+Before proceeding, you should ensure that [.Net Framework 3.5](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10) or later is installed. 
 
 As an optional step, if you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python installed.
    

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -31,7 +31,7 @@ Please note that the Smart Agent does not support Mac OS.
 
 **Windows requirements**
 - You must run .Net Framework 3.5 on Windows 8 or higher.
-- (Optional) If you want to run non-default monitors, specifically **exec**, then you must run Visual C++ Compiler for Python 2.7.
+- (Optional) If you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python 3.8.
 
 
 ### Step 1. Install the SignalFx Smart Agent on your host

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -31,7 +31,7 @@ Please note that the Smart Agent does not support Mac OS.
 
 **Windows requirements**
 - You must run .Net Framework 3.5 on Windows 8 or higher.
-- (Optional) If you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python 3.8.
+- (Optional) If you want to invoke a Python script for non-default monitors, specifically **exec**, then you must have Python installed.
 
 
 ### Step 1. Install the SignalFx Smart Agent on your host

--- a/docs/quick-install.md
+++ b/docs/quick-install.md
@@ -31,7 +31,7 @@ Please note that the Smart Agent does not support Mac OS.
 
 **Windows requirements**
 - You must run .Net Framework 3.5 on Windows 8 or higher.
-- You must run Visual C++ Compiler for Python 2.7.
+- (Optional) If you want to run non-default monitors, specifically **exec**, then you must run Visual C++ Compiler for Python 2.7.
 
 
 ### Step 1. Install the SignalFx Smart Agent on your host


### PR DESCRIPTION
You must run Visual C++ Compiler for Python 2.7.  ==> (Optional) If you want to invoke a Python script for non-default monitors, specifically exec, then you must have Python 3.8.
