### PR TITLE
K8s v1.18 integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,10 +255,10 @@ commands:
     parameters:
       version:
         type: string
-        default: v1.4.0
+        default: v1.9.2
       k8s_version:
         type: string
-        default: v1.12.0
+        default: v1.14.0
       options:
         type: string
         default: ""
@@ -551,6 +551,12 @@ workflows:
           requires:
             - build
       - k8s_integration_tests:
+          name: k8s_v1.18.0_integration_tests
+          k8s_version: v1.18.0
+          requires:
+            - build
+            - helm_check
+      - k8s_integration_tests:
           name: k8s_v1.17.0_integration_tests
           k8s_version: v1.17.0
           requires:
@@ -575,14 +581,8 @@ workflows:
             - build
             - helm_check
       - k8s_integration_tests:
-          name: k8s_v1.13.0_integration_tests
-          k8s_version: v1.13.0
-          requires:
-            - build
-            - helm_check
-      - k8s_integration_tests:
           name: k8s_crio_integration_tests
-          k8s_version: v1.17.0
+          k8s_version: v1.18.0
           with_crio: true
           requires:
             - build

--- a/.circleci/scripts/setup-k8s-tests.sh
+++ b/.circleci/scripts/setup-k8s-tests.sh
@@ -4,8 +4,8 @@ set -eo pipefail
 
 [ -n "$K8S_VERSION" ] || (echo "K8S_VERSION not defined!" && exit 1)
 
-K8S_MIN_VERSION="${K8S_MIN_VERSION:-v1.13.0}"
-K8S_MAX_VERSION="${K8S_MAX_VERSION:-v1.17.0}"
+K8S_MIN_VERSION="${K8S_MIN_VERSION:-v1.14.0}"
+K8S_MAX_VERSION="${K8S_MAX_VERSION:-v1.18.0}"
 K8S_SFX_AGENT="${K8S_SFX_AGENT:-quay.io/signalfx/signalfx-agent-dev:latest}"
 WITH_CRIO=${WITH_CRIO:-0}
 

--- a/.circleci/scripts/start-minikube.sh
+++ b/.circleci/scripts/start-minikube.sh
@@ -11,6 +11,17 @@ export OPTIONS=${OPTIONS:-}
 
 [ -f ~/.skip ] && exit 0
 
+sudo apt-get update
+sudo apt-get -y install conntrack
+
+# enable kubelet port 10255 for cadvisor and stats
+OPTIONS="$OPTIONS --extra-config=kubelet.read-only-port=10255"
+
+if [[ "$K8S_VERSION" =~ ^v1\.18\. ]]; then
+    # enable kubelet cadvisor for K8S_VERSION v1.18
+    OPTIONS="$OPTIONS --extra-config=kubelet.enable-cadvisor-json-endpoints=true"
+fi
+
 if [ -f test-services/minikube/config.json ]; then
     mkdir -p $HOME/.minikube/config
     cp test-services/minikube/config.json $HOME/.minikube/config/config.json

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ run-k8s-tests: run-minikube push-minikube-agent
 		tests
 
 K8S_VERSION ?= latest
-MINIKUBE_VERSION ?= v1.4.0
+MINIKUBE_VERSION ?= v1.9.2
 
 .PHONY: run-minikube
 run-minikube:

--- a/test-services/minikube/start-minikube.sh
+++ b/test-services/minikube/start-minikube.sh
@@ -33,7 +33,13 @@ MINIKUBE_OPTIONS="--vm-driver=none \
     --bootstrapper=${BOOTSTRAPPER} \
     --kubernetes-version=${K8S_VERSION} \
     --wait=true \
+    --extra-config=kubelet.read-only-port=10255 \
     --extra-config=kubeadm.ignore-preflight-errors=SystemVerification,FileContent--proc-sys-net-bridge-bridge-nf-call-iptables,FileExisting-crictl"
+
+if [[ "$K8S_VERSION" =~ ^v1\.18\. ]]; then
+    # enable kubelet cadvisor for K8S_VERSION v1.18
+    MINIKUBE_OPTIONS="$MINIKUBE_OPTIONS --extra-config=kubelet.enable-cadvisor-json-endpoints=true"
+fi
 
 function download_kubectl() {
     [ -f /usr/local/bin/kubectl ] && rm -f /usr/local/bin/kubectl

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -36,9 +36,10 @@ def test_kubernetes_cluster_in_k8s(k8s_cluster):
 def test_resource_quota_metrics(k8s_cluster):
     yamls = [SCRIPT_DIR / "resource_quota.yaml"]
     with k8s_cluster.create_resources(yamls):
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
         """
@@ -88,9 +89,10 @@ def test_resource_quota_metrics(k8s_cluster):
 def test_kubernetes_cluster_namespace_scope(k8s_cluster):
     yamls = [SCRIPT_DIR / "good-pod.yaml", SCRIPT_DIR / "bad-pod.yaml"]
     with k8s_cluster.create_resources(yamls):
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
               namespace: good
@@ -108,9 +110,10 @@ def test_kubernetes_cluster_namespace_scope(k8s_cluster):
 def test_stateful_sets(k8s_cluster):
     yamls = [SCRIPT_DIR / "statefulset.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
               extraMetrics:
@@ -152,9 +155,10 @@ def test_stateful_sets(k8s_cluster):
 def test_jobs(k8s_cluster):
     yamls = [SCRIPT_DIR / "job.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
               extraMetrics:
@@ -191,9 +195,10 @@ def test_jobs(k8s_cluster):
 def test_jobs_no_completions(k8s_cluster):
     yamls = [SCRIPT_DIR / "job-no-completions.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
               extraMetrics:
@@ -238,9 +243,10 @@ def test_jobs_no_completions(k8s_cluster):
 def test_cronjobs(k8s_cluster):
     yamls = [SCRIPT_DIR / "cronjob.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
-        config = """
+        config = f"""
             monitors:
             - type: kubernetes-cluster
+              namespace: {k8s_cluster.test_namespace}
               kubernetesAPI:
                 authType: serviceAccount
               extraMetrics:
@@ -280,9 +286,10 @@ def test_cronjobs(k8s_cluster):
 
 @pytest.mark.kubernetes
 def test_deployments(k8s_cluster):
-    config = """
+    config = f"""
     monitors:
      - type: kubernetes-cluster
+       namespace: {k8s_cluster.test_namespace}
     """
     yamls = [TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
@@ -307,9 +314,10 @@ def test_deployments(k8s_cluster):
 
 @pytest.mark.kubernetes
 def test_deployment_workload_property(k8s_cluster):
-    config = """
+    config = f"""
     monitors:
      - type: kubernetes-cluster
+       namespace: {k8s_cluster.test_namespace}
     """
     yamls = [TEST_SERVICES_DIR / "nginx/nginx-k8s.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
@@ -336,9 +344,10 @@ def test_deployment_workload_property(k8s_cluster):
 
 @pytest.mark.kubernetes
 def test_replicaset_workload_property(k8s_cluster):
-    config = """
+    config = f"""
     monitors:
      - type: kubernetes-cluster
+       namespace: {k8s_cluster.test_namespace}
     """
     yamls = [SCRIPT_DIR / "replicaSet.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
@@ -392,6 +401,7 @@ def test_containers(k8s_cluster):
     config = f"""
     monitors:
      - type: kubernetes-cluster
+       namespace: {k8s_cluster.test_namespace}
        extraMetrics:
         - {CONTAINER_RESOURCE_METRICS["request"]["cpu"]}
         - {CONTAINER_RESOURCE_METRICS["request"]["memory"]}
@@ -479,9 +489,10 @@ def test_containers(k8s_cluster):
 
 @pytest.mark.kubernetes
 def test_replication_controllers(k8s_cluster):
-    config = """
+    config = f"""
     monitors:
      - type: kubernetes-cluster
+       namespace: {k8s_cluster.test_namespace}
     """
     yamls = [SCRIPT_DIR / "nginx-replication-controller.yaml"]
     with k8s_cluster.create_resources(yamls) as resources:
@@ -506,9 +517,9 @@ def test_replication_controllers(k8s_cluster):
 @pytest.mark.kubernetes
 def test_node_metrics_and_props(k8s_cluster):
     config = """
-            monitors:
-            - type: kubernetes-cluster
-        """
+    monitors:
+     - type: kubernetes-cluster
+    """
     with k8s_cluster.run_agent(agent_yaml=config) as agent:
         for node in k8s_cluster.client.CoreV1Api().list_node().items:
             assert wait_for(


### PR DESCRIPTION
- Upgrade default minikube to v1.9.2
- Update default minikube options
- Remove k8s v1.13 test job from circleci