### PR TITLE
Allow 'catch-all' maps in config to interoperate with endpoint config

### DIFF
--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -462,3 +462,9 @@ func BundlePythonHomeEnvvar() string {
 	}
 	return "PYTHONHOME=" + bundleDir
 }
+
+// AdditionalConfig is the type that should be used for any "catch-all" config
+// fields in a monitor/observer.  That field should be marked as
+// `yaml:",inline"`.  It will receive special handling when config is rendered
+// to merge all values from multiple decoding rounds.
+type AdditionalConfig map[string]interface{}

--- a/pkg/core/config/dynamic.go
+++ b/pkg/core/config/dynamic.go
@@ -39,7 +39,22 @@ func DecodeExtraConfig(in CustomConfigurable, out interface{}, strict bool) erro
 	if strict {
 		err = yaml.UnmarshalStrict(otherYaml, out)
 	} else {
+		// Preserve any special "catch-all" config that is typed with the
+		// special AdditionalConfig type.  This is needed because many config
+		// structs will be Unmarshaled to multiple times from various sources,
+		// and any inline struct fields will be overwritten on subsequent
+		// Unmarshals.
+		var additionalConf AdditionalConfig
+		additionalConfigField := utils.FindFirstFieldOfType(out, reflect.TypeOf((AdditionalConfig)(nil)))
+		if additionalConfigField.IsValid() {
+			additionalConf = additionalConfigField.Interface().(AdditionalConfig)
+		}
+
 		err = yaml.Unmarshal(otherYaml, out)
+
+		for k, v := range additionalConf {
+			additionalConfigField.Interface().(AdditionalConfig)[k] = v
+		}
 	}
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/pkg/monitors/subproc/signalfx/python/signalfx.go
+++ b/pkg/monitors/subproc/signalfx/python/signalfx.go
@@ -29,9 +29,6 @@ type PyConfig interface {
 	PythonConfig() *Config
 }
 
-// CustomConfig is embedded in Config struct to catch all extra config to pass to Python
-type CustomConfig map[string]interface{}
-
 // Config specifies configurations that are specific to the individual python based monitor
 type Config struct {
 	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
@@ -51,8 +48,8 @@ type Config struct {
 	// The PYTHONPATH that will be used when importing the script specified at
 	// `scriptFilePath`.  The directory of `scriptFilePath` will always be
 	// included in the path.
-	PythonPath   []string `yaml:"pythonPath" json:"pythonPath"`
-	CustomConfig `yaml:",inline" json:"-" neverLog:"true"`
+	PythonPath              []string `yaml:"pythonPath" json:"pythonPath"`
+	config.AdditionalConfig `yaml:",inline" json:"-" neverLog:"true"`
 }
 
 // MarshalJSON flattens out the CustomConfig provided by the user into a single
@@ -72,7 +69,7 @@ func (c Config) MarshalJSON() ([]byte, error) {
 	// Don't need this.
 	delete(m, "OtherConfig")
 
-	for k, v := range c.CustomConfig {
+	for k, v := range c.AdditionalConfig {
 		m[k], err = json.Marshal(v)
 		if err != nil {
 			return nil, err

--- a/pkg/utils/reflection.go
+++ b/pkg/utils/reflection.go
@@ -57,6 +57,16 @@ func FindFieldWithEmbeddedStructs(st interface{}, name string, typ reflect.Type)
 	return fieldValue
 }
 
+func FindFirstFieldOfType(st interface{}, typ reflect.Type) reflect.Value {
+	val := reflect.Indirect(reflect.ValueOf(st))
+	for i := 0; i < val.NumField(); i++ {
+		if val.Field(i).Type() == typ {
+			return val.Field(i)
+		}
+	}
+	return reflect.ValueOf(nil)
+}
+
 // IsStructOrPointerToStruct returns true if the given reflect.Type is a
 // struct or pointer to a struct
 func IsStructOrPointerToStruct(typ reflect.Type) bool {


### PR DESCRIPTION
When YAML unmarshalls extra keys into a struct with an inline field
it wipes out any existing values in that inline field.  This preserves
those values by readding them after each unmarshal operation.