### PR TITLE
Fix GCP metadata endpoint

### DIFF
--- a/pkg/core/hostid/gcp.go
+++ b/pkg/core/hostid/gcp.go
@@ -25,7 +25,7 @@ func GoogleComputeID(cloudMetadataTimeout timeutil.Duration) string {
 }
 
 func getMetadata(path string, cloudMetadataTimeout timeutil.Duration) string {
-	url := fmt.Sprintf("http://metadata.google.pkg/computeMetadata/v1/%s", path)
+	url := fmt.Sprintf("http://metadata.google.internal/computeMetadata/v1/%s", path)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		// This would only be due to a programming bug


### PR DESCRIPTION
This was broken a few months ago: 

- https://github.com/signalfx/signalfx-agent/commit/c295133b4a52b2fff071c8070536183a48e403fc#diff-e3a5b197b3f4e8bc25ffcc06c8e810caL27
- https://github.com/signalfx/signalfx-agent/commit/c295133b4a52b2fff071c8070536183a48e403fc#diff-6cfb951705f6c4b248a6d3c6faa23069R27

```
bash-4.3# curl -H "Metadata-Flavor: Google" http://metadata.google.pkg/computeMetadata/v1/instance/id
curl: (6) Could not resolve host: metadata.google.pkg

bash-4.3# curl "http://metadata.google.internal/computeMetadata/v1/instance/id" -H "Metadata-Flavor: Google"
3395187815902811713
```

Internal case: `00012827`