### PR TITLE
Modify the splunk sample to use a Prometheus federation endpoint

### DIFF
--- a/deployments/splunk/README.md
+++ b/deployments/splunk/README.md
@@ -1,6 +1,6 @@
 # SignalFx agent Splunk Docker-compose example
 
-This example showcases how the agent works with Splunk Enterprise.
+This example showcases how the agent works with Splunk Enterprise and an existing Prometheus deployment.
 
 The example runs as a Docker Compose deployment. The agent can be configured to send various metrics to Splunk Enterprise.
 
@@ -15,3 +15,4 @@ Splunk will become available on port 18000. You can login on [http://localhost:1
 
 Once logged in, visit the [analytics workspace](http://localhost:18000/en-US/app/search/analytics_workspace) to see which metrics are sent by the SignalFx Agent.
 
+Additionally, you can consult the [http://localhost:9090](Prometheus UI) to see the metric data collected from the sample go program.

--- a/deployments/splunk/README.md
+++ b/deployments/splunk/README.md
@@ -15,4 +15,4 @@ Splunk will become available on port 18000. You can login on [http://localhost:1
 
 Once logged in, visit the [analytics workspace](http://localhost:18000/en-US/app/search/analytics_workspace) to see which metrics are sent by the SignalFx Agent.
 
-Additionally, you can consult the [http://localhost:9090](Prometheus UI) to see the metric data collected from the sample go program.
+Additionally, you can consult the [Prometheus UI](http://localhost:9090) to see the metric data collected from the sample go program.

--- a/deployments/splunk/agent.yaml
+++ b/deployments/splunk/agent.yaml
@@ -40,3 +40,12 @@ monitors:
   - type: docker-container-stats
   - type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
+  - type: prometheus-exporter
+    host: prometheus
+    # Prometheus captures the counter metric on the go program we run independently.
+    # We choose to run a separate Prometheus container to gather the metrics data, and read that data with SignalFx.
+    # the match[] parameter is required. There can be multiple match[] parameters. Each match entry is a query against Prometheus.
+    metricPath: '/federate?match[]=counter'
+    port: 9090
+    extraDimensions:
+      metric_source: prometheus

--- a/deployments/splunk/docker-compose.yml
+++ b/deployments/splunk/docker-compose.yml
@@ -1,5 +1,12 @@
 version: "3"
 services:
+  prometheus-node:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - 9090:9090
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
   splunk:
     image: splunk/splunk:latest
     container_name: splunk
@@ -19,7 +26,7 @@ services:
       - /opt/splunk/var
       - /opt/splunk/etc
   signalfx-agent:
-    image: quay.io/signalfx/signalfx-agent:latest
+    image: quay.io/signalfx/signalfx-agent:5.3.1
     container_name: signalfx-agent
     restart: always
     depends_on:
@@ -37,6 +44,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./agent.yaml:/etc/signalfx/agent.yaml:ro
   tracing:
+    container_name: tracing
     build:
       context: tracing
     restart: always

--- a/deployments/splunk/prometheus.yml
+++ b/deployments/splunk/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: tracing
+    static_configs:
+      - targets: ['tracing:8080']

--- a/deployments/splunk/tracing/main.go
+++ b/deployments/splunk/tracing/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -8,12 +10,23 @@ import (
 	"time"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/signalfx/signalfx-go-tracing/tracing"
 )
 
 func main() {
+	http.Handle("/metrics", promhttp.Handler())
+	go func() {
+		log.Fatal(http.ListenAndServe(":8080", nil))
+	}()
 	tracing.Start(tracing.WithEndpointURL("http://signalfx-agent:9080/v1/trace"), tracing.WithServiceName("tracing"))
 	defer tracing.Stop()
+	counterGauge := promauto.NewCounter(prometheus.CounterOpts{
+		Name: "counter",
+		Help: "The total number of times we produced a trace",
+	})
 	counter := 0
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
@@ -29,6 +42,7 @@ func main() {
 			childSpan.Finish()
 			span.Finish()
 			counter++
+			counterGauge.Inc()
 			break
 		case <-c:
 			ticker.Stop()

--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ require (
 	github.com/pkg/errors v0.8.2-0.20190227000051-27936f6d90f9
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/pquerna/otp v1.1.0 // indirect
+	github.com/prometheus/client_golang v0.9.3-0.20190313112143-fa4aa9000d28
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/prometheus/common v0.4.0
 	github.com/prometheus/procfs v0.0.9-0.20191209220459-fa4d6ce8c078

--- a/scripts/docs/check-links/config.json
+++ b/scripts/docs/check-links/config.json
@@ -17,6 +17,9 @@
         },
         {
             "pattern": "localhost\\:18000"
+        },
+        {
+            "pattern": "localhost\\:9090"
         }
     ]
 }


### PR DESCRIPTION
This adds a bit more complexity to our Splunk sample alongside the SignalFx agent.

When we interact with users deploying the agent, we often find that they have a dedicated Prometheus environment using federation, allowing them to roll up their metrics for collection and analytics purposes.

Rather than having SignalFx interact directly with the Prometheus endpoint on the container running the program, we show it is also possible to gather metrics through a federation endpoint.

More info about [https://prometheus.io/docs/prometheus/latest/federation/](Prometheus federation).