### PR TITLE
Add support for dogstatsd tags to statsd receiver

### DIFF
--- a/pkg/monitors/statsd/parser_test.go
+++ b/pkg/monitors/statsd/parser_test.go
@@ -6,6 +6,98 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestParseMetrics(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		converters []*converter
+		parsed     statsDMetric
+	}{
+		{
+			"tags",
+			"runtime.node.heap.size.by.space:430080|g|#service:svc1,runtime-id:dcd3,space:code_space",
+			nil,
+			statsDMetric{
+				rawMetricName: "runtime.node.heap.size.by.space",
+				metricName:    "runtime.node.heap.size.by.space",
+				metricType:    "g",
+				value:         430080,
+				dimensions: map[string]string{
+					"service":    "svc1",
+					"runtime-id": "dcd3",
+					"space":      "code_space",
+				},
+			},
+		},
+		{
+			"no-tags",
+			"runtime.node.heap.size.by.space:43|g",
+			nil,
+			statsDMetric{
+				rawMetricName: "runtime.node.heap.size.by.space",
+				metricName:    "runtime.node.heap.size.by.space",
+				metricType:    "g",
+				value:         43,
+				dimensions:    nil,
+			},
+		},
+		{
+			"tags-with-converters",
+			"cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success:100|g|#svc:svc2",
+			[]*converter{
+				{
+					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}"),
+					metric:  parseFields("{traffic}.{action}"),
+				},
+			},
+			statsDMetric{
+				rawMetricName: "cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success",
+				metricName:    "egress.update_success",
+				metricType:    "g",
+				value:         100,
+				dimensions: map[string]string{
+					"svc":     "svc2",
+					"traffic": "egress",
+					"mesh":    "ecommerce-demo-mesh",
+					"service": "gateway",
+					"action":  "update_success",
+				},
+			},
+		},
+		{
+			"converters-without-tags",
+			"cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success:100|g",
+			[]*converter{
+				{
+					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}"),
+					metric:  parseFields("{traffic}.{action}"),
+				},
+			},
+			statsDMetric{
+				rawMetricName: "cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success",
+				metricName:    "egress.update_success",
+				metricType:    "g",
+				value:         100,
+				dimensions: map[string]string{
+					"traffic": "egress",
+					"mesh":    "ecommerce-demo-mesh",
+					"service": "gateway",
+					"action":  "update_success",
+				},
+			},
+		},
+	}
+
+	for i := range cases {
+		tt := cases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			sm := parseMetrics([]string{tt.raw}, tt.converters, "")
+			require.Equal(t, 1, len(sm))
+			require.Equal(t, tt.parsed, *sm[0])
+		})
+	}
+}
+
 func TestParseFields(t *testing.T) {
 	cases := []struct {
 		pattern        string

--- a/pkg/monitors/statsd/statsd.go
+++ b/pkg/monitors/statsd/statsd.go
@@ -116,6 +116,10 @@ func parseMetrics(raw []string, converters []*converter, prefix string) []*stats
 	var metrics []*statsDMetric
 
 	for _, m := range raw {
+		if m == "" {
+			continue
+		}
+		m, dims := parseDogstatsdTags(m)
 		colonIdx := strings.Index(m, ":")
 		pipeIdx := strings.Index(m, "|")
 		if pipeIdx >= len(m)-1 || pipeIdx < 0 || colonIdx-1 > len(m) || colonIdx < 0 {
@@ -134,8 +138,6 @@ func parseMetrics(raw []string, converters []*converter, prefix string) []*stats
 			metricType = m[pipeIdx+1:]
 		}
 
-		var dims map[string]string
-
 		if prefix != "" {
 			metricName = strings.TrimPrefix(rawMetricName, prefix+".")
 		} else {
@@ -143,7 +145,7 @@ func parseMetrics(raw []string, converters []*converter, prefix string) []*stats
 		}
 
 		if converters != nil {
-			metricName, dims = convertMetric(metricName, converters)
+			metricName, dims = convertMetric(metricName, converters, dims)
 		}
 
 		strValue := m[colonIdx+1 : pipeIdx]


### PR DESCRIPTION
This commit add support for dogstatsd metric tags to the statsd
receiver. The change is completely backward compatible and does not
affect statsd senders in any way. This makes it possible for the smart
agent to receive runtime metrics from a number of SingalFx
instrumentation libraries.