### PR TITLE
allows host and port config on php and supervisor

### DIFF
--- a/docs/monitors/collectd-php-fpm.md
+++ b/docs/monitors/collectd-php-fpm.md
@@ -51,7 +51,7 @@ monitors:
  - type: collectd/php-fpm
    host: localhost
    port: 80
-   url: "http://{{.Host}}:{{.Port}}/fpm-status?json"
+   url: "http://{{.host}}:{{.port}}/fpm-status?json"
 ```
 
 For a full list of options, see [Configuration](#configuration).
@@ -77,7 +77,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `host` | **yes** | `string` | The hostname of the webserver (i.e. `127.0.0.1`) |
 | `port` | **yes** | `integer` | The port number of the webserver (i.e. `80`) |
 | `name` | no | `string` | This will be sent as the `plugin_instance` dimension and can be any name you like. |
-| `url` | no | `string` | The URL, either a final URL or a Go template that will be populated with the `host` and `port` values. (**default:** `http://{{.Host}}:{{.Port}}/status?json`) |
+| `url` | no | `string` | The URL, either a final URL or a Go template that will be populated with the `host` and `port` values. (**default:** `http://{{.host}}:{{.port}}/status?json`) |
 
 
 ## Metrics

--- a/docs/monitors/collectd-php-fpm.md
+++ b/docs/monitors/collectd-php-fpm.md
@@ -29,7 +29,32 @@ To configure the PHP-FPM service itself to expose status metrics:
    ```
 3. Restart Webserver (i.e. Nginx) and PHP-FPM.
 
+_Note_: Make sure that the URL you provide to reach fpm status
+page through your webserver ends in `?json`. This returns the 
+metrics as `json`, which this plugin requires.
+
 <!--- SETUP --->
+## Config Examples
+
+```
+monitors:
+ - type: collectd/php-fpm
+   host: localhost
+   port: 80
+```
+
+If fpm status page is exposed on an endpoint other than `/status`,
+you can use the `url` config option to specify the path:
+
+```
+monitors:
+ - type: collectd/php-fpm
+   host: localhost
+   port: 80
+   url: "http://{{.Host}}:{{.Port}}/fpm-status?json"
+```
+
+For a full list of options, see [Configuration](#configuration).
 
 
 ## Configuration
@@ -49,8 +74,10 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
-| `name` | **yes** | `string` | This will be sent as the `plugin_instance` dimension and can be any name you like. |
-| `url` | **yes** | `string` | Final URL ending by `?json` (i.e. http://127.0.0.1/_fpmstatus?json). |
+| `host` | **yes** | `string` | The hostname of the webserver (i.e. `127.0.0.1`) |
+| `port` | **yes** | `integer` | The port number of the webserver (i.e. `80`) |
+| `name` | no | `string` | This will be sent as the `plugin_instance` dimension and can be any name you like. |
+| `url` | no | `string` | The URL, either a final URL or a Go template that will be populated with the `host` and `port` values. (**default:** `http://{{.Host}}:{{.Port}}/status?json`) |
 
 
 ## Metrics

--- a/docs/monitors/supervisor.md
+++ b/docs/monitors/supervisor.md
@@ -30,7 +30,9 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
-| `url` | **yes** | `string` | The Supervisor XML-RPC API URL (i.e. `http://localhost:9001/RPC2`). |
+| `host` | no | `string` | The host/ip address of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided. |
+| `port` | no | `integer` | The port of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided. (i.e. `localhost`) (**default:** `9001`) |
+| `url` | no | `string` | URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, and `port` options. (i.e. `http://localhost:9001/RPC2`) |
 
 
 ## Metrics

--- a/docs/monitors/supervisor.md
+++ b/docs/monitors/supervisor.md
@@ -32,7 +32,9 @@ Configuration](../monitor-config.md#common-configuration).**
 | --- | --- | --- | --- |
 | `host` | no | `string` | The host/ip address of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided. |
 | `port` | no | `integer` | The port of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided. (i.e. `localhost`) (**default:** `9001`) |
-| `url` | no | `string` | URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, and `port` options. (i.e. `http://localhost:9001/RPC2`) |
+| `useHTTPS` | no | `bool` | If true, the monitor will connect to Supervisor via HTTPS instead of HTTP. (**default:** `false`) |
+| `path` | no | `string` | The URL path to use for the scrape URL for Supervisor. (**default:** `/RPC2`) |
+| `url` | no | `string` | URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, `port`, `useHTTPS`, and `path` options. (i.e. `http://localhost:9001/RPC2`) |
 
 
 ## Metrics

--- a/docs/monitors/telegraf-dns.md
+++ b/docs/monitors/telegraf-dns.md
@@ -31,10 +31,10 @@ Configuration](../monitor-config.md#common-configuration).**
 
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
-| `domains` | no | `list of strings` | Domains or subdomains to query. |
+| `domains` | no | `list of strings` | Domains or subdomains to query. If this is not provided it will be `["."]` and `RecordType` will be forced to `NS`. |
 | `network` | no | `string` | Network is the network protocol name. (**default:** `udp`) |
 | `port` | no | `integer` | Dns server port. (**default:** `53`) |
-| `servers` | no | `list of strings` | Servers to query. |
+| `servers` | **yes** | `list of strings` | Servers to query. |
 | `recordType` | no | `string` | Query record type (A, AAAA, CNAME, MX, NS, PTR, TXT, SOA, SPF, SRV). (**default:** `NS`) |
 | `timeout` | no | `int64` | Query timeout. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration. (**default:** `2s`) |
 

--- a/pkg/monitors/collectd/php/metadata.yaml
+++ b/pkg/monitors/collectd/php/metadata.yaml
@@ -22,7 +22,33 @@ monitors:
        ```
     3. Restart Webserver (i.e. Nginx) and PHP-FPM.
 
+    _Note_: Make sure that the URL you provide to reach fpm status
+    page through your webserver ends in `?json`. This returns the 
+    metrics as `json`, which this plugin requires.
+
     <!--- SETUP --->
+    ## Config Examples
+
+    ```
+    monitors:
+     - type: collectd/php-fpm
+       host: localhost
+       port: 80
+    ```
+
+    If fpm status page is exposed on an endpoint other than `/status`,
+    you can use the `url` config option to specify the path:
+
+    ```
+    monitors:
+     - type: collectd/php-fpm
+       host: localhost
+       port: 80
+       url: "http://{{.Host}}:{{.Port}}/fpm-status?json"
+    ```
+
+    For a full list of options, see [Configuration](#configuration).
+
 
   metrics:
     phpfpm_requests.accepted:

--- a/pkg/monitors/collectd/php/metadata.yaml
+++ b/pkg/monitors/collectd/php/metadata.yaml
@@ -44,7 +44,7 @@ monitors:
      - type: collectd/php-fpm
        host: localhost
        port: 80
-       url: "http://{{.Host}}:{{.Port}}/fpm-status?json"
+       url: "http://{{.host}}:{{.port}}/fpm-status?json"
     ```
 
     For a full list of options, see [Configuration](#configuration).

--- a/pkg/monitors/collectd/php/php.go
+++ b/pkg/monitors/collectd/php/php.go
@@ -30,7 +30,7 @@ type Config struct {
 	Name string `yaml:"name"`
 	// The URL, either a final URL or a Go template that will be populated with
 	// the `host` and `port` values.
-	URL string `yaml:"url" default:"http://{{.Host}}:{{.Port}}/status?json"`
+	URL string `yaml:"url" default:"http://{{.host}}:{{.port}}/status?json"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/php/php.go
+++ b/pkg/monitors/collectd/php/php.go
@@ -21,12 +21,16 @@ func init() {
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
 	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
-
+	// The hostname of the webserver (i.e. `127.0.0.1`)
+	Host string `yaml:"host" validate:"required"`
+	// The port number of the webserver (i.e. `80`)
+	Port uint16 `yaml:"port" validate:"required"`
 	// This will be sent as the `plugin_instance` dimension and can be any name
 	// you like.
-	Name string `yaml:"name" validate:"required"`
-	// Final URL ending by `?json` (i.e. http://127.0.0.1/_fpmstatus?json).
-	URL string `yaml:"url" validate:"required"`
+	Name string `yaml:"name"`
+	// The URL, either a final URL or a Go template that will be populated with
+	// the `host` and `port` values.
+	URL string `yaml:"url" default:"http://{{.Host}}:{{.Port}}/status?json"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/php/php.tmpl
+++ b/pkg/monitors/collectd/php/php.tmpl
@@ -2,7 +2,7 @@
   Interval {{.IntervalSeconds}}
 </LoadPlugin>
 <Plugin "curl_json">
-  <URL "{{.URL}}">
+  <URL "{{renderValue .URL $ }}">
     Instance "{{.Name}}[monitorID={{.MonitorID}}]"
     <Key "accepted conn">
       Type "phpfpm_requests"

--- a/pkg/monitors/collectd/php/php.tmpl
+++ b/pkg/monitors/collectd/php/php.tmpl
@@ -2,7 +2,7 @@
   Interval {{.IntervalSeconds}}
 </LoadPlugin>
 <Plugin "curl_json">
-  <URL "{{renderValue .URL $ }}">
+  <URL "{{renderValue .URL (toMap $) }}">
     Instance "{{.Name}}[monitorID={{.MonitorID}}]"
     <Key "accepted conn">
       Type "phpfpm_requests"

--- a/pkg/monitors/collectd/php/template.go
+++ b/pkg/monitors/collectd/php/template.go
@@ -16,7 +16,7 @@ var CollectdTemplate = template.Must(collectd.InjectTemplateFuncs(template.New("
   Interval {{.IntervalSeconds}}
 </LoadPlugin>
 <Plugin "curl_json">
-  <URL "{{.URL}}">
+  <URL "{{renderValue .URL $ }}">
     Instance "{{.Name}}[monitorID={{.MonitorID}}]"
     <Key "accepted conn">
       Type "phpfpm_requests"

--- a/pkg/monitors/collectd/php/template.go
+++ b/pkg/monitors/collectd/php/template.go
@@ -16,7 +16,7 @@ var CollectdTemplate = template.Must(collectd.InjectTemplateFuncs(template.New("
   Interval {{.IntervalSeconds}}
 </LoadPlugin>
 <Plugin "curl_json">
-  <URL "{{renderValue .URL $ }}">
+  <URL "{{renderValue .URL (toMap $) }}">
     Instance "{{.Name}}[monitorID={{.MonitorID}}]"
     <Key "accepted conn">
       Type "phpfpm_requests"

--- a/pkg/monitors/telegraf/monitors/dns/dns.go
+++ b/pkg/monitors/telegraf/monitors/dns/dns.go
@@ -26,17 +26,19 @@ func init() {
 // Config for this monitor
 type Config struct {
 	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"true"`
-	// Domains or subdomains to query.
+	// Domains or subdomains to query. If this is not provided it will be
+	// `["."]` and `RecordType` will be forced to `NS`.
 	Domains []string `yaml:"domains"`
 	// Network is the network protocol name.
 	Network string `yaml:"network" default:"udp"`
 	// Dns server port.
 	Port int `yaml:"port" default:"53"`
 	// Servers to query.
-	Servers []string `yaml:"servers"`
+	Servers []string `yaml:"servers" validate:"required"`
 	// Query record type (A, AAAA, CNAME, MX, NS, PTR, TXT, SOA, SPF, SRV).
 	RecordType string `yaml:"recordType" default:"NS"`
-	// Query timeout. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration.
+	// Query timeout. This should be a duration string that is accepted
+	// by https://golang.org/pkg/time/#ParseDuration.
 	Timeout timeutil.Duration `yaml:"timeout" default:"2s"`
 }
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -16034,7 +16034,7 @@
           "description": "Set to whatever you set in the `name` config option."
         }
       },
-      "doc": "Monitors PHP-FPM using pool status URL.\n\n\u003c!--- SETUP ---\u003e\n## PHP-FPM Setup\nTo configure the PHP-FPM service itself to expose status metrics:\n\n1. Enable status https://www.php.net/manual/en/install.fpm.configuration.php#pm.status-path\n2. Then, configure access through the webserver, i.e. nginx:\n\n   ```\n    location ~ ^/(status|ping)$ {\n      access_log off;\n      fastcgi_pass unix:/run/php/php-fpm.sock;\n      include fastcgi_params;\n      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;\n    }\n   ```\n3. Restart Webserver (i.e. Nginx) and PHP-FPM.\n\n\u003c!--- SETUP ---\u003e\n",
+      "doc": "Monitors PHP-FPM using pool status URL.\n\n\u003c!--- SETUP ---\u003e\n## PHP-FPM Setup\nTo configure the PHP-FPM service itself to expose status metrics:\n\n1. Enable status https://www.php.net/manual/en/install.fpm.configuration.php#pm.status-path\n2. Then, configure access through the webserver, i.e. nginx:\n\n   ```\n    location ~ ^/(status|ping)$ {\n      access_log off;\n      fastcgi_pass unix:/run/php/php-fpm.sock;\n      include fastcgi_params;\n      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;\n    }\n   ```\n3. Restart Webserver (i.e. Nginx) and PHP-FPM.\n\n_Note_: Make sure that the URL you provide to reach fpm status\npage through your webserver ends in `?json`. This returns the \nmetrics as `json`, which this plugin requires.\n\n\u003c!--- SETUP ---\u003e\n## Config Examples\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n```\n\nIf fpm status page is exposed on an endpoint other than `/status`,\nyou can use the `url` config option to specify the path:\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n   url: \"http://{{.Host}}:{{.Port}}/fpm-status?json\"\n```\n\nFor a full list of options, see [Configuration](#configuration).\n",
       "groups": {
         "": {
           "description": "",
@@ -16086,18 +16086,34 @@
         "package": "pkg/monitors/collectd/php",
         "fields": [
           {
-            "yamlName": "name",
-            "doc": "This will be sent as the `plugin_instance` dimension and can be any name you like.",
+            "yamlName": "host",
+            "doc": "The hostname of the webserver (i.e. `127.0.0.1`)",
             "default": null,
             "required": true,
             "type": "string",
             "elementKind": ""
           },
           {
-            "yamlName": "url",
-            "doc": "Final URL ending by `?json` (i.e. http://127.0.0.1/_fpmstatus?json).",
+            "yamlName": "port",
+            "doc": "The port number of the webserver (i.e. `80`)",
             "default": null,
             "required": true,
+            "type": "uint16",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "name",
+            "doc": "This will be sent as the `plugin_instance` dimension and can be any name you like.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "url",
+            "doc": "The URL, either a final URL or a Go template that will be populated with the `host` and `port` values.",
+            "default": "http://{{.Host}}:{{.Port}}/status?json",
+            "required": false,
             "type": "string",
             "elementKind": ""
           }
@@ -46108,10 +46124,26 @@
         "package": "pkg/monitors/supervisor",
         "fields": [
           {
+            "yamlName": "host",
+            "doc": "The host/ip address of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "port",
+            "doc": "The port of the Supervisor XML-RPC API. This is used to construct the `url` option if not provided. (i.e. `localhost`)",
+            "default": 9001,
+            "required": false,
+            "type": "uint16",
+            "elementKind": ""
+          },
+          {
             "yamlName": "url",
-            "doc": "The Supervisor XML-RPC API URL (i.e. `http://localhost:9001/RPC2`).",
-            "default": null,
-            "required": true,
+            "doc": "URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, and `port` options. (i.e. `http://localhost:9001/RPC2`)",
+            "default": "",
+            "required": false,
             "type": "string",
             "elementKind": ""
           }
@@ -46177,7 +46209,7 @@
         "fields": [
           {
             "yamlName": "domains",
-            "doc": "Domains or subdomains to query.",
+            "doc": "Domains or subdomains to query. If this is not provided it will be `[\".\"]` and `RecordType` will be forced to `NS`.",
             "default": null,
             "required": false,
             "type": "slice",
@@ -46203,7 +46235,7 @@
             "yamlName": "servers",
             "doc": "Servers to query.",
             "default": null,
-            "required": false,
+            "required": true,
             "type": "slice",
             "elementKind": "string"
           },

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -16034,7 +16034,7 @@
           "description": "Set to whatever you set in the `name` config option."
         }
       },
-      "doc": "Monitors PHP-FPM using pool status URL.\n\n\u003c!--- SETUP ---\u003e\n## PHP-FPM Setup\nTo configure the PHP-FPM service itself to expose status metrics:\n\n1. Enable status https://www.php.net/manual/en/install.fpm.configuration.php#pm.status-path\n2. Then, configure access through the webserver, i.e. nginx:\n\n   ```\n    location ~ ^/(status|ping)$ {\n      access_log off;\n      fastcgi_pass unix:/run/php/php-fpm.sock;\n      include fastcgi_params;\n      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;\n    }\n   ```\n3. Restart Webserver (i.e. Nginx) and PHP-FPM.\n\n_Note_: Make sure that the URL you provide to reach fpm status\npage through your webserver ends in `?json`. This returns the \nmetrics as `json`, which this plugin requires.\n\n\u003c!--- SETUP ---\u003e\n## Config Examples\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n```\n\nIf fpm status page is exposed on an endpoint other than `/status`,\nyou can use the `url` config option to specify the path:\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n   url: \"http://{{.Host}}:{{.Port}}/fpm-status?json\"\n```\n\nFor a full list of options, see [Configuration](#configuration).\n",
+      "doc": "Monitors PHP-FPM using pool status URL.\n\n\u003c!--- SETUP ---\u003e\n## PHP-FPM Setup\nTo configure the PHP-FPM service itself to expose status metrics:\n\n1. Enable status https://www.php.net/manual/en/install.fpm.configuration.php#pm.status-path\n2. Then, configure access through the webserver, i.e. nginx:\n\n   ```\n    location ~ ^/(status|ping)$ {\n      access_log off;\n      fastcgi_pass unix:/run/php/php-fpm.sock;\n      include fastcgi_params;\n      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;\n    }\n   ```\n3. Restart Webserver (i.e. Nginx) and PHP-FPM.\n\n_Note_: Make sure that the URL you provide to reach fpm status\npage through your webserver ends in `?json`. This returns the \nmetrics as `json`, which this plugin requires.\n\n\u003c!--- SETUP ---\u003e\n## Config Examples\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n```\n\nIf fpm status page is exposed on an endpoint other than `/status`,\nyou can use the `url` config option to specify the path:\n\n```\nmonitors:\n - type: collectd/php-fpm\n   host: localhost\n   port: 80\n   url: \"http://{{.host}}:{{.port}}/fpm-status?json\"\n```\n\nFor a full list of options, see [Configuration](#configuration).\n",
       "groups": {
         "": {
           "description": "",
@@ -16112,7 +16112,7 @@
           {
             "yamlName": "url",
             "doc": "The URL, either a final URL or a Go template that will be populated with the `host` and `port` values.",
-            "default": "http://{{.Host}}:{{.Port}}/status?json",
+            "default": "http://{{.host}}:{{.port}}/status?json",
             "required": false,
             "type": "string",
             "elementKind": ""
@@ -46140,8 +46140,24 @@
             "elementKind": ""
           },
           {
+            "yamlName": "useHTTPS",
+            "doc": "If true, the monitor will connect to Supervisor via HTTPS instead of HTTP.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "path",
+            "doc": "The URL path to use for the scrape URL for Supervisor.",
+            "default": "/RPC2",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "url",
-            "doc": "URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, and `port` options. (i.e. `http://localhost:9001/RPC2`)",
+            "doc": "URL on which to scrape Supervisor XML-RPC API. If this is not provided, it will be derive from the `host`, `port`, `useHTTPS`, and `path` options. (i.e. `http://localhost:9001/RPC2`)",
             "default": "",
             "required": false,
             "type": "string",

--- a/tests/monitors/collectd_php/php_test.py
+++ b/tests/monitors/collectd_php/php_test.py
@@ -32,7 +32,8 @@ def test_php_default():
         f"""
         monitors:
         - type: collectd/php-fpm
-          url: "http://{host}/status?json"
+          host: {host}
+          port: 80
           name: {INSTANCE}
         """
     ) as agent:

--- a/tests/monitors/supervisor/supervisor_test.py
+++ b/tests/monitors/supervisor/supervisor_test.py
@@ -29,7 +29,8 @@ def test_supervisor_default():
         f"""
         monitors:
         - type: supervisor
-          url: "http://{host}:{PORT}/RPC2"
+          host: {host}
+          port: {PORT}
         """
     ) as agent:
         verify(agent, METADATA.default_metrics)

--- a/tests/monitors/telegraf_dns/dns_test.py
+++ b/tests/monitors/telegraf_dns/dns_test.py
@@ -23,8 +23,6 @@ def test_telegraf_dns_metrics():
         - type: telegraf/dns
           servers:
             - {SERVER}
-          domains:
-            - {DOMAIN}
         """
     )
     run_agent_verify_default_metrics(agent_config, METADATA)
@@ -39,17 +37,9 @@ def test_telegraf_resolve():
             - {SERVER}
           domains:
             - {DOMAIN}
+          recordType: A
         """
     ) as agent:
-        assert wait_for(
-            p(
-                has_datapoint,
-                agent.fake_services,
-                "dns.result_code",
-                metric_type=sf_pbuf.GAUGE,
-                #               dimensions={"location": "us-midwest"},
-                value=0,
-            )
-        )
+        assert wait_for(p(has_datapoint, agent.fake_services, "dns.result_code", metric_type=sf_pbuf.GAUGE, value=0))
         assert wait_for(p(has_datapoint_with_dim, agent.fake_services, "server", SERVER))
         assert wait_for(p(has_datapoint_with_dim, agent.fake_services, "domain", DOMAIN))


### PR DESCRIPTION
Currently, php fpm and supervisor montiors only accept url as config option.

Adding host and port will ease the config in discovery setups from:

```
  - type: collectd/php-fpm
    discoveryRule: container_image =~ "php"
    configEndpointMappings:
      url: 'Sprintf("http://%v:%v/fpm-status?json", host, port)'
```

to:

```
  - type: collectd/php-fpm
    discoveryRule: container_image =~ "php"
```

also improved dns configuration while domains could be optional