### PR TITLE
[Helm] Enabling dnsConfig option in the Helm Chart

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/Chart.yaml
+++ b/deployments/k8s/helm/signalfx-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: The SignalFx Smart Agent
 name: signalfx-agent
 appVersion: 5.2.1
-version: 1.0.0
+version: 1.0.1
 keywords:
 - monitoring
 - alerting

--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -37,6 +37,10 @@ spec:
       # Use host network so we can access kubelet directly
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+      {{ toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ template "signalfx-agent.serviceAccountName" . }}
       {{ with .Values.image.pullSecret -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
+      {{- if .Values.dnsConfig }}
+      dnsConfig:
+      {{ toYaml .Values.dnsConfig | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       serviceAccountName: {{ template "signalfx-agent.serviceAccountName" . }}
       {{ with .Values.image.pullSecret -}}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -36,6 +36,19 @@ minReadySeconds:
 # Namespace to deploy agent in (Optional: Will default to release namespace)
 namespace:
 
+# Optional field that allows more control on the DNS settings for the pod.
+# Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+dnsConfig: {}
+  # nameservers:
+  #   - 1.2.3.4
+  # searches:
+  #   - ns1.svc.cluster-domain.example
+  #   - my.dns.search.suffix
+  # options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
 # Configure resource requests and limits.
 # https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 resources: {}


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding possibility to set a custom [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) for the pods. Pod's DNS Config field enable users more control on the DNS settings for the pods.

#### Use case
SignalFx pods with `/etc/resolv.conf ndots:5` (default) and output `ingest.eu0.signalfx.com`,  syscall will try to resolve it sequentially going through all local search domains first and then resolve the absolute name only at last, which puts load on the DNS resolver and impacts the performance of the applications. Tuning `dnsConfig` for SignalFx pod allows us to avoid such scenarios and resolve the absolute name at first and cache the positive response.