### PR TITLE
Rework vSphere inventory traversal

### DIFF
--- a/pkg/monitors/vsphere/model/model.go
+++ b/pkg/monitors/vsphere/model/model.go
@@ -15,6 +15,7 @@ const (
 	ComputeType        = "ComputeResource"
 	VMType             = "VirtualMachine"
 	HostType           = "HostSystem"
+	FolderType         = "Folder"
 )
 
 // Config for the vSphere monitor

--- a/pkg/monitors/vsphere/runner.go
+++ b/pkg/monitors/vsphere/runner.go
@@ -13,7 +13,7 @@ type runner struct {
 	monitor               *Monitor
 	conf                  *model.Config
 	vsm                   *vSphereMonitor
-	vsphereReloadInterval int //seconds
+	vsphereReloadInterval int // seconds
 }
 
 func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monitor *Monitor) runner {

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -14,7 +14,7 @@ import (
 // A thin wrapper around the vmomi SDK so that callers don't have to use it directly.
 type IGateway interface {
 	retrievePerformanceManager() (*mo.PerformanceManager, error)
-	retrieveTopLevelFolder() (*mo.Folder, error)
+	topLevelFolderRef() types.ManagedObjectReference
 	retrieveRefProperties(mor types.ManagedObjectReference, dst interface{}) error
 	queryAvailablePerfMetric(ref types.ManagedObjectReference) (*types.QueryAvailablePerfMetricResponse, error)
 	queryPerfProviderSummary(mor types.ManagedObjectReference) (*types.QueryPerfProviderSummaryResponse, error)
@@ -49,16 +49,8 @@ func (g *Gateway) retrievePerformanceManager() (*mo.PerformanceManager, error) {
 	return &pm, err
 }
 
-func (g *Gateway) retrieveTopLevelFolder() (*mo.Folder, error) {
-	var folder mo.Folder
-	err := mo.RetrieveProperties(
-		g.ctx,
-		g.client,
-		g.client.ServiceContent.PropertyCollector,
-		g.client.ServiceContent.RootFolder,
-		&folder,
-	)
-	return &folder, err
+func (g *Gateway) topLevelFolderRef() types.ManagedObjectReference {
+	return g.client.ServiceContent.RootFolder
 }
 
 func (g *Gateway) retrieveRefProperties(ref types.ManagedObjectReference, dst interface{}) error {
@@ -89,7 +81,14 @@ func (g *Gateway) queryPerfProviderSummary(ref types.ManagedObjectReference) (*t
 }
 
 func (g *Gateway) queryPerf(invObjs []*model.InventoryObject, maxSample int32) (*types.QueryPerfResponse, error) {
-	specs := make([]types.PerfQuerySpec, 0, len(invObjs))
+	numObjs := len(invObjs)
+	if numObjs == 0 {
+		// empty inventory, return empty response
+		// passing an empty spec to the api causes an error
+		return &types.QueryPerfResponse{}, nil
+	}
+
+	specs := make([]types.PerfQuerySpec, 0, numObjs)
 	for _, invObj := range invObjs {
 		specs = append(specs, types.PerfQuerySpec{
 			Entity:     invObj.Ref,

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
+	log "github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -26,13 +27,15 @@ type IGateway interface {
 type Gateway struct {
 	ctx    context.Context
 	client *govmomi.Client
+	log    *log.Entry
 	vcName string
 }
 
-func NewGateway(ctx context.Context, client *govmomi.Client) *Gateway {
+func NewGateway(ctx context.Context, client *govmomi.Client, log *log.Entry) *Gateway {
 	return &Gateway{
 		ctx:    ctx,
 		client: client,
+		log:    log,
 		vcName: client.Client.URL().Host,
 	}
 }
@@ -85,6 +88,7 @@ func (g *Gateway) queryPerf(invObjs []*model.InventoryObject, maxSample int32) (
 	if numObjs == 0 {
 		// empty inventory, return empty response
 		// passing an empty spec to the api causes an error
+		g.log.Warn("empty inventory, skipping QueryPerf")
 		return &types.QueryPerfResponse{}, nil
 	}
 

--- a/pkg/monitors/vsphere/service/inventory.go
+++ b/pkg/monitors/vsphere/service/inventory.go
@@ -133,7 +133,7 @@ func (svc *InventorySvc) followHost(
 	hostInvObj := model.NewInventoryObject(host.Self, hostDims)
 	inv.AddObject(hostInvObj)
 	for _, vmRef := range host.Vm {
-		err = svc.followVm(inv, vmRef, dims)
+		err = svc.followVM(inv, vmRef, dims)
 		if err != nil {
 			return err
 		}
@@ -141,7 +141,7 @@ func (svc *InventorySvc) followHost(
 	return nil
 }
 
-func (svc *InventorySvc) followVm(
+func (svc *InventorySvc) followVM(
 	inv *model.Inventory,
 	vmRef types.ManagedObjectReference,
 	dims pairs,

--- a/pkg/monitors/vsphere/service/service_test.go
+++ b/pkg/monitors/vsphere/service/service_test.go
@@ -34,6 +34,12 @@ func newFakeGateway() *fakeGateway {
 	return &fakeGateway{}
 }
 
+func (g *fakeGateway) topLevelFolderRef() types.ManagedObjectReference {
+	return types.ManagedObjectReference{
+		Value: "top",
+	}
+}
+
 func (g *fakeGateway) retrievePerformanceManager() (*mo.PerformanceManager, error) {
 	return &mo.PerformanceManager{
 		PerfCounter: []types.PerfCounterInfo{{
@@ -45,21 +51,20 @@ func (g *fakeGateway) retrievePerformanceManager() (*mo.PerformanceManager, erro
 	}, nil
 }
 
-func (g *fakeGateway) retrieveTopLevelFolder() (*mo.Folder, error) {
-	return &mo.Folder{
-		ChildEntity: []types.ManagedObjectReference{
-			{Type: model.DatacenterType, Value: "dc-1"},
-		},
-	}, nil
-}
-
 func (g *fakeGateway) retrieveRefProperties(mor types.ManagedObjectReference, dst interface{}) error {
 	switch t := dst.(type) {
 	case *mo.Folder:
-		t.Self = mor
-		cluster := g.createRef(model.ClusterComputeType, "cluster", &g.typeCounts.cluster)
-		freeStandingHost := g.createRef(model.ComputeType, "compute", &g.typeCounts.compute)
-		t.ChildEntity = []types.ManagedObjectReference{cluster, freeStandingHost}
+		if mor.Value == "top" {
+			t.Self = mor
+			t.ChildEntity = []types.ManagedObjectReference{
+				{Type: model.DatacenterType, Value: "dc-1"},
+			}
+		} else {
+			t.Self = mor
+			cluster := g.createRef(model.ClusterComputeType, "cluster", &g.typeCounts.cluster)
+			freeStandingHost := g.createRef(model.ComputeType, "compute", &g.typeCounts.compute)
+			t.ChildEntity = []types.ManagedObjectReference{cluster, freeStandingHost}
+		}
 	case *mo.ClusterComputeResource:
 		t.Self = mor
 		t.Name = "foo cluster"

--- a/pkg/monitors/vsphere/vsphere_monitor.go
+++ b/pkg/monitors/vsphere/vsphere_monitor.go
@@ -57,7 +57,7 @@ func (vsm *vSphereMonitor) firstTimeSetup(ctx context.Context, conf *model.Confi
 
 // Creates the service objects and assigns them to the vSphereMonitor struct.
 func (vsm *vSphereMonitor) wireUpServices(ctx context.Context, client *govmomi.Client) {
-	gateway := service.NewGateway(ctx, client)
+	gateway := service.NewGateway(ctx, client, vsm.log)
 	vsm.ptsSvc = service.NewPointsSvc(gateway, vsm.log)
 	vsm.invSvc = service.NewInventorySvc(gateway, vsm.log)
 	vsm.metricSvc = service.NewMetricsService(gateway, vsm.log)


### PR DESCRIPTION
The previous inventory traversal code was not tested against
inventory trees with arbitrary directory placement. This
change generalizes directory traversal with support for more
complex tree structures.

Fixes: INT-1872