### PR TITLE
Add error logs and make http client timeout configurable

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -47,6 +47,7 @@ if not set.
 | `useFullyQualifiedHost` | no | bool | If true (the default), and the `hostname` option is not set, the hostname will be determined by doing a reverse DNS query on the IP address that is returned by querying for the bare hostname.  This is useful in cases where the hostname reported by the kernel is a short name. (**default**: `true`) |
 | `disableHostDimensions` | no | bool | Our standard agent model is to collect metrics for services running on the same host as the agent.  Therefore, host-specific dimensions (e.g. `host`, `AWSUniqueId`, etc) are automatically added to every datapoint that is emitted from the agent by default.  Set this to true if you are using the agent primarily to monitor things on other hosts.  You can set this option at the monitor level as well. (**default:** `false`) |
 | `intervalSeconds` | no | integer | How often to send metrics to SignalFx.  Monitors can override this individually. (**default:** `10`) |
+| `cloudMetadataTimeout` | no | int64 | This flag sets the HTTP timeout duration for metadata queries from AWS, Azure and GCP. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `"2s"`) |
 | `globalDimensions` | no | map of strings | Dimensions (key:value pairs) that will be added to every datapoint emitted by the agent. To specify that all metrics should be high-resolution, add the dimension `sf_hires: 1` |
 | `globalSpanTags` | no | map of strings | Tags (key:value pairs) that will be added to every span emitted by the agent. |
 | `cluster` | no | string | The logical environment/cluster that this agent instance is running in. All of the services that this instance monitors should be in the same environment as well. This value, if provided, will be synced as a property onto the `host` dimension, or onto any cloud-provided specific dimensions (`AWSUniqueId`, `gcp_id`, and `azure_resource_id`) when available. Example values: "prod-usa", "dev" |
@@ -373,6 +374,7 @@ where applicable:
   useFullyQualifiedHost: 
   disableHostDimensions: false
   intervalSeconds: 10
+  cloudMetadataTimeout: "2s"
   globalDimensions: 
   globalSpanTags: 
   cluster: 

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+
 	set "gopkg.in/fatih/set.v0"
 
 	"github.com/mitchellh/hashstructure"
@@ -73,6 +75,9 @@ type Config struct {
 	// How often to send metrics to SignalFx.  Monitors can override this
 	// individually.
 	IntervalSeconds int `yaml:"intervalSeconds" default:"10"`
+	// This flag sets the HTTP timeout duration for metadata queries from AWS, Azure and GCP.
+	// This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration
+	CloudMetadataTimeout timeutil.Duration `yaml:"cloudMetadataTimeout" default:"2s"`
 	// Dimensions (key:value pairs) that will be added to every datapoint emitted by the agent.
 	// To specify that all metrics should be high-resolution, add the dimension `sf_hires: 1`
 	GlobalDimensions map[string]string `yaml:"globalDimensions" default:"{}"`

--- a/pkg/core/hostid/aws.go
+++ b/pkg/core/hostid/aws.go
@@ -5,24 +5,32 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+	log "github.com/sirupsen/logrus"
 )
 
 // AWSUniqueID constructs the unique EC2 instance of the underlying host.  If
 // not running on EC2, returns the empty string.
-func AWSUniqueID() string {
+func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	c := http.Client{
-		Timeout: 1 * time.Second,
+		Timeout: cloudMetadataTimeout.AsDuration(),
 	}
 
 	resp, err := c.Get("http://169.254.169.254/2014-11-05/dynamic/instance-identity/document")
 	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Debug("Failed to get AWS instance-identity")
 		return ""
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Debug("Failed to read AWS instance-identity response")
 		return ""
 	}
 
@@ -34,10 +42,14 @@ func AWSUniqueID() string {
 
 	err = json.Unmarshal(body, &doc)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"error": err,
+		}).Debug("Failed to unmarshal AWS instance-identity response")
 		return ""
 	}
 
 	if doc.AccountID == "" || doc.InstanceID == "" || doc.Region == "" {
+		log.Debugf("One (or more) required field is empty. AccountID: %s ; InstanceID: %s ; Region: %s", doc.AccountID, doc.InstanceID, doc.Region)
 		return ""
 	}
 

--- a/pkg/core/hostid/azure.go
+++ b/pkg/core/hostid/azure.go
@@ -6,16 +6,17 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
-	"time"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // AzureUniqueID constructs the unique ID of the underlying Azure VM.  If
 // not running on Azure VM, returns the empty string.
 // Details about Azure Instance Metadata ednpoint:
 // https://docs.microsoft.com/en-us/azure/virtual-machines/windows/instance-metadata-service
-func AzureUniqueID() string {
+func AzureUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	c := http.Client{
-		Timeout: 1 * time.Second,
+		Timeout: cloudMetadataTimeout.AsDuration(),
 	}
 	req, err := http.NewRequest("GET", "http://169.254.169.254/metadata/instance?api-version=2018-10-01", nil)
 	if err != nil {

--- a/pkg/core/hostid/dims.go
+++ b/pkg/core/hostid/dims.go
@@ -28,12 +28,18 @@ func Dimensions(conf *config.Config) map[string]string {
 	// The envvar exists primarily for testing but could be useful otherwise.
 	// It remains undocumented for the time being though.
 	if os.Getenv("SKIP_PLATFORM_HOST_DIMS") != "yes" {
-		g.GatherDim("AWSUniqueId", AWSUniqueID)
-		g.GatherDim("gcp_id", GoogleComputeID)
+		g.GatherDim("AWSUniqueId", func() string {
+			return AWSUniqueID(conf.CloudMetadataTimeout)
+		})
+		g.GatherDim("gcp_id", func() string {
+			return GoogleComputeID(conf.CloudMetadataTimeout)
+		})
 		g.GatherDim("kubernetes_node_uid", func() string {
 			return KubernetesNodeUID(conf.Monitors)
 		})
-		g.GatherDim("azure_resource_id", AzureUniqueID)
+		g.GatherDim("azure_resource_id", func() string {
+			return AzureUniqueID(conf.CloudMetadataTimeout)
+		})
 	}
 
 	dims := g.WaitForDimensions()

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -52120,6 +52120,14 @@
         "elementKind": ""
       },
       {
+        "yamlName": "cloudMetadataTimeout",
+        "doc": "This flag sets the HTTP timeout duration for metadata queries from AWS, Azure and GCP. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration",
+        "default": "2s",
+        "required": false,
+        "type": "int64",
+        "elementKind": ""
+      },
+      {
         "yamlName": "globalDimensions",
         "doc": "Dimensions (key:value pairs) that will be added to every datapoint emitted by the agent. To specify that all metrics should be high-resolution, add the dimension `sf_hires: 1`",
         "default": "",


### PR DESCRIPTION
- Introduce a new flag to control the HTTP Client timeout for Azure, AWS and GCP. "cloudMetadataTimeout" defaults to 2 seconds.
- Log errors while runnig AWSUniqueID. Log is only enabled in debug mode.

cc: @jaysfx @mstumpfx 
Signed-off-by: Dani Louca <dlouca@splunk.com>