### PR TITLE
Add pagination to perf queries

### DIFF
--- a/docs/monitors/vsphere.md
+++ b/docs/monitors/vsphere.md
@@ -64,6 +64,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `password` | no | `string` | The vSphere password |
 | `insecureSkipVerify` | no | `bool` | Whether we verify the server's certificate chain and host name (**default:** `false`) |
 | `inventoryRefreshInterval` | no | `int64` | How often to reload the inventory and inventory metrics (**default:** `60s`) |
+| `perfBatchSize` | no | `integer` | Maximum number of inventory objects to be queried for performance data per request. Set this value to zero (0) to request performance data for all inventory objects at a time. (**default:** `10`) |
 | `tlsCACertPath` | no | `string` | Path to the ca file |
 | `tlsClientCertificatePath` | no | `string` | Configure client certs. Both tlsClientKeyPath and tlsClientCertificatePath must be present. The files must contain PEM encoded data. Path to the client certificate |
 | `tlsClientKeyPath` | no | `string` | Path to the keyfile |

--- a/pkg/monitors/vsphere/model/model.go
+++ b/pkg/monitors/vsphere/model/model.go
@@ -31,6 +31,10 @@ type Config struct {
 	InsecureSkipVerify bool `yaml:"insecureSkipVerify"`
 	// How often to reload the inventory and inventory metrics
 	InventoryRefreshInterval timeutil.Duration `yaml:"inventoryRefreshInterval" default:"60s"`
+	// Maximum number of inventory objects to be queried for performance data
+	// per request. Set this value to zero (0) to request performance data for
+	// all inventory objects at a time.
+	PerfBatchSize int `yaml:"perfBatchSize" default:"10"`
 
 	// Path to the ca file
 	TLSCACertPath string `yaml:"tlsCACertPath"`

--- a/pkg/monitors/vsphere/runner.go
+++ b/pkg/monitors/vsphere/runner.go
@@ -18,7 +18,7 @@ type runner struct {
 
 func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monitor *Monitor) runner {
 	vsphereReloadInterval := int(conf.InventoryRefreshInterval.AsDuration().Seconds())
-	vsm := newVsphereMonitor(log)
+	vsm := newVsphereMonitor(conf, log)
 	return runner{
 		ctx:                   ctx,
 		log:                   log,
@@ -31,7 +31,7 @@ func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monit
 
 // Called periodically. This is the entry point to the vSphere monitor.
 func (r *runner) run() {
-	err := r.vsm.firstTimeSetup(r.ctx, r.conf)
+	err := r.vsm.firstTimeSetup(r.ctx)
 	if err != nil {
 		r.log.WithError(err).Error("firstTimeSetup failed")
 		return

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -14,14 +14,18 @@ import (
 
 // A thin wrapper around the vmomi SDK so that callers don't have to use it directly.
 type IGateway interface {
+	IPerfQuerier
 	retrievePerformanceManager() (*mo.PerformanceManager, error)
 	topLevelFolderRef() types.ManagedObjectReference
 	retrieveRefProperties(mor types.ManagedObjectReference, dst interface{}) error
 	queryAvailablePerfMetric(ref types.ManagedObjectReference) (*types.QueryAvailablePerfMetricResponse, error)
 	queryPerfProviderSummary(mor types.ManagedObjectReference) (*types.QueryPerfProviderSummaryResponse, error)
-	queryPerf(invObjs []*model.InventoryObject, maxSample int32) (*types.QueryPerfResponse, error)
 	retrieveCurrentTime() (*time.Time, error)
 	vcenterName() string
+}
+
+type IPerfQuerier interface {
+	queryPerf(invObjs []*model.InventoryObject, maxSample int32) (*types.QueryPerfResponse, error)
 }
 
 type Gateway struct {

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -14,7 +14,7 @@ import (
 
 // A thin wrapper around the vmomi SDK so that callers don't have to use it directly.
 type IGateway interface {
-	IPerfQuerier
+	PerfQuerier
 	retrievePerformanceManager() (*mo.PerformanceManager, error)
 	topLevelFolderRef() types.ManagedObjectReference
 	retrieveRefProperties(mor types.ManagedObjectReference, dst interface{}) error
@@ -24,7 +24,7 @@ type IGateway interface {
 	vcenterName() string
 }
 
-type IPerfQuerier interface {
+type PerfQuerier interface {
 	queryPerf(invObjs []*model.InventoryObject, maxSample int32) (*types.QueryPerfResponse, error)
 }
 

--- a/pkg/monitors/vsphere/service/paginator.go
+++ b/pkg/monitors/vsphere/service/paginator.go
@@ -27,11 +27,15 @@ func (p *queryPerfPaginator) paginate(
 ) (*types.QueryPerfResponse, error) {
 	numObjs := len(objs)
 	pages := p.numPages(numObjs)
+	pageSize := p.pageSize
+	if pageSize == 0 {
+		pageSize = numObjs
+	}
 	start := time.Now()
 	var metrics []types.BasePerfEntityMetricBase
 	for i := 0; i < pages; i++ {
-		startIdx := i * p.pageSize
-		endIdx := startIdx + p.pageSize
+		startIdx := i * pageSize
+		endIdx := startIdx + pageSize
 		if endIdx > numObjs {
 			endIdx = numObjs
 		}
@@ -51,7 +55,7 @@ func (p *queryPerfPaginator) paginate(
 func (p *queryPerfPaginator) numPages(n int) int {
 	// no pagination if page size is zero
 	if p.pageSize == 0 {
-		return n
+		return 1
 	}
 	return (n + p.pageSize - 1) / p.pageSize
 }

--- a/pkg/monitors/vsphere/service/paginator.go
+++ b/pkg/monitors/vsphere/service/paginator.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
+)
+
+// queryPerfPaginator allows callers to split up requests for performance data
+// for all inventory objects into batches. This is because for large enough
+// vSphere deployments, a query for performance data (queryPerf) will fail if
+// performance data is requested for all of the inventory objects in one call.
+type queryPerfPaginator struct {
+	gateway IGateway
+	// The max number of inventory objects requested at a time.
+	// A pagesize of 0 will result in no pagination (one call for all inv objects)
+	pageSize int
+	log      *log.Entry
+}
+
+func (p *queryPerfPaginator) paginate(
+	objs []*model.InventoryObject,
+	maxSample int32,
+) (*types.QueryPerfResponse, error) {
+	numObjs := len(objs)
+	pages := p.numPages(numObjs)
+	start := time.Now()
+	var metrics []types.BasePerfEntityMetricBase
+	for i := 0; i < pages; i++ {
+		startIdx := i * p.pageSize
+		endIdx := startIdx + p.pageSize
+		if endIdx > numObjs {
+			endIdx = numObjs
+		}
+		slice := objs[startIdx:endIdx]
+		perf, err := p.gateway.queryPerf(slice, maxSample)
+		if err != nil {
+			return nil, err
+		}
+		metrics = append(metrics, perf.Returnval...)
+	}
+	end := time.Now()
+	duration := end.Sub(start)
+	p.log.Debugf("Paginator: %d pages took %v", pages, duration)
+	return &types.QueryPerfResponse{Returnval: metrics}, nil
+}
+
+func (p *queryPerfPaginator) numPages(n int) int {
+	// no pagination if page size is zero
+	if p.pageSize == 0 {
+		return n
+	}
+	return (n + p.pageSize - 1) / p.pageSize
+}

--- a/pkg/monitors/vsphere/service/paginator.go
+++ b/pkg/monitors/vsphere/service/paginator.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"time"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/vim25/types"
 
@@ -14,28 +12,21 @@ import (
 // vSphere deployments, a query for performance data (queryPerf) will fail if
 // performance data is requested for all of the inventory objects in one call.
 type queryPerfPaginator struct {
-	gateway IGateway
-	// The max number of inventory objects requested at a time.
-	// A pagesize of 0 will result in no pagination (one call for all inv objects)
+	gateway  IGateway
 	pageSize int
 	log      *log.Entry
 }
 
-func (p *queryPerfPaginator) paginate(
+func (p *queryPerfPaginator) queryPerf(
 	objs []*model.InventoryObject,
 	maxSample int32,
 ) (*types.QueryPerfResponse, error) {
 	numObjs := len(objs)
 	pages := p.numPages(numObjs)
-	pageSize := p.pageSize
-	if pageSize == 0 {
-		pageSize = numObjs
-	}
-	start := time.Now()
 	var metrics []types.BasePerfEntityMetricBase
 	for i := 0; i < pages; i++ {
-		startIdx := i * pageSize
-		endIdx := startIdx + pageSize
+		startIdx := i * p.pageSize
+		endIdx := startIdx + p.pageSize
 		if endIdx > numObjs {
 			endIdx = numObjs
 		}
@@ -46,16 +37,10 @@ func (p *queryPerfPaginator) paginate(
 		}
 		metrics = append(metrics, perf.Returnval...)
 	}
-	end := time.Now()
-	duration := end.Sub(start)
-	p.log.Debugf("Paginator: %d pages took %v", pages, duration)
+	p.log.Debugf("Paginator: %d objects, %d pages", numObjs, pages)
 	return &types.QueryPerfResponse{Returnval: metrics}, nil
 }
 
-func (p *queryPerfPaginator) numPages(n int) int {
-	// no pagination if page size is zero
-	if p.pageSize == 0 {
-		return 1
-	}
-	return (n + p.pageSize - 1) / p.pageSize
+func (p *queryPerfPaginator) numPages(numObjs int) int {
+	return (numObjs + p.pageSize - 1) / p.pageSize
 }

--- a/pkg/monitors/vsphere/service/paginator_test.go
+++ b/pkg/monitors/vsphere/service/paginator_test.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
+)
+
+func TestTooManyInvObjects(t *testing.T) {
+	g := fakePaginatorGateway{}
+	_, err := g.queryPerf(invObjs(100), 1)
+	require.NotNil(t, err)
+}
+
+func TestNumPages(t *testing.T) {
+	p := queryPerfPaginator{
+		pageSize: 3,
+	}
+	require.Equal(t, 0, p.numPages(0))
+	require.Equal(t, 1, p.numPages(1))
+	require.Equal(t, 1, p.numPages(2))
+	require.Equal(t, 1, p.numPages(3))
+	require.Equal(t, 2, p.numPages(4))
+
+	// if page size is zero, there should be no pagination
+	p = queryPerfPaginator{pageSize: 0}
+	require.Equal(t, 42, p.numPages(42))
+}
+
+func TestPagination1(t *testing.T) {
+	p := queryPerfPaginator{pageSize: 2, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
+	n := 100
+	resp, _ := p.paginate(invObjs(n), 1)
+	require.Equal(t, n, len(resp.Returnval))
+}
+
+func TestPagination2(t *testing.T) {
+	p := queryPerfPaginator{pageSize: 4, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
+	numObjs := 5
+	resp, _ := p.paginate(invObjs(numObjs), 1)
+	require.Equal(t, numObjs, len(resp.Returnval))
+}
+
+func invObjs(n int) []*model.InventoryObject {
+	var objs []*model.InventoryObject
+	for i := 0; i < n; i++ {
+		objs = append(objs, &model.InventoryObject{})
+	}
+	return objs
+}
+
+var _ IGateway = (*fakePaginatorGateway)(nil)
+
+type fakePaginatorGateway struct{}
+
+func (g *fakePaginatorGateway) retrievePerformanceManager() (*mo.PerformanceManager, error) {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) topLevelFolderRef() types.ManagedObjectReference {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) retrieveRefProperties(
+	types.ManagedObjectReference,
+	interface{},
+) error {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) queryAvailablePerfMetric(
+	types.ManagedObjectReference,
+) (*types.QueryAvailablePerfMetricResponse, error) {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) queryPerfProviderSummary(types.ManagedObjectReference) (
+	*types.QueryPerfProviderSummaryResponse, error,
+) {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) queryPerf(
+	invObjs []*model.InventoryObject,
+	_ int32,
+) (*types.QueryPerfResponse, error) {
+	// simulate api failure if too many inv objects are passed in
+	if len(invObjs) > 10 {
+		return nil, errors.New("too many inv objects")
+	}
+	var metrics []types.BasePerfEntityMetricBase
+	// otherwise return one metric per inv object
+	for range invObjs {
+		metrics = append(metrics, &types.PerfEntityMetric{})
+	}
+	return &types.QueryPerfResponse{
+		Returnval: metrics,
+	}, nil
+}
+
+func (g *fakePaginatorGateway) retrieveCurrentTime() (*time.Time, error) {
+	panic("implement me")
+}
+
+func (g *fakePaginatorGateway) vcenterName() string {
+	panic("implement me")
+}

--- a/pkg/monitors/vsphere/service/paginator_test.go
+++ b/pkg/monitors/vsphere/service/paginator_test.go
@@ -30,7 +30,7 @@ func TestNumPages(t *testing.T) {
 
 	// if page size is zero, there should be no pagination
 	p = queryPerfPaginator{pageSize: 0}
-	require.Equal(t, 42, p.numPages(42))
+	require.Equal(t, 1, p.numPages(42))
 }
 
 func TestPagination1(t *testing.T) {
@@ -45,6 +45,14 @@ func TestPagination2(t *testing.T) {
 	numObjs := 5
 	resp, _ := p.paginate(invObjs(numObjs), 1)
 	require.Equal(t, numObjs, len(resp.Returnval))
+}
+
+func TestPageSizeZero(t *testing.T) {
+	p := queryPerfPaginator{pageSize: 0, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
+	numObjs := 42
+	_, err := p.paginate(invObjs(numObjs), 1)
+	// a single, big page should trigger a too many inv obj error
+	require.NotNil(t, err)
 }
 
 func invObjs(n int) []*model.InventoryObject {

--- a/pkg/monitors/vsphere/service/paginator_test.go
+++ b/pkg/monitors/vsphere/service/paginator_test.go
@@ -27,32 +27,20 @@ func TestNumPages(t *testing.T) {
 	require.Equal(t, 1, p.numPages(2))
 	require.Equal(t, 1, p.numPages(3))
 	require.Equal(t, 2, p.numPages(4))
-
-	// if page size is zero, there should be no pagination
-	p = queryPerfPaginator{pageSize: 0}
-	require.Equal(t, 1, p.numPages(42))
 }
 
 func TestPagination1(t *testing.T) {
 	p := queryPerfPaginator{pageSize: 2, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
 	n := 100
-	resp, _ := p.paginate(invObjs(n), 1)
+	resp, _ := p.queryPerf(invObjs(n), 1)
 	require.Equal(t, n, len(resp.Returnval))
 }
 
 func TestPagination2(t *testing.T) {
 	p := queryPerfPaginator{pageSize: 4, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
 	numObjs := 5
-	resp, _ := p.paginate(invObjs(numObjs), 1)
+	resp, _ := p.queryPerf(invObjs(numObjs), 1)
 	require.Equal(t, numObjs, len(resp.Returnval))
-}
-
-func TestPageSizeZero(t *testing.T) {
-	p := queryPerfPaginator{pageSize: 0, gateway: &fakePaginatorGateway{}, log: getTestingLog()}
-	numObjs := 42
-	_, err := p.paginate(invObjs(numObjs), 1)
-	// a single, big page should trigger a too many inv obj error
-	require.NotNil(t, err)
 }
 
 func invObjs(n int) []*model.InventoryObject {

--- a/pkg/monitors/vsphere/service/points.go
+++ b/pkg/monitors/vsphere/service/points.go
@@ -13,11 +13,11 @@ import (
 type PointsSvc struct {
 	log         *logrus.Entry
 	gateway     IGateway
-	perfQuerier IPerfQuerier
+	perfQuerier PerfQuerier
 }
 
 func NewPointsSvc(gateway IGateway, log *logrus.Entry, batchSize int) *PointsSvc {
-	var q IPerfQuerier
+	var q PerfQuerier
 	if batchSize == 0 {
 		// if batchSize == 0 we don't paginate at all
 		q = gateway

--- a/pkg/monitors/vsphere/service/points_test.go
+++ b/pkg/monitors/vsphere/service/points_test.go
@@ -15,7 +15,7 @@ func TestRetrievePoints(t *testing.T) {
 	metricsSvc := NewMetricsService(gateway, log)
 	infoSvc := NewVSphereInfoService(inventorySvc, metricsSvc)
 	vsphereInfo, _ := infoSvc.RetrieveVSphereInfo()
-	svc := NewPointsSvc(gateway, log)
+	svc := NewPointsSvc(gateway, log, 0)
 	pts, _ := svc.RetrievePoints(vsphereInfo, 1)
 	pt := pts[0]
 	require.Equal(t, "vsphere.cpu_core_utilization_percent", pt.Metric)

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -50333,6 +50333,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "perfBatchSize",
+            "doc": "Maximum number of inventory objects to be queried for performance data per request. Set this value to zero (0) to request performance data for all inventory objects at a time.",
+            "default": 10,
+            "required": false,
+            "type": "int",
+            "elementKind": ""
+          },
+          {
             "yamlName": "tlsCACertPath",
             "doc": "Path to the ca file",
             "default": "",


### PR DESCRIPTION
Larger vSphere deployments can fail when trying to
retrieve performance metrics for all inventory objects.
This change adds a `perfBatchSize` config, which
defaults to 10, and splits up requests for performance
data into batches of a number of inventory objects of
that size or smaller.