### PR TITLE
Delete environments for pods and containers when a span comes through with out an environment

### DIFF
--- a/pkg/core/writer/tracetracker/cache.go
+++ b/pkg/core/writer/tracetracker/cache.go
@@ -35,6 +35,17 @@ type TimeoutCache struct {
 	PurgedCount int64
 }
 
+// RunIfKeyDoesNotExist locks and runs the supplied function if the key does not exist.
+// Be careful not to perform cache operations inside of this function because they will deadlock
+func (t *TimeoutCache) RunIfKeyDoesNotExist(o *cacheKey, fn func()) {
+	t.Lock()
+	defer t.Unlock()
+	if _, ok := t.keysActive[*o]; ok {
+		return
+	}
+	fn()
+}
+
 // UpdateOrCreate
 func (t *TimeoutCache) UpdateOrCreate(o *cacheKey, now time.Time) (isNew bool) {
 	t.Lock()

--- a/pkg/core/writer/tracetracker/tracker.go
+++ b/pkg/core/writer/tracetracker/tracker.go
@@ -96,10 +96,10 @@ func (a *ActiveServiceTracker) CorrelationDatapoints() []*datapoint.Datapoint {
 	return out
 }
 
-// LoadCorrelations asynchronously retrieves all known correlations from the backend
+// LoadHostIDDimCorrelations asynchronously retrieves all known correlations from the backend
 // for all known hostIDDims.  This allows the agent to timeout and manage correlation
 // deletions on restart.
-func (a *ActiveServiceTracker) LoadCorrelations() {
+func (a *ActiveServiceTracker) LoadHostIDDimCorrelations() {
 	// asynchronously fetch all services and environments for each hostIDDim at startup
 	for dimName, dimValue := range a.hostIDDims {
 		dimName := dimName
@@ -157,7 +157,7 @@ func New(timeout time.Duration, correlationClient correlations.CorrelationClient
 		sendTraceHostCorrelationMetrics: sendTraceHostCorrelationMetrics,
 		timeNow:                         time.Now,
 	}
-	a.LoadCorrelations()
+	a.LoadHostIDDimCorrelations()
 
 	return a
 }


### PR DESCRIPTION
This addresses a very specific corner case in the tracetracker where a default environment was set by the agent for a given pod or container id, and the agent has been reconfigured and restarted without a default environment value.