### PR TITLE
Update agent bundle to exclude the "./" directory

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -24,7 +24,8 @@ then
 
   docker export $cid | tar -C $tmpdir/signalfx-agent -xf -
   rm -rf $tmpdir/signalfx-agent/{proc,sys,dev,etc} $tmpdir/signalfx-agent/.dockerenv
-  tar -C $tmpdir -zcf $output_tar.gz .
+  curdir=$(pwd)
+  (cd $tmpdir && tar -zcf ${curdir}/${output_tar}.gz *)
 fi
 
 if [[ "${PUSH-}" = "yes" ]]


### PR DESCRIPTION
The bundle currently includes the "./" directory when archived at build time.

> $ tar -tzf signalfx-agent-5.2.0.tar.gz | head
 ./
 ./signalfx-agent/
 ./signalfx-agent/jre/
 ./signalfx-agent/bin/
 ./signalfx-agent/signalfx_types.db
 ./signalfx-agent/var/
 ./signalfx-agent/collectd-python/
 ./signalfx-agent/lib/
 ./signalfx-agent/collectd-java/
 ./signalfx-agent/run/

If this directory exists in the bundle, the ownership and permissions of the current directory may be changed when extracted:

> root@7ba0b55ca78e:/home/pptools# ls -ld /home/pptools/
 drwxr-xr-x 2 pptools pptools 4096 May 20 22:13 /home/pptools/
 root@7ba0b55ca78e:/home/pptools# tar -xzf signalfx-agent-5.2.0.tar.gz
 root@7ba0b55ca78e:/home/pptools# ls -ld /home/pptools/
 drwx------ 3 502 staff 4096 May 20 15:17 /home/pptools/