### PR TITLE
Fix invalid config key, and remove old image reference

### DIFF
--- a/deployments/k8s/helm/splunk-dev-values.yaml
+++ b/deployments/k8s/helm/splunk-dev-values.yaml
@@ -9,13 +9,13 @@ splunkUrl: https://localhost:8088
 splunkToken: 00000000-0000-0000-0000-000000000000
 splunkSource: sfx
 splunkIndex: sfx
-splunkSkipTlsVerify: true
+splunkSkipTLSVerify: true
 
 clusterName: dev-cluster
 
 image:
-  repository: tmio/signalfx-agent-demo
-  tag: 5.1.3
+  repository: quay.io/signalfx/signalfx-agent-dev
+  tag: 5.3.1
   pullPolicy: Always
 fullnameOverride: agent
 


### PR DESCRIPTION
This PR touches the sample values file used when developing with the agent on helm.

I noticed that one config key was wrong, and the image referenced was old and pointing at my docker account. I fixed both issues.