### PR TITLE
processlist monitor: Change double quotes to single quotes in process…

### DIFF
--- a/pkg/monitors/processlist/processlist.go
+++ b/pkg/monitors/processlist/processlist.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/signalfx/golib/v3/event"
@@ -160,9 +161,9 @@ func (m *Monitor) encodeProcess(proc *TopProcess, sampleInterval time.Duration) 
 		nice = strconv.Itoa(*proc.Nice)
 	}
 
-	return fmt.Sprintf("\"%d\":[\"%s\",%d,\"%s\",%d,%d,%d,\"%s\",%.2f,%.2f,\"%s\",\"%s\"]",
+	return fmt.Sprintf(`"%d":["%s",%d,"%s",%d,%d,%d,"%s",%.2f,%.2f,"%s","%s"]`,
 		proc.ProcessID,
-		proc.Username,
+		strings.ReplaceAll(proc.Username, `"`, "'"),
 		proc.Priority,
 		nice,
 		proc.VirtualMemoryBytes/1024,
@@ -172,7 +173,7 @@ func (m *Monitor) encodeProcess(proc *TopProcess, sampleInterval time.Duration) 
 		cpuPercent,
 		proc.MemPercent,
 		toTime(proc.TotalCPUTime.Seconds()),
-		proc.Command,
+		strings.ReplaceAll(proc.Command, `"`, `'`),
 	)
 }
 

--- a/pkg/monitors/processlist/processlist_windows_test.go
+++ b/pkg/monitors/processlist/processlist_windows_test.go
@@ -69,6 +69,37 @@ func TestMonitor_Configure(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "handles nested quotes",
+			m:    &Monitor{Output: neotest.NewTestOutput()},
+			processes: []Win32Process{
+				{
+					Name:           "test-proc",
+					ExecutablePath: pointer.String("C:\\HelloWorld2\"quoted\".exe"),
+					CommandLine:    pointer.String("HelloWorld2.exe"),
+					Priority:       8,
+					ProcessID:      0,
+					Status:         pointer.String(""),
+					ExecutionState: pointer.Uint16(0),
+					KernelModeTime: 1500,
+					PageFileUsage:  1600,
+					UserModeTime:   1700,
+					WorkingSetSize: 1800,
+					VirtualSize:    1900,
+				},
+			},
+			usernames: map[uint32]string{
+				0: "ted\"bud\"Mosby",
+			},
+			want: &event.Event{
+				EventType:  "objects.top-info",
+				Category:   event.AGENT,
+				Dimensions: map[string]string{},
+				Properties: map[string]interface{}{
+					"message": "{\"t\":\"eJyqVjJQsopWKklNUU8qTVH3zS9OqlTSsdBRKs3Lzssvz1PSMdQx1DHQUVLSMdAzMIAQSgYGVgYglpKOkrNVTIxHak5Ofnh+UU6KkXphaT7IML3UilSl2FpAAAAA///fVRrM\",\"v\":\"0.0.30\"}",
+				},
+			},
+		},
 	}
 	for i := range tests {
 		origGetAllProcesses := getAllProcesses


### PR DESCRIPTION
… string fields

The backend cannot handle even escaped double quotes.