### PR TITLE
Add checksum for ConfigMap to Pod Annotations

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -32,7 +32,10 @@ spec:
         {{ toYaml . | indent 8 | trim }}
         {{- end }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+        {{- end }}
     spec:
       # Use host network so we can access kubelet directly
       hostNetwork: true

--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -35,7 +35,10 @@ spec:
         {{ toYaml . | indent 8 | trim }}
         {{- end }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+        {{- end }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       {{- if .Values.dnsConfig }}


### PR DESCRIPTION
This will change the Deployment/DaemonSet object on ConfigMap change which will in turn trigger deployment/restart of SignalFx Agent.