### PR TITLE
Docs - Change kubernetes_annotations type to map of string

### DIFF
--- a/docs/observers/host.md
+++ b/docs/observers/host.md
@@ -33,7 +33,7 @@ can be used in discovery rules.
 | `command` | `string` | The full command used to invoke this process, including the executable itself at the beginning. |
 | `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
-| `is_ipv6` | `string` | Will be `true` if the endpoint is IPv6. |
+| `is_ipv6` | `bool` | Will be `true` if the endpoint is IPv6. |
 | `network_port` | `string` | An alias for `port` |
 | `discovered_by` | `string` | The observer that discovered this endpoint |
 | `host` | `string` | The hostname/IP address of the endpoint.  If this is an IPv6 address, it will be surrounded by `[` and `]`. |

--- a/docs/observers/k8s-api.md
+++ b/docs/observers/k8s-api.md
@@ -63,14 +63,14 @@ can be used in discovery rules.
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
 | `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
-| `kubernetes_annotations` | `map of string` | A map that contains pod or node annotation key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
+| `kubernetes_annotations` | `map of strings` | The set of annotations on the discovered pod or node. |
 | `network_port` | `string` | An alias for `port` |
-| `node_addresses` | `string` | A map of the different Node addresses specified in the Node status object.  The key of the map is the address type and the value is the address string. The address types are `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`.  Most likely not all of these address types will be present for a given Node. |
-| `node_metadata` | `string` | The metadata about the Node, for `k8s-node` targets, with fields in TitleCase.  See [ObjectMeta v1 meta reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta). |
-| `node_spec` | `string` | The Node spec object, for `k8s-node` targets.  See [the K8s reference on this resource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodespec-v1-core), but keep in the mind that fields will be in TitleCase due to passing through Go. |
-| `node_status` | `string` | The Node status object, for `k8s-node` targets. See [the K8s reference on Node Status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodestatus-v1-core) but keep in mind that fields will be in TitleCase due to passing through Go. |
-| `pod_metadata` | `string` | The full pod metadata object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta. |
-| `pod_spec` | `string` | The full pod spec object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec. |
+| `node_addresses` | `map of strings` | A map of the different Node addresses specified in the Node status object.  The key of the map is the address type and the value is the address string. The address types are `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`.  Most likely not all of these address types will be present for a given Node. |
+| `node_metadata` | `node_metadata` | The metadata about the Node, for `k8s-node` targets, with fields in TitleCase.  See [ObjectMeta v1 meta reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta). |
+| `node_spec` | `node_spec` | The Node spec object, for `k8s-node` targets.  See [the K8s reference on this resource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodespec-v1-core), but keep in the mind that fields will be in TitleCase due to passing through Go. |
+| `node_status` | `node_status` | The Node status object, for `k8s-node` targets. See [the K8s reference on Node Status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodestatus-v1-core) but keep in mind that fields will be in TitleCase due to passing through Go. |
+| `pod_metadata` | `pod metadata` | The full pod metadata object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta. |
+| `pod_spec` | `pod spec` | The full pod spec object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec. |
 | `private_port` | `string` | The port that the service endpoint runs on inside the container |
 | `public_port` | `string` | The port exposed outside the container |
 | `alternate_port` | `integer` | Used for services that are accessed through some kind of NAT redirection as Docker does.  This could be either the public port or the private one. |

--- a/docs/observers/k8s-api.md
+++ b/docs/observers/k8s-api.md
@@ -63,7 +63,7 @@ can be used in discovery rules.
 | `container_name` | `string` | The first and primary name of the container as it is known to the container runtime (e.g. Docker). |
 | `has_port` | `string` | Set to `true` if the endpoint has a port assigned to it.  This will be `false` for endpoints that represent a host/container as a whole. |
 | `ip_address` | `string` | The IP address of the endpoint if the `host` is in the from of an IPv4 address |
-| `kubernetes_annotations` | `string` | The set of annotations on the discovered pod or node. |
+| `kubernetes_annotations` | `map of string` | A map that contains pod or node annotation key/value pairs. You can use the `Contains` and `Get` helper functions in discovery rules to make use of this. See [Endpoint Discovery](../auto-discovery.md#additional-functions). |
 | `network_port` | `string` | An alias for `port` |
 | `node_addresses` | `string` | A map of the different Node addresses specified in the Node status object.  The key of the map is the address type and the value is the address string. The address types are `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`.  Most likely not all of these address types will be present for a given Node. |
 | `node_metadata` | `string` | The metadata about the Node, for `k8s-node` targets, with fields in TitleCase.  See [ObjectMeta v1 meta reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta). |

--- a/pkg/observers/host/host.go
+++ b/pkg/observers/host/host.go
@@ -34,7 +34,7 @@ const (
 // ENDPOINT_VAR(command): The full command used to invoke this process,
 // including the executable itself at the beginning.
 
-// ENDPOINT_VAR(is_ipv6): Will be `true` if the endpoint is IPv6.
+// ENDPOINT_VAR(is_ipv6|bool): Will be `true` if the endpoint is IPv6.
 
 // Observer that watches the current host
 type Observer struct {

--- a/pkg/observers/kubernetes/api.go
+++ b/pkg/observers/kubernetes/api.go
@@ -74,31 +74,31 @@ const (
 // DIMENSION(kubernetes_node_uid): For Node (`k8s-node`) targets, the UID of
 // the Node
 
-// ENDPOINT_VAR(kubernetes_annotations): The set of annotations on the
+// ENDPOINT_VAR(kubernetes_annotations|map of strings): The set of annotations on the
 // discovered pod or node.
 
-// ENDPOINT_VAR(pod_spec): The full pod spec object, as represented by the Go
+// ENDPOINT_VAR(pod_spec|pod spec): The full pod spec object, as represented by the Go
 // K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec.
 
-// ENDPOINT_VAR(pod_metadata): The full pod metadata object, as represented by the Go
+// ENDPOINT_VAR(pod_metadata|pod metadata): The full pod metadata object, as represented by the Go
 // K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta.
 
-// ENDPOINT_VAR(node_metadata): The metadata about the Node, for `k8s-node`
+// ENDPOINT_VAR(node_metadata|node_metadata): The metadata about the Node, for `k8s-node`
 // targets, with fields in TitleCase.  See [ObjectMeta v1 meta
 // reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta).
 
-// ENDPOINT_VAR(node_spec): The Node spec object, for `k8s-node` targets.  See
+// ENDPOINT_VAR(node_spec|node_spec): The Node spec object, for `k8s-node` targets.  See
 // [the K8s reference on this
 // resource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodespec-v1-core),
 // but keep in the mind that fields will be in TitleCase due to passing through
 // Go.
 
-// ENDPOINT_VAR(node_status): The Node status object, for `k8s-node` targets.
+// ENDPOINT_VAR(node_status|node_status): The Node status object, for `k8s-node` targets.
 // See [the K8s reference on Node
 // Status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodestatus-v1-core)
 // but keep in mind that fields will be in TitleCase due to passing through Go.
 
-// ENDPOINT_VAR(node_addresses): A map of the different Node addresses
+// ENDPOINT_VAR(node_addresses|map of strings): A map of the different Node addresses
 // specified in the Node status object.  The key of the map is the address type
 // and the value is the address string. The address types are `Hostname`,
 // `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`.  Most likely not

--- a/pkg/selfdescribe/observers.go
+++ b/pkg/selfdescribe/observers.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/observers"
@@ -176,9 +177,15 @@ func endpointVarsFromStructMetadataFields(fields []fieldMetadata) []endpointVar 
 func endpointVariablesFromNotes(allDocs []*doc.Package, includeContainerVars bool) []endpointVar {
 	var endpointVars []endpointVar
 	for _, note := range notesFromDocs(allDocs, "ENDPOINT_VAR") {
+		uidSplit := strings.Split(note.UID, "|")
+		typ := "string"
+		if len(uidSplit) > 1 {
+			typ = uidSplit[1]
+		}
+
 		endpointVars = append(endpointVars, endpointVar{
-			Name:        note.UID,
-			Type:        "string",
+			Name:        uidSplit[0],
+			Type:        typ,
 			Description: commentTextToParagraphs(note.Body),
 		})
 	}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -54437,7 +54437,7 @@
         },
         {
           "name": "is_ipv6",
-          "type": "string",
+          "type": "bool",
           "elementKind": "",
           "description": "Will be `true` if the endpoint is IPv6."
         },
@@ -54635,7 +54635,7 @@
         },
         {
           "name": "kubernetes_annotations",
-          "type": "string",
+          "type": "map of strings",
           "elementKind": "",
           "description": "The set of annotations on the discovered pod or node."
         },
@@ -54647,37 +54647,37 @@
         },
         {
           "name": "node_addresses",
-          "type": "string",
+          "type": "map of strings",
           "elementKind": "",
           "description": "A map of the different Node addresses specified in the Node status object.  The key of the map is the address type and the value is the address string. The address types are `Hostname`, `ExternalIP`, `InternalIP`, `ExternalDNS`, `InternalDNS`.  Most likely not all of these address types will be present for a given Node."
         },
         {
           "name": "node_metadata",
-          "type": "string",
+          "type": "node_metadata",
           "elementKind": "",
           "description": "The metadata about the Node, for `k8s-node` targets, with fields in TitleCase.  See [ObjectMeta v1 meta reference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta)."
         },
         {
           "name": "node_spec",
-          "type": "string",
+          "type": "node_spec",
           "elementKind": "",
           "description": "The Node spec object, for `k8s-node` targets.  See [the K8s reference on this resource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodespec-v1-core), but keep in the mind that fields will be in TitleCase due to passing through Go."
         },
         {
           "name": "node_status",
-          "type": "string",
+          "type": "node_status",
           "elementKind": "",
           "description": "The Node status object, for `k8s-node` targets. See [the K8s reference on Node Status](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#nodestatus-v1-core) but keep in mind that fields will be in TitleCase due to passing through Go."
         },
         {
           "name": "pod_metadata",
-          "type": "string",
+          "type": "pod metadata",
           "elementKind": "",
           "description": "The full pod metadata object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/apimachinery/pkg/apis/meta/v1#ObjectMeta."
         },
         {
           "name": "pod_spec",
-          "type": "string",
+          "type": "pod spec",
           "elementKind": "",
           "description": "The full pod spec object, as represented by the Go K8s client library (client-go): https://godoc.org/k8s.io/api/core/v1#PodSpec."
         },


### PR DESCRIPTION
Simple docs update to reflect the correct type of the `kubernetes_annotations` target variable for the `k8s-api` observer.