### PR TITLE
kubernetes-volume: add dimensions for other volume types

### DIFF
--- a/docs/monitors/kubernetes-volumes.md
+++ b/docs/monitors/kubernetes-volumes.md
@@ -19,8 +19,9 @@ dynamically and older versions of K8s don't support mount propagation of
 those mounts to the agent container.
 
 Dimensions that identify the underlying volume source will be added for
-`awsElasticBlockStore` and `glusterfs` volumes.  Support for more can be
-easily added as needed.
+`awsElasticBlockStore`, `gcePersistentDisk` and `glusterfs` persistent
+volumes, and for `configMap`, `downwardAPI`, `emptyDir` and `secret`
+non-persistent volumes. Support for more can be easily added as needed.
 
 
 ## Configuration
@@ -101,13 +102,15 @@ dimensions may be specific to certain metrics.
 | ---  | ---         |
 | `VolumeId` | (*EBS volumes only*) The EBS volume id of the underlying volume source |
 | `endpoints_name` | (*GlusterFS volumes only*) The endpoint name used for the GlusterFS volume |
+| `fs_type` | (*EBS volumes and GCE persistent disks only*) The filesystem type of the underlying EBS volume or GCE persistent disk |
 | `glusterfs_path` | (*GlusterFS volumes only*) The GlusterFS volume path |
 | `kubernetes_namespace` | The namespace of the pod that has this volume |
 | `kubernetes_pod_name` | The name of the pod that has this volume |
 | `kubernetes_pod_uid` | The UID of the pod that has this volume |
-| `partition` | (*EBS volumes only*) The partition number of the underlying EBS volume (`0` indicates the entire disk) |
+| `partition` | (*EBS volumes and GCE persistent disks only*) The partition number of the underlying EBS volume or GCE persistent disk (`0` indicates the entire disk) |
+| `pd_name` | (*GCE persistent disks only*) The GCE persistent disk name of the underlying volume source |
 | `volume` | The volume name as given in the pod spec under `volumes` |
-| `volume_type` | The type of the underlying volume -- this will be the key used in the k8s volume config spec (e.g. awsElasticBlockStore, etc.) |
+| `volume_type` | The type of the underlying volume -- this will be the key used in the k8s volume config spec (e.g. `awsElasticBlockStore`, `gcePersistentDisk`, `configMap`, `secret`, etc.) |
 
 
 

--- a/pkg/monitors/kubernetes/volumes/metadata.yaml
+++ b/pkg/monitors/kubernetes/volumes/metadata.yaml
@@ -3,6 +3,9 @@ monitors:
     VolumeId:
       description: (*EBS volumes only*) The EBS volume id of the underlying volume
         source
+    pd_name:
+      description: (*GCE persistent disks only*) The GCE persistent disk name of the
+        underlying volume source
     endpoints_name:
       description: (*GlusterFS volumes only*) The endpoint name used for the GlusterFS
         volume
@@ -14,14 +17,19 @@ monitors:
       description: The name of the pod that has this volume
     kubernetes_pod_uid:
       description: The UID of the pod that has this volume
+    fs_type:
+      description: (*EBS volumes and GCE persistent disks only*) The filesystem type of
+        the underlying EBS volume or GCE persistent disk
     partition:
-      description: (*EBS volumes only*) The partition number of the underlying EBS
-        volume (`0` indicates the entire disk)
+      description: (*EBS volumes and GCE persistent disks only*) The partition number of
+        the underlying EBS volume or GCE persistent disk (`0` indicates the
+        entire disk)
     volume:
       description: The volume name as given in the pod spec under `volumes`
     volume_type:
       description: The type of the underlying volume -- this will be the key used
-        in the k8s volume config spec (e.g. awsElasticBlockStore, etc.)
+        in the k8s volume config spec (e.g. `awsElasticBlockStore`,
+        `gcePersistentDisk`, `configMap`, `secret`, etc.)
   doc: |
     This monitor sends usage stats about volumes
     mounted to Kubernetes pods (e.g. free space/inodes).  This information is
@@ -32,8 +40,9 @@ monitors:
     those mounts to the agent container.
 
     Dimensions that identify the underlying volume source will be added for
-    `awsElasticBlockStore` and `glusterfs` volumes.  Support for more can be
-    easily added as needed.
+    `awsElasticBlockStore`, `gcePersistentDisk` and `glusterfs` persistent
+    volumes, and for `configMap`, `downwardAPI`, `emptyDir` and `secret`
+    non-persistent volumes. Support for more can be easily added as needed.
   sendAll: false
   metrics:
     kubernetes.volume_available_bytes:

--- a/pkg/monitors/kubernetes/volumes/pvdim.go
+++ b/pkg/monitors/kubernetes/volumes/pvdim.go
@@ -48,11 +48,12 @@ func findVolumeInPod(pod *v1.Pod, volName string) *v1.Volume {
 
 func dimsForPersistentVolumeSource(pvs v1.PersistentVolumeSource) map[string]string {
 	// IF YOU ADD A NEW PERSISTENT TYPE HERE, ADD IT IN dimsForVolumeSource BELOW TOO!
-	if pvs.AWSElasticBlockStore != nil {
+	switch {
+	case pvs.AWSElasticBlockStore != nil:
 		return awsElasticBlockStoreDims(*pvs.AWSElasticBlockStore)
-	} else if pvs.GCEPersistentDisk != nil {
+	case pvs.GCEPersistentDisk != nil:
 		return gcePersistentDiskDims(*pvs.GCEPersistentDisk)
-	} else if pvs.Glusterfs != nil {
+	case pvs.Glusterfs != nil:
 		// Special case for pvs.Glusterfs as it is a GlusterfsPersistentVolumeSource instead of GlusterfsVolumeSource
 		return glusterfsDims(v1.GlusterfsVolumeSource{
 			EndpointsName: pvs.Glusterfs.EndpointsName,

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -39639,6 +39639,9 @@
         "endpoints_name": {
           "description": "(*GlusterFS volumes only*) The endpoint name used for the GlusterFS volume"
         },
+        "fs_type": {
+          "description": "(*EBS volumes and GCE persistent disks only*) The filesystem type of the underlying EBS volume or GCE persistent disk"
+        },
         "glusterfs_path": {
           "description": "(*GlusterFS volumes only*) The GlusterFS volume path"
         },
@@ -39652,16 +39655,19 @@
           "description": "The UID of the pod that has this volume"
         },
         "partition": {
-          "description": "(*EBS volumes only*) The partition number of the underlying EBS volume (`0` indicates the entire disk)"
+          "description": "(*EBS volumes and GCE persistent disks only*) The partition number of the underlying EBS volume or GCE persistent disk (`0` indicates the entire disk)"
+        },
+        "pd_name": {
+          "description": "(*GCE persistent disks only*) The GCE persistent disk name of the underlying volume source"
         },
         "volume": {
           "description": "The volume name as given in the pod spec under `volumes`"
         },
         "volume_type": {
-          "description": "The type of the underlying volume -- this will be the key used in the k8s volume config spec (e.g. awsElasticBlockStore, etc.)"
+          "description": "The type of the underlying volume -- this will be the key used in the k8s volume config spec (e.g. `awsElasticBlockStore`, `gcePersistentDisk`, `configMap`, `secret`, etc.)"
         }
       },
-      "doc": "This monitor sends usage stats about volumes\nmounted to Kubernetes pods (e.g. free space/inodes).  This information is\ngotten from the Kubelet /stats/summary endpoint.  The normal `filesystems`\nmonitor generally will not report Persistent Volume usage metrics because\nthose volumes are not seen by the agent since they can be mounted\ndynamically and older versions of K8s don't support mount propagation of\nthose mounts to the agent container.\n\nDimensions that identify the underlying volume source will be added for\n`awsElasticBlockStore` and `glusterfs` volumes.  Support for more can be\neasily added as needed.\n",
+      "doc": "This monitor sends usage stats about volumes\nmounted to Kubernetes pods (e.g. free space/inodes).  This information is\ngotten from the Kubelet /stats/summary endpoint.  The normal `filesystems`\nmonitor generally will not report Persistent Volume usage metrics because\nthose volumes are not seen by the agent since they can be mounted\ndynamically and older versions of K8s don't support mount propagation of\nthose mounts to the agent container.\n\nDimensions that identify the underlying volume source will be added for\n`awsElasticBlockStore`, `gcePersistentDisk` and `glusterfs` persistent\nvolumes, and for `configMap`, `downwardAPI`, `emptyDir` and `secret`\nnon-persistent volumes. Support for more can be easily added as needed.\n",
       "groups": {
         "": {
           "description": "",


### PR DESCRIPTION
Add dimensions to kubernetes-volume monitor for:
- persistent volumes: GCE
- non persistent volumes: ConfigMaps, DownwardAPI, EmptyDir, and Secret