### PR TITLE
Helm configmap checksum

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -32,7 +32,10 @@ spec:
         {{ toYaml . | indent 8 | trim }}
         {{- end }}
       annotations:
+        {{ if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       # Use host network so we can access kubelet directly
       hostNetwork: true

--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -35,7 +35,10 @@ spec:
         {{ toYaml . | indent 8 | trim }}
         {{- end }}
       annotations:
+        {{ if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+        {{- end }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       restartPolicy: Always


### PR DESCRIPTION
To force kubernetes pods replacement when there is only changes in the configmap, we added an checksum of this configmap into pod annotations.

Inspired by helm tips and tricks: https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments