### PR TITLE
Add ability to export spans to Splunk

### DIFF
--- a/deployments/splunk/README.md
+++ b/deployments/splunk/README.md
@@ -8,7 +8,7 @@ Splunk is configured to receive data from the SignalFx Agent using the HTTP Even
 
 To deploy the example, open a terminal and in this directory type:
 ```bash
-$> docker-compose up
+$> docker-compose up --build
 ```
 :
 Splunk will become available on port 18000. You can login on [http://localhost:18000] with `admin` and `changeme`.

--- a/deployments/splunk/agent.yaml
+++ b/deployments/splunk/agent.yaml
@@ -15,12 +15,15 @@ observers:
   - type: docker
 
 writer:
+  signalFxEnabled: false
   splunk:
     enabled: true
     url: ${SPLUNK_URL}
     token: ${SPLUNK_TOKEN}
     index: ${SPLUNK_INDEX}
     source: ${SPLUNK_SOURCE}
+    eventsIndex: ${SPLUNK_EVENTS_INDEX}
+    eventsSource: ${SPLUNK_EVENTS_SOURCE}
     skipTLSVerify: ${SPLUNK_SKIP_TLS_VERIFY}
 monitors:
   - {"#from": "/etc/signalfx/monitors/*.yaml", flatten: true, optional: true}
@@ -35,3 +38,5 @@ monitors:
   - type: host-metadata
   - type: processlist
   - type: docker-container-stats
+  - type: signalfx-forwarder
+    listenAddress: 0.0.0.0:9080

--- a/deployments/splunk/docker-compose.yml
+++ b/deployments/splunk/docker-compose.yml
@@ -30,7 +30,13 @@ services:
       - SPLUNK_SKIP_TLS_VERIFY=true
       - SPLUNK_INDEX=metrics
       - SPLUNK_SOURCE=signalfx
+      - SPLUNK_EVENTS_INDEX=traces
+      - SPLUNK_EVENTS_SOURCE=sfx-traces
     volumes:
       - /:/hostfs:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./agent.yaml:/etc/signalfx/agent.yaml:ro
+  tracing:
+    build:
+      context: tracing
+    restart: always

--- a/deployments/splunk/splunk.yml
+++ b/deployments/splunk/splunk.yml
@@ -9,3 +9,9 @@ splunk:
           homePath: $SPLUNK_DB/metrics/db
           maxTotalDataSizeMB: 512000
           thawedPath: $SPLUNK_DB/metrics/thaweddb
+        traces:
+          coldPath: $SPLUNK_DB/traces/colddb
+          datatype: event
+          homePath: $SPLUNK_DB/traces/db
+          maxTotalDataSizeMB: 512000
+          thawedPath: $SPLUNK_DB/traces/thaweddb

--- a/deployments/splunk/tracing/Dockerfile
+++ b/deployments/splunk/tracing/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.13-stretch
+
+WORKDIR /go/src/app
+
+COPY main.go .
+
+RUN go get
+
+RUN go build
+
+CMD /go/src/app/app

--- a/deployments/splunk/tracing/main.go
+++ b/deployments/splunk/tracing/main.go
@@ -16,7 +16,7 @@ func main() {
 	defer tracing.Stop()
 	counter := 0
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGQUIT)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {

--- a/deployments/splunk/tracing/main.go
+++ b/deployments/splunk/tracing/main.go
@@ -1,20 +1,21 @@
 package main
 
 import (
-	"github.com/opentracing/opentracing-go"
 	"os"
 	"os/signal"
 	"strconv"
 	"syscall"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/signalfx/signalfx-go-tracing/tracing"
 )
-import "github.com/signalfx/signalfx-go-tracing/tracing"
 
 func main() {
 	tracing.Start(tracing.WithEndpointURL("http://signalfx-agent:9080/v1/trace"), tracing.WithServiceName("tracing"))
 	defer tracing.Stop()
 	counter := 0
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGQUIT)
 	ticker := time.NewTicker(1 * time.Second)
 	for {

--- a/deployments/splunk/tracing/main.go
+++ b/deployments/splunk/tracing/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/opentracing/opentracing-go"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+)
+import "github.com/signalfx/signalfx-go-tracing/tracing"
+
+func main() {
+	tracing.Start(tracing.WithEndpointURL("http://signalfx-agent:9080/v1/trace"), tracing.WithServiceName("tracing"))
+	defer tracing.Stop()
+	counter := 0
+	c := make(chan os.Signal)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGKILL, syscall.SIGQUIT)
+	ticker := time.NewTicker(1 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			span := opentracing.GlobalTracer().StartSpan("main")
+			span.SetTag("span.kind", "server")
+			span.SetTag("counter", strconv.Itoa(counter))
+			childSpan := opentracing.GlobalTracer().StartSpan("sub1", opentracing.ChildOf(span.Context()))
+			time.Sleep(1 * time.Second)
+			childSpan.Finish()
+			span.Finish()
+			counter++
+			break
+		case <-c:
+			ticker.Stop()
+			return
+		}
+	}
+
+}

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -177,6 +177,9 @@ The **nested** `splunk` config object has the following fields:
 | `source` | no | string | Splunk source field value, description of the source of the event |
 | `sourceType` | no | string | Splunk source type, optional name of a sourcetype field value |
 | `index` | no | string | Splunk index, optional name of the Splunk index to store the event in |
+| `eventsIndex` | no | string | Splunk index, specifically for traces (must be event type) |
+| `eventsSource` | no | string | Splunk source field value, description of the source of the trace |
+| `eventsSourceType` | no | string | Splunk trace source type, optional name of a sourcetype field value |
 | `skipTLSVerify` | no | bool | Skip verifying the certificate of the HTTP Event Collector (**default:** `false`) |
 | `maxBuffered` | no | integer | The maximum number of Splunk log entries of all types (e.g. metric, event) to be buffered before old events are dropped.  Defaults to the writer.maxDatapointsBuffered config if not specified. (**default:** `0`) |
 | `maxRequests` | no | integer | The maximum number of simultaneous requests to the Splunk HEC endpoint. Defaults to the writer.maxBuffered config if not specified. (**default:** `0`) |
@@ -434,6 +437,9 @@ where applicable:
       source: 
       sourceType: 
       index: 
+      eventsIndex: 
+      eventsSource: 
+      eventsSourceType: 
       skipTLSVerify: false
       maxBuffered: 0
       maxRequests: 0

--- a/go.mod
+++ b/go.mod
@@ -168,6 +168,7 @@ require (
 	gopkg.in/ory-am/dockertest.v2 v2.2.3 // indirect
 	gopkg.in/square/go-jose.v2 v2.3.0 // indirect
 	gopkg.in/yaml.v2 v2.2.7
+	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.17.0
 	k8s.io/apimachinery v0.17.0
 	k8s.io/client-go v0.17.0

--- a/go.mod
+++ b/go.mod
@@ -139,6 +139,7 @@ require (
 	github.com/signalfx/gateway v1.2.19-0.20191125135538-2c417b7ae0bd
 	github.com/signalfx/golib/v3 v3.3.0
 	github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5
+	github.com/signalfx/signalfx-go-tracing v1.2.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/soniah/gosnmp v0.0.0-20190220004421-68e8beac0db9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,7 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/philhofer/fwd v1.0.0 h1:UbZqGr5Y38ApvM/V/jEljVxwocdweyH+vmYvRPBnbqQ=
 github.com/philhofer/fwd v1.0.0/go.mod h1:gk3iGcWd9+svBvR0sR+KPcfE+RNWozjowpeBVG3ZVNU=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -845,6 +846,8 @@ github.com/signalfx/sapm-proto v0.4.0 h1:5lQX++6FeIjUZEIcnSgBqhOpmSjMkRBW3y/4ZiK
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5 h1:+tu30Q5SkbYMBmI3sgDJTB9M1/Ga8z0V0LGDVY1D99g=
 github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5/go.mod h1:CeCGXKT2wqqky0Nz8eV0NH/CpMPE7tzYUcV8eQS1U1s=
+github.com/signalfx/signalfx-go-tracing v1.2.0 h1:wEdlZQ69u3QyEZEEIo+prmGaVieKgiICqBVb2Dtfnvc=
+github.com/signalfx/signalfx-go-tracing v1.2.0/go.mod h1:JoTkkhSBe42ns9/AsvtqX7lLiiS6YwE0Q7J0DZFzt00=
 github.com/signalfx/tdigest v0.0.0-20191031204725-c860c3ff6902 h1:V/uPctkyrXFOwGmWbFFEJP48ntw8ykJN6oxEJBTPARE=
 github.com/signalfx/tdigest v0.0.0-20191031204725-c860c3ff6902/go.mod h1:fbvuJM3o+bwr36+TVjokMUGd4muJVHiCshTmKZ/6eNU=
 github.com/signalfx/telegraf v0.10.2-0.20200415004250-249b98cac6c7 h1:2yl1neQAA7FvggdNsY65PiZnTTzQH/mBQhNEiwUV/fQ=
@@ -920,6 +923,7 @@ github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51 h1:BP2bjP495BBPaBcS5rmqviTfrOkN5rO5ceKAMRZCRFc=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinylib/msgp v1.0.2 h1:DfdQrzQa7Yh2es9SuLkixqxuXS2SxsdYn0KbdrOGWD8=
 github.com/tinylib/msgp v1.0.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=

--- a/pkg/core/config/writer.go
+++ b/pkg/core/config/writer.go
@@ -249,11 +249,17 @@ type SplunkConfig struct {
 	// Splunk HTTP Event Collector token
 	Token string `yaml:"token"`
 	// Splunk source field value, description of the source of the event
-	Source string `yaml:"source"`
+	MetricsSource string `yaml:"source"`
 	// Splunk source type, optional name of a sourcetype field value
-	SourceType string `yaml:"sourceType"`
+	MetricsSourceType string `yaml:"sourceType"`
 	// Splunk index, optional name of the Splunk index to store the event in
-	Index string `yaml:"index"`
+	MetricsIndex string `yaml:"index"`
+	// Splunk index, specifically for traces (must be event type)
+	EventsIndex string `yaml:"eventsIndex"`
+	// Splunk source field value, description of the source of the trace
+	EventsSource string `yaml:"eventsSource"`
+	// Splunk trace source type, optional name of a sourcetype field value
+	EventsSourceType string `yaml:"eventsSourceType"`
 	// Skip verifying the certificate of the HTTP Event Collector
 	SkipTLSVerify bool `yaml:"skipTLSVerify"`
 

--- a/pkg/core/writer/splunk/splunk.go
+++ b/pkg/core/writer/splunk/splunk.go
@@ -9,12 +9,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/signalfx/golib/v3/trace"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/signalfx/golib/v3/trace"
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
@@ -22,6 +23,10 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/writer/processor"
 	"github.com/sirupsen/logrus"
+)
+
+const (
+	unknownHost = "unknown"
 )
 
 // Output posts data to Splunk HTTP Event Collector.
@@ -171,7 +176,7 @@ func (o *Output) convertDatapoint(d *datapoint.Datapoint) *logMetric {
 
 	host := d.Dimensions["host"]
 	if host == "" {
-		host = "unknown"
+		host = unknownHost
 	}
 	return &logMetric{
 		Time:       computeTime(d.Timestamp),
@@ -201,7 +206,7 @@ func (o *Output) convertEvent(e *event.Event) *logEvent {
 	}
 	host := e.Dimensions["host"]
 	if host == "" {
-		host = "unknown"
+		host = unknownHost
 	}
 	return &logEvent{
 		Time:       computeTime(e.Timestamp),
@@ -226,7 +231,7 @@ func (o *Output) convertSpan(s *trace.Span) *logSpan {
 	b, err := json.Marshal(s.LocalEndpoint)
 	var host string
 	if err != nil {
-		host = "unknown"
+		host = unknownHost
 	} else {
 		host = string(b)
 	}

--- a/pkg/core/writer/splunk/splunk.go
+++ b/pkg/core/writer/splunk/splunk.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/signalfx/golib/v3/trace"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -27,14 +28,17 @@ import (
 type Output struct {
 	*processor.Processor
 
-	httpClient    *http.Client
-	url           string
-	token         string
-	source        string
-	sourceType    string
-	index         string
-	skipTLSVerify bool
-	hostIDDims    map[string]string
+	httpClient        *http.Client
+	url               string
+	token             string
+	metricsSource     string
+	metricsSourceType string
+	metricsIndex      string
+	eventsSource      string
+	eventsSourceType  string
+	eventsIndex       string
+	skipTLSVerify     bool
+	hostIDDims        map[string]string
 
 	entryWriter *LogEntryWriter
 
@@ -43,21 +47,26 @@ type Output struct {
 
 	dpChan    chan []*datapoint.Datapoint
 	eventChan chan *event.Event
+	spanChan  chan []*trace.Span
 }
 
 // Build a Splunk Writer.
-func New(conf *config.WriterConfig, dpChan chan []*datapoint.Datapoint, eventChan chan *event.Event) (*Output, error) {
+func New(conf *config.WriterConfig, dpChan chan []*datapoint.Datapoint, eventChan chan *event.Event, spanChan chan []*trace.Span) (*Output, error) {
 	out := &Output{
-		Processor:     processor.New(conf),
-		url:           conf.Splunk.URL,
-		token:         conf.Splunk.Token,
-		source:        conf.Splunk.Source,
-		sourceType:    conf.Splunk.SourceType,
-		index:         conf.Splunk.Index,
-		skipTLSVerify: conf.Splunk.SkipTLSVerify,
-		hostIDDims:    conf.HostIDDims,
-		dpChan:        dpChan,
-		eventChan:     eventChan,
+		Processor:         processor.New(conf),
+		url:               conf.Splunk.URL,
+		token:             conf.Splunk.Token,
+		metricsSource:     conf.Splunk.MetricsSource,
+		metricsSourceType: conf.Splunk.MetricsSourceType,
+		metricsIndex:      conf.Splunk.MetricsIndex,
+		eventsSource:      conf.Splunk.EventsSource,
+		eventsSourceType:  conf.Splunk.EventsSourceType,
+		eventsIndex:       conf.Splunk.EventsIndex,
+		skipTLSVerify:     conf.Splunk.SkipTLSVerify,
+		hostIDDims:        conf.HostIDDims,
+		dpChan:            dpChan,
+		eventChan:         eventChan,
+		spanChan:          spanChan,
 	}
 
 	out.ctx, out.cancel = context.WithCancel(context.Background())
@@ -114,6 +123,13 @@ func (o *Output) Start() {
 					continue
 				}
 				entries = append(entries, o.convertEvent(event))
+			case spans := <-o.spanChan:
+				for _, span := range spans {
+					if !o.PreprocessSpan(span) {
+						continue
+					}
+					entries = append(entries, o.convertSpan(span))
+				}
 			}
 
 			if len(entries) > 0 {
@@ -160,15 +176,15 @@ func (o *Output) convertDatapoint(d *datapoint.Datapoint) *logMetric {
 	return &logMetric{
 		Time:       computeTime(d.Timestamp),
 		Host:       host,
-		Source:     o.source,
-		SourceType: o.sourceType,
-		Index:      o.index,
+		Source:     o.metricsSource,
+		SourceType: o.metricsSourceType,
+		Index:      o.metricsIndex,
 		Event:      "metric",
 		Fields:     fields,
 	}
 }
 
-// LogEvent logs an event as a Splunk metric event
+// convertEvent converts an event as a Splunk event
 func (o *Output) convertEvent(e *event.Event) *logEvent {
 	props := make(map[string]string)
 	for key, v := range e.Properties {
@@ -190,10 +206,43 @@ func (o *Output) convertEvent(e *event.Event) *logEvent {
 	return &logEvent{
 		Time:       computeTime(e.Timestamp),
 		Host:       host,
-		Source:     o.source,
-		SourceType: o.sourceType,
-		Index:      o.index,
+		Source:     o.eventsSource,
+		SourceType: o.eventsSourceType,
+		Index:      o.eventsIndex,
 		Event:      eventdata{Properties: props, Dimensions: e.Dimensions, Meta: meta, EventType: e.EventType, Category: e.Category},
+	}
+}
+
+// convertSpan converts a span as a Splunk event
+func (o *Output) convertSpan(s *trace.Span) *logSpan {
+
+	meta := make(map[string]string)
+	for key, v := range s.Meta {
+		if v != nil {
+			meta[toString(key)] = toString(v)
+		}
+	}
+
+	b, err := json.Marshal(s.LocalEndpoint)
+	var host string
+	if err != nil {
+		host = "unknown"
+	} else {
+		host = string(b)
+	}
+
+	ts := *s.Timestamp
+	if ts == 0 {
+		ts = time.Now().UnixNano() / time.Millisecond.Nanoseconds()
+	}
+
+	return &logSpan{
+		Time:       ts,
+		Host:       host,
+		Source:     o.eventsSource,
+		SourceType: o.eventsSourceType,
+		Index:      o.eventsIndex,
+		Event:      spandata{TraceID: s.TraceID, ID: s.ID, Name: s.Name, LocalEndpoint: s.LocalEndpoint, RemoteEndpoint: s.RemoteEndpoint, Debug: s.Debug, Duration: s.Duration, Kind: s.Kind, ParentID: s.ParentID, Shared: s.Shared, Tags: s.Tags, Meta: meta, Annotations: s.Annotations},
 	}
 }
 

--- a/pkg/core/writer/splunk/splunk_test.go
+++ b/pkg/core/writer/splunk/splunk_test.go
@@ -2,6 +2,7 @@ package splunk
 
 import (
 	"encoding/json"
+	"github.com/signalfx/golib/v3/trace"
 	"testing"
 	"time"
 
@@ -48,6 +49,53 @@ func TestSplunkMetricMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 	expected := "{\"time\":631152000000,\"host\":\"localhost\",\"source\":\"sfx\",\"sourcetype\":\"sfx\",\"index\":\"sfx\",\"event\":\"metric\",\"fields\":{\"foo\":\"bar\"}}"
+	if string(b) != expected {
+		t.Fatalf("JSON serialization does not match, expected: %s,\n got %s", expected, string(b))
+	}
+}
+
+func TestSplunkSpanMarshal(t *testing.T) {
+	name := "foo"
+	duration := int64(1000)
+	kind := "dashboard"
+	annotations := []*trace.Annotation{{
+		Timestamp: &duration,
+		Value:     &name,
+	}}
+	serviceName := "myservice"
+	localhost := "127.0.0.1"
+	myTrace := logSpan{
+		Time:       time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano() / int64(time.Millisecond),
+		Host:       "localhost",
+		Source:     "sfx",
+		SourceType: "sfx",
+		Index:      "sfx",
+		Event: spandata{
+			Meta:        map[string]string{"foo": "bar"},
+			Debug:       nil,
+			Name:        &name,
+			Duration:    &duration,
+			Kind:        &kind,
+			ParentID:    nil,
+			Shared:      nil,
+			Tags:        map[string]string{"foo": "bar"},
+			Annotations: annotations,
+			ID:          "myID",
+			TraceID:     "myTraceID",
+			LocalEndpoint: &trace.Endpoint{
+				ServiceName: &serviceName,
+				Ipv4:        &localhost,
+				Ipv6:        nil,
+				Port:        nil,
+			},
+			RemoteEndpoint: nil,
+		},
+	}
+	b, err := json.Marshal(myTrace)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "{\"time\":631152000000,\"host\":\"localhost\",\"source\":\"sfx\",\"sourcetype\":\"sfx\",\"index\":\"sfx\",\"event\":{\"meta\":{\"foo\":\"bar\"},\"name\":\"foo\",\"duration\":1000,\"kind\":\"dashboard\",\"tags\":{\"foo\":\"bar\"},\"annotations\":[{\"timestamp\":1000,\"value\":\"foo\"}],\"id\":\"myID\",\"traceID\":\"myTraceID\",\"localEndpoint\":{\"serviceName\":\"myservice\",\"ipv4\":\"127.0.0.1\"}}}"
 	if string(b) != expected {
 		t.Fatalf("JSON serialization does not match, expected: %s,\n got %s", expected, string(b))
 	}

--- a/pkg/core/writer/splunk/splunk_test.go
+++ b/pkg/core/writer/splunk/splunk_test.go
@@ -2,9 +2,10 @@ package splunk
 
 import (
 	"encoding/json"
-	"github.com/signalfx/golib/v3/trace"
 	"testing"
 	"time"
+
+	"github.com/signalfx/golib/v3/trace"
 
 	"github.com/signalfx/golib/v3/event"
 )

--- a/pkg/core/writer/splunk/types.go
+++ b/pkg/core/writer/splunk/types.go
@@ -1,6 +1,9 @@
 package splunk
 
-import "github.com/signalfx/golib/v3/event"
+import (
+	"github.com/signalfx/golib/v3/event"
+	"github.com/signalfx/golib/v3/trace"
+)
 
 // Just a dummy interface that covers all types of HEC inputs
 type logEntry interface{}
@@ -11,6 +14,22 @@ type eventdata struct {
 	Meta       map[string]string `json:"meta"`
 	Dimensions map[string]string `json:"dimensions"`
 	Properties map[string]string `json:"properties"`
+}
+
+type spandata struct {
+	Meta           map[string]string   `json:"meta"`
+	Debug          *bool               `json:"debug,omitempty"`
+	Name           *string             `json:"name,omitempty"`
+	Duration       *int64              `json:"duration,omitempty"`
+	Kind           *string             `json:"kind,omitempty"`
+	ParentID       *string             `json:"parentID,omitempty"`
+	Shared         *bool               `json:"shared,omitempty"`
+	Tags           map[string]string   `json:"tags"`
+	Annotations    []*trace.Annotation `json:"annotations,omitempty"`
+	ID             string              `json:"id"`
+	TraceID        string              `json:"traceID"`
+	LocalEndpoint  *trace.Endpoint     `json:"localEndpoint,omitempty"`
+	RemoteEndpoint *trace.Endpoint     `json:"remoteEndpoint,omitempty"`
 }
 
 // This is the format that the HEC input accepts
@@ -32,4 +51,14 @@ type logEvent struct {
 	SourceType string    `json:"sourcetype,omitempty"` // optional name of a Splunk parsing configuration; this is usually inferred by Splunk
 	Index      string    `json:"index,omitempty"`      // optional name of the Splunk index to store the event in; not required if the token has a default index set in Splunk
 	Event      eventdata `json:"event"`                // event data
+}
+
+// This is the format that the HEC input accepts
+type logSpan struct {
+	Time       int64    `json:"time"`                 // epoch time
+	Host       string   `json:"host"`                 // hostname
+	Source     string   `json:"source,omitempty"`     // optional description of the source of the event; typically the app's name
+	SourceType string   `json:"sourcetype,omitempty"` // optional name of a Splunk parsing configuration; this is usually inferred by Splunk
+	Index      string   `json:"index,omitempty"`      // optional name of the Splunk index to store the event in; not required if the token has a default index set in Splunk
+	Event      spandata `json:"event"`                // event data -- span
 }

--- a/pkg/utils/spans.go
+++ b/pkg/utils/spans.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"github.com/signalfx/golib/v3/pointer"
+	"github.com/signalfx/golib/v3/trace"
+)
+
+// CloneSpanSlice creates a clone of an array of trace spans.
+func CloneSpanSlice(spans []*trace.Span) []*trace.Span {
+	out := make([]*trace.Span, len(spans))
+	for i := range spans {
+		out[i] = CloneSpan(spans[i])
+	}
+	return out
+}
+
+// CloneSpan creates a copy of a span.
+func CloneSpan(span *trace.Span) *trace.Span {
+	newAnnotations := make([]*trace.Annotation, len(span.Annotations))
+	for i, annotation := range span.Annotations {
+		newAnnotations[i] = &(*annotation)
+	}
+	var parentID *string
+	if span.ParentID == nil {
+		parentID = nil
+	} else {
+		parentID = pointer.String(*span.ParentID)
+	}
+
+	return &trace.Span{
+		TraceID:        span.TraceID,
+		Name:           pointer.String(*span.Name),
+		ParentID:       parentID,
+		ID:             span.ID,
+		Timestamp:      pointer.Int64(*span.Timestamp),
+		Duration:       pointer.Int64(*span.Duration),
+		Debug:          pointer.Bool(*span.Debug),
+		Shared:         pointer.Bool(*span.Shared),
+		LocalEndpoint:  cloneEndpoint(span.LocalEndpoint),
+		RemoteEndpoint: cloneEndpoint(span.RemoteEndpoint),
+		Annotations:    newAnnotations,
+		Tags:           CloneStringMap(span.Tags),
+		Meta:           CloneFullInterfaceMap(span.Meta),
+	}
+}
+
+func cloneEndpoint(endpoint *trace.Endpoint) *trace.Endpoint {
+	if endpoint == nil {
+		return nil
+	}
+
+	var serviceName *string
+	if endpoint.ServiceName != nil {
+		serviceName = pointer.String(*endpoint.ServiceName)
+	}
+	var ipv4 *string
+	if endpoint.Ipv4 != nil {
+		ipv4 = pointer.String(*endpoint.Ipv4)
+	}
+	var ipv6 *string
+	if endpoint.Ipv6 != nil {
+		ipv6 = pointer.String(*endpoint.Ipv6)
+	}
+	var port *int32
+	if endpoint.Port != nil {
+		port = pointer.Int32(*endpoint.Port)
+	}
+	return &trace.Endpoint{
+		ServiceName: serviceName,
+		Ipv4:        ipv4,
+		Ipv6:        ipv6,
+		Port:        port,
+	}
+}

--- a/pkg/utils/spans_test.go
+++ b/pkg/utils/spans_test.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
+	"testing"
+
 	"github.com/signalfx/golib/v3/trace"
 	"gotest.tools/assert"
-	"testing"
 )
 
 func TestSpanClone(t *testing.T) {

--- a/pkg/utils/spans_test.go
+++ b/pkg/utils/spans_test.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"github.com/signalfx/golib/v3/trace"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestSpanClone(t *testing.T) {
+	name := "foo"
+	localhost := "127.0.0.1"
+	parentID := "parentID"
+	kind := "server"
+	ts := int64(300000)
+	duration := int64(40)
+	boolfalse := false
+	annotations := []*trace.Annotation{{
+		Timestamp: &duration,
+		Value:     &name,
+	}}
+	span := trace.Span{
+		TraceID:   "12345",
+		Name:      &name,
+		ParentID:  &parentID,
+		ID:        "myID",
+		Kind:      &kind,
+		Timestamp: &ts,
+		Duration:  &duration,
+		Debug:     &boolfalse,
+		Shared:    &boolfalse,
+		LocalEndpoint: &trace.Endpoint{
+			ServiceName: &name,
+			Ipv4:        &localhost,
+		},
+		RemoteEndpoint: nil,
+		Annotations:    annotations,
+		Tags:           map[string]string{"foo": "bar"},
+		Meta:           map[interface{}]interface{}{"foo": "bar"},
+	}
+	clone := CloneSpan(&span)
+	assert.Equal(t, span.TraceID, clone.TraceID)
+	assert.Equal(t, *span.ParentID, *clone.ParentID)
+	assert.Equal(t, *span.LocalEndpoint.ServiceName, *clone.LocalEndpoint.ServiceName)
+	assert.Equal(t, *span.LocalEndpoint.Ipv4, *clone.LocalEndpoint.Ipv4)
+	assert.DeepEqual(t, span.Tags, clone.Tags)
+	assert.Equal(t, *span.Shared, *clone.Shared)
+}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -55921,6 +55921,30 @@
                     "elementKind": ""
                   },
                   {
+                    "yamlName": "eventsIndex",
+                    "doc": "Splunk index, specifically for traces (must be event type)",
+                    "default": "",
+                    "required": false,
+                    "type": "string",
+                    "elementKind": ""
+                  },
+                  {
+                    "yamlName": "eventsSource",
+                    "doc": "Splunk source field value, description of the source of the trace",
+                    "default": "",
+                    "required": false,
+                    "type": "string",
+                    "elementKind": ""
+                  },
+                  {
+                    "yamlName": "eventsSourceType",
+                    "doc": "Splunk trace source type, optional name of a sourcetype field value",
+                    "default": "",
+                    "required": false,
+                    "type": "string",
+                    "elementKind": ""
+                  },
+                  {
                     "yamlName": "skipTLSVerify",
                     "doc": "Skip verifying the certificate of the HTTP Event Collector",
                     "default": false,


### PR DESCRIPTION
* Allow to specify an event index alongside the metrics index
* Send events and spans as events to the Splunk HEC.
* Add an example of use to the docker-compose example.