### PR TITLE
fixing dynamic config

### DIFF
--- a/pkg/core/config/sources/walker.go
+++ b/pkg/core/config/sources/walker.go
@@ -94,7 +94,22 @@ func (w *walker) injectDynamicValues(v interface{}) (interface{}, error) {
 
 func (w *walker) injectDynamicValuesInMap(m map[interface{}]interface{}) (map[interface{}]interface{}, error) {
 	out := make(map[interface{}]interface{})
-	for k, v := range m {
+	keys := make([]interface{}, 0, len(m))
+	index := 0
+	swap := 0
+	for k := range m {
+		if strings.HasPrefix(k.(string), "_") {
+			swap = index
+		}
+		keys = append(keys, k)
+		index++
+	}
+	if swap > 0 && index > 1 {
+		keys[len(keys)-1], keys[swap] = keys[swap], keys[len(keys)-1]
+	}
+
+	for _, k := range keys {
+		v := m[k]
 		if isDynamicValue(v) {
 			values, spec, err := w.doResolution(RawDynamicValueSpec(v))
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

The logic works well when the map iteration is in order, however in go this is not the case and order is not guaranteed. 

This causes the `_:` dynamic config to randomly fail replacing existing config.

The fix uses a slice of keys to force the order and move `_:` to the end of the slice
I didn't use sort as we just need to do a single swap .

### Repro Steps:

Use the following unit test, config and env variable:

**Test:**

```
func TestDynamicConfig(t *testing.T) {
        ctx, cancel := context.WithCancel(context.Background())
        defer cancel()
        data, _ := ioutil.ReadFile("<path_to>/env.txt")
        os.Setenv("CONFIG_OVERRIDE", string(data))
        for {
                value, exists := os.LookupEnv("CONFIG_OVERRIDE")
                if exists {
                        fmt.Println(value)
                } else {
                        fmt.Println("missing env")
                }

                loads, err := LoadConfig(ctx, "<path_to>/agent.yaml")
                if err != nil {
                        fmt.Println(err.Error())
                }
                config := <-loads
                if config.Monitors[0].Type != "collectd/jenkins" {
                        fmt.Printf("Error %v", config.Monitors)
                        os.Exit(1)
                } else {
                        fmt.Println("all good")
                }
        }
}

```

**agent.yaml**:

```
monitors:

_: {"#from": "env:CONFIG_OVERRIDE", optional: true, flatten: true}

```

**env.txt:**

```
monitors:
  - type: collectd/jenkins
    host: jenkins.eng-dev.mb-internal.com
    port: 443
    metricsKey: elb
    useHTTPS: true
    enhancedMetrics: true
    intervalSeconds: 120
```

cc: @jaysfx @keitwb @mstumpfx 