### PR TITLE
Add haproxy_session_limit and haproxy_session_max metrics

### DIFF
--- a/docs/monitors/haproxy.md
+++ b/docs/monitors/haproxy.md
@@ -152,6 +152,8 @@ Metrics that are categorized as
  - `haproxy_server_aborts` (*cumulative*)<br>    Number of data transfers aborted by the server (inc. in eresp). Values reported for backends and servers.
  - ***`haproxy_server_selected_total`*** (*cumulative*)<br>    Total number of times a server was selected, either for new sessions, or when re-dispatching. The server counter is the number of times that server was selected. Values reported for backends and servers.
  - ***`haproxy_session_current`*** (*gauge*)<br>    Number current sessions. Values reported for listeners, frontends, backends, and servers.
+ - `haproxy_session_limit` (*gauge*)<br>    The maximum number of connections allowed, configured with `maxconn`. Values reported for listeners, frontends, backends, and servers.
+ - `haproxy_session_max` (*gauge*)<br>    The max value of scur. Values reported for listeners, frontends, backends, and servers.
  - ***`haproxy_session_rate`*** (*gauge*)<br>    Number of sessions per second over last elapsed second. Values reported for frontends, backends, and servers.
  - ***`haproxy_session_rate_all`*** (*gauge*)<br>    Corresponds to the HAProxy process `SessRate` value given by the `show info` command issued over UNIX socket.
  - `haproxy_session_rate_limit` (*gauge*)<br>    Configured limit on new sessions per second. Values reported for frontends.

--- a/pkg/monitors/haproxy/genmetadata.go
+++ b/pkg/monitors/haproxy/genmetadata.go
@@ -71,6 +71,8 @@ const (
 	haproxyServerAborts             = "haproxy_server_aborts"
 	haproxyServerSelectedTotal      = "haproxy_server_selected_total"
 	haproxySessionCurrent           = "haproxy_session_current"
+	haproxySessionLimit             = "haproxy_session_limit"
+	haproxySessionMax               = "haproxy_session_max"
 	haproxySessionRate              = "haproxy_session_rate"
 	haproxySessionRateAll           = "haproxy_session_rate_all"
 	haproxySessionRateLimit         = "haproxy_session_rate_limit"
@@ -150,6 +152,8 @@ var metricSet = map[string]monitors.MetricInfo{
 	haproxyServerAborts:             {Type: datapoint.Counter},
 	haproxyServerSelectedTotal:      {Type: datapoint.Counter},
 	haproxySessionCurrent:           {Type: datapoint.Gauge},
+	haproxySessionLimit:             {Type: datapoint.Gauge},
+	haproxySessionMax:               {Type: datapoint.Gauge},
 	haproxySessionRate:              {Type: datapoint.Gauge},
 	haproxySessionRateAll:           {Type: datapoint.Gauge},
 	haproxySessionRateLimit:         {Type: datapoint.Gauge},

--- a/pkg/monitors/haproxy/helpers.go
+++ b/pkg/monitors/haproxy/helpers.go
@@ -86,6 +86,8 @@ var sfxMetricsMap = map[string]string{
 	"rtime":              haproxyResponseTimeAverage,
 	"Run_queue":          haproxyRunQueue,
 	"scur":               haproxySessionCurrent,
+	"slim":               haproxySessionLimit,
+	"smax":               haproxySessionMax,
 	"rate":               haproxySessionRate,
 	"SessRate":           haproxySessionRateAll,
 	"rate_lim":           haproxySessionRateLimit,

--- a/pkg/monitors/haproxy/metadata.yaml
+++ b/pkg/monitors/haproxy/metadata.yaml
@@ -78,6 +78,14 @@ monitors:
         default: true
         description: 'Number current sessions. Values reported for listeners, frontends, backends, and servers.'
         type: gauge
+      haproxy_session_limit:
+        default: false
+        description: 'The maximum number of connections allowed, configured with `maxconn`. Values reported for listeners, frontends, backends, and servers.'
+        type: gauge
+      haproxy_session_max:
+        default: false
+        description: 'The max value of scur. Values reported for listeners, frontends, backends, and servers.'
+        type: gauge
       haproxy_session_total:
         default: false
         description: 'The cumulative number of sessions. Values reported for listeners, frontends, backends, and servers.'

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -29776,6 +29776,8 @@
             "haproxy_server_aborts",
             "haproxy_server_selected_total",
             "haproxy_session_current",
+            "haproxy_session_limit",
+            "haproxy_session_max",
             "haproxy_session_rate",
             "haproxy_session_rate_all",
             "haproxy_session_rate_limit",
@@ -30150,6 +30152,18 @@
           "description": "Number current sessions. Values reported for listeners, frontends, backends, and servers.",
           "group": null,
           "default": true
+        },
+        "haproxy_session_limit": {
+          "type": "gauge",
+          "description": "The maximum number of connections allowed, configured with `maxconn`. Values reported for listeners, frontends, backends, and servers.",
+          "group": null,
+          "default": false
+        },
+        "haproxy_session_max": {
+          "type": "gauge",
+          "description": "The max value of scur. Values reported for listeners, frontends, backends, and servers.",
+          "group": null,
+          "default": false
         },
         "haproxy_session_rate": {
           "type": "gauge",


### PR DESCRIPTION
Hello,

A small PR to add two haproxy metrics :
* `haproxy_session_limit`
* `haproxy_session_max`

The limit metric is really useful and seems important to me to monitor and compare it with `haproxy_session_current`. It is defined by the `maxconn` directive (see https://cbonte.github.io/haproxy-dconv/2.1/configuration.html#maxconn%20(Server%20and%20default-server%20options)).

Thanks.
