### PR TITLE
Enable SlaveStats option on MySQL plugin

### DIFF
--- a/docs/monitors/collectd-mysql.md
+++ b/docs/monitors/collectd-mysql.md
@@ -90,6 +90,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `password` | no | `string` |  |
 | `reportHost` | no | `bool` | A SignalFx extension to the plugin that allows us to disable the normal behavior of the MySQL collectd plugin where the `host` dimension is set to the hostname of the MySQL database server.  When `false` (the recommended and default setting), the globally configured `hostname` config is used instead. (**default:** `false`) |
 | `innodbStats` | no | `bool` |  (**default:** `false`) |
+| `slaveStats` | no | `bool` |  (**default:** `false`) |
 
 
 The **nested** `databases` config object has the following fields:
@@ -314,9 +315,12 @@ Metrics that are categorized as
  - `mysql_sort.scan` (*cumulative*)<br>    The number of sorts that were done by scanning the table.
  - `mysql_sort_merge_passes` (*cumulative*)<br>    The number of merge passes done by the sorting algorithm.
  - `mysql_sort_rows` (*cumulative*)<br>    The number of rows that were sorted.
+ - `slave-io-running` (*gauge*)<br>    Whether the I/O thread for reading the master's binary log is running.
+ - `slave-sql-running` (*gauge*)<br>    Whether the SQL thread for executing events in the relay log is running.
  - ***`threads.cached`*** (*gauge*)<br>    The number of threads cached by MySQL for re-use on a new client connection.  A MySQL thread corresponds to a single MySQL connection.
  - ***`threads.connected`*** (*gauge*)<br>    The number of currently open MySQL connections.  A MySQL thread corresponds to a single MySQL connection.
  - `threads.running` (*gauge*)<br>    The number of MySQL threads that are processing a query.  A MySQL thread corresponds to a single MySQL connection.
+ - `time-offset` (*gauge*)<br>    The number of seconds that the slave SQL thread is behind processing the master binary log.
  - `total_threads.created` (*cumulative*)<br>    The total number of threads created by MySQL for client connections.  A MySQL thread corresponds to a single MySQL connection.
 
 ### Non-default metrics (version 4.7.0+)

--- a/docs/monitors/collectd-mysql.md
+++ b/docs/monitors/collectd-mysql.md
@@ -90,6 +90,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `password` | no | `string` |  |
 | `reportHost` | no | `bool` | A SignalFx extension to the plugin that allows us to disable the normal behavior of the MySQL collectd plugin where the `host` dimension is set to the hostname of the MySQL database server.  When `false` (the recommended and default setting), the globally configured `hostname` config is used instead. (**default:** `false`) |
 | `innodbStats` | no | `bool` |  (**default:** `false`) |
+| `masterStats` | no | `bool` |  (**default:** `false`) |
 | `slaveStats` | no | `bool` |  (**default:** `false`) |
 
 
@@ -303,6 +304,7 @@ Metrics that are categorized as
  - `mysql_innodb_rows.updated` (*cumulative*)<br>    The number of rows updated in InnoDB tables.
  - ***`mysql_locks.immediate`*** (*cumulative*)<br>    The number of MySQL table locks which were granted immediately.
  - ***`mysql_locks.waited`*** (*cumulative*)<br>    The number of MySQL table locks which had to wait before being granted.
+ - `mysql_log_position.master-bin` (*cumulative*)<br>    Current log file position.
  - ***`mysql_octets.rx`*** (*cumulative*)<br>    The number of bytes received by MySQL server from all clients.
  - ***`mysql_octets.tx`*** (*cumulative*)<br>    The number of bytes sent by MySQL server to all clients.
  - `mysql_select.full_join` (*cumulative*)<br>    The number of joins that perform full table scans.

--- a/pkg/monitors/collectd/mysql/genmetadata.go
+++ b/pkg/monitors/collectd/mysql/genmetadata.go
@@ -217,9 +217,12 @@ const (
 	mysqlSortScan                      = "mysql_sort.scan"
 	mysqlSortMergePasses               = "mysql_sort_merge_passes"
 	mysqlSortRows                      = "mysql_sort_rows"
+	slaveIoRunning                     = "slave-io-running"
+	slaveSQLRunning                    = "slave-sql-running"
 	threadsCached                      = "threads.cached"
 	threadsConnected                   = "threads.connected"
 	threadsRunning                     = "threads.running"
+	timeOffset                         = "time-offset"
 	totalThreadsCreated                = "total_threads.created"
 )
 
@@ -429,9 +432,12 @@ var metricSet = map[string]monitors.MetricInfo{
 	mysqlSortScan:                      {Type: datapoint.Counter},
 	mysqlSortMergePasses:               {Type: datapoint.Counter},
 	mysqlSortRows:                      {Type: datapoint.Counter},
+	slaveIoRunning:                     {Type: datapoint.Gauge},
+	slaveSQLRunning:                    {Type: datapoint.Gauge},
 	threadsCached:                      {Type: datapoint.Gauge},
 	threadsConnected:                   {Type: datapoint.Gauge},
 	threadsRunning:                     {Type: datapoint.Gauge},
+	timeOffset:                         {Type: datapoint.Gauge},
 	totalThreadsCreated:                {Type: datapoint.Counter},
 }
 

--- a/pkg/monitors/collectd/mysql/genmetadata.go
+++ b/pkg/monitors/collectd/mysql/genmetadata.go
@@ -205,6 +205,7 @@ const (
 	mysqlInnodbRowsUpdated             = "mysql_innodb_rows.updated"
 	mysqlLocksImmediate                = "mysql_locks.immediate"
 	mysqlLocksWaited                   = "mysql_locks.waited"
+	mysqlLogPositionMasterBin          = "mysql_log_position.master-bin"
 	mysqlOctetsRx                      = "mysql_octets.rx"
 	mysqlOctetsTx                      = "mysql_octets.tx"
 	mysqlSelectFullJoin                = "mysql_select.full_join"
@@ -420,6 +421,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	mysqlInnodbRowsUpdated:             {Type: datapoint.Counter},
 	mysqlLocksImmediate:                {Type: datapoint.Counter},
 	mysqlLocksWaited:                   {Type: datapoint.Counter},
+	mysqlLogPositionMasterBin:          {Type: datapoint.Counter},
 	mysqlOctetsRx:                      {Type: datapoint.Counter},
 	mysqlOctetsTx:                      {Type: datapoint.Counter},
 	mysqlSelectFullJoin:                {Type: datapoint.Counter},

--- a/pkg/monitors/collectd/mysql/metadata.yaml
+++ b/pkg/monitors/collectd/mysql/metadata.yaml
@@ -914,5 +914,9 @@ monitors:
       description: The number of seconds that the slave SQL thread is behind processing the master binary log.
       default: false
       type: gauge
+    mysql_log_position.master-bin:
+      description: Current log file position.
+      default: false
+      type: cumulative
   monitorType: collectd/mysql
   properties:

--- a/pkg/monitors/collectd/mysql/metadata.yaml
+++ b/pkg/monitors/collectd/mysql/metadata.yaml
@@ -902,5 +902,17 @@ monitors:
       description: The number of rows updated in InnoDB tables.
       default: false
       type: cumulative
+    slave-sql-running:
+      description: Whether the SQL thread for executing events in the relay log is running.
+      default: false
+      type: gauge
+    slave-io-running:
+      description: Whether the I/O thread for reading the master's binary log is running.
+      default: false
+      type: gauge
+    time-offset:
+      description: The number of seconds that the slave SQL thread is behind processing the master binary log.
+      default: false
+      type: gauge
   monitorType: collectd/mysql
   properties:

--- a/pkg/monitors/collectd/mysql/mysql.go
+++ b/pkg/monitors/collectd/mysql/mysql.go
@@ -46,6 +46,7 @@ type Config struct {
 	// config is used instead.
 	ReportHost  bool `yaml:"reportHost"`
 	InnodbStats bool `yaml:"innodbStats"`
+	MasterStats bool `yaml:"masterStats"`
 	SlaveStats  bool `yaml:"slaveStats"`
 }
 

--- a/pkg/monitors/collectd/mysql/mysql.go
+++ b/pkg/monitors/collectd/mysql/mysql.go
@@ -46,6 +46,7 @@ type Config struct {
 	// config is used instead.
 	ReportHost  bool `yaml:"reportHost"`
 	InnodbStats bool `yaml:"innodbStats"`
+	SlaveStats  bool `yaml:"slaveStats"`
 }
 
 // Validate will check the config for correctness.

--- a/pkg/monitors/collectd/mysql/mysql.tmpl
+++ b/pkg/monitors/collectd/mysql/mysql.tmpl
@@ -8,6 +8,7 @@
     Host "{{$.Host}}"
     Port {{$.Port}}
     Database "{{$db.Name}}"
+    SlaveStats {{toBool $.SlaveStats}}
     {{if $db.Username -}}User "{{$db.Username}}"{{else if $.Username}}User "{{$.Username}}"{{- end}}
     {{if $db.Password -}}Password "{{$db.Password}}"{{else if $.Password}}Password "{{$.Password}}"{{- end}}
     InnodbStats {{toBool $.InnodbStats}}

--- a/pkg/monitors/collectd/mysql/mysql.tmpl
+++ b/pkg/monitors/collectd/mysql/mysql.tmpl
@@ -8,6 +8,7 @@
     Host "{{$.Host}}"
     Port {{$.Port}}
     Database "{{$db.Name}}"
+    MasterStats {{toBool $.MasterStats}}
     SlaveStats {{toBool $.SlaveStats}}
     {{if $db.Username -}}User "{{$db.Username}}"{{else if $.Username}}User "{{$.Username}}"{{- end}}
     {{if $db.Password -}}Password "{{$db.Password}}"{{else if $.Password}}Password "{{$.Password}}"{{- end}}

--- a/pkg/monitors/collectd/mysql/template.go
+++ b/pkg/monitors/collectd/mysql/template.go
@@ -22,6 +22,7 @@ var CollectdTemplate = template.Must(collectd.InjectTemplateFuncs(template.New("
     Host "{{$.Host}}"
     Port {{$.Port}}
     Database "{{$db.Name}}"
+    MasterStats {{toBool $.MasterStats}}
     SlaveStats {{toBool $.SlaveStats}}
     {{if $db.Username -}}User "{{$db.Username}}"{{else if $.Username}}User "{{$.Username}}"{{- end}}
     {{if $db.Password -}}Password "{{$db.Password}}"{{else if $.Password}}Password "{{$.Password}}"{{- end}}

--- a/pkg/monitors/collectd/mysql/template.go
+++ b/pkg/monitors/collectd/mysql/template.go
@@ -22,6 +22,7 @@ var CollectdTemplate = template.Must(collectd.InjectTemplateFuncs(template.New("
     Host "{{$.Host}}"
     Port {{$.Port}}
     Database "{{$db.Name}}"
+    SlaveStats {{toBool $.SlaveStats}}
     {{if $db.Username -}}User "{{$db.Username}}"{{else if $.Username}}User "{{$.Username}}"{{- end}}
     {{if $db.Password -}}Password "{{$db.Password}}"{{else if $.Password}}Password "{{$.Password}}"{{- end}}
     InnodbStats {{toBool $.InnodbStats}}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -15584,9 +15584,12 @@
             "mysql_sort.scan",
             "mysql_sort_merge_passes",
             "mysql_sort_rows",
+            "slave-io-running",
+            "slave-sql-running",
             "threads.cached",
             "threads.connected",
             "threads.running",
+            "time-offset",
             "total_threads.created"
           ]
         }
@@ -16822,6 +16825,18 @@
           "group": null,
           "default": false
         },
+        "slave-io-running": {
+          "type": "gauge",
+          "description": "Whether the I/O thread for reading the master's binary log is running.",
+          "group": null,
+          "default": false
+        },
+        "slave-sql-running": {
+          "type": "gauge",
+          "description": "Whether the SQL thread for executing events in the relay log is running.",
+          "group": null,
+          "default": false
+        },
         "threads.cached": {
           "type": "gauge",
           "description": "The number of threads cached by MySQL for re-use on a new client connection.  A MySQL thread corresponds to a single MySQL connection.",
@@ -16837,6 +16852,12 @@
         "threads.running": {
           "type": "gauge",
           "description": "The number of MySQL threads that are processing a query.  A MySQL thread corresponds to a single MySQL connection.",
+          "group": null,
+          "default": false
+        },
+        "time-offset": {
+          "type": "gauge",
+          "description": "The number of seconds that the slave SQL thread is behind processing the master binary log.",
           "group": null,
           "default": false
         },
@@ -16942,6 +16963,14 @@
           },
           {
             "yamlName": "innodbStats",
+            "doc": "",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "slaveStats",
             "doc": "",
             "default": false,
             "required": false,

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -15572,6 +15572,7 @@
             "mysql_innodb_rows.updated",
             "mysql_locks.immediate",
             "mysql_locks.waited",
+            "mysql_log_position.master-bin",
             "mysql_octets.rx",
             "mysql_octets.tx",
             "mysql_select.full_join",
@@ -16753,6 +16754,12 @@
           "group": null,
           "default": true
         },
+        "mysql_log_position.master-bin": {
+          "type": "cumulative",
+          "description": "Current log file position.",
+          "group": null,
+          "default": false
+        },
         "mysql_octets.rx": {
           "type": "cumulative",
           "description": "The number of bytes received by MySQL server from all clients.",
@@ -16963,6 +16970,14 @@
           },
           {
             "yamlName": "innodbStats",
+            "doc": "",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "masterStats",
             "doc": "",
             "default": false,
             "required": false,


### PR DESCRIPTION
According to the [MySQL plugin documentation](https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_mysql) the `SlaveStats` can be used to report information on the slave state and wether there is some delay or not compared to the master.

Since this PR https://github.com/collectd/collectd/pull/3463/files, slave threads informations are now reported as gauge and not only as notification, it seems that this PR is not yet included in https://github.com/signalfx/collectd/ and so not available in the agent (according to my tests) . Do you think it is possible to include those changes in the signalfx collectd process ?

This PR allows the reporting of those three new metrics once they will be available in the agent.

Thanks.

EDIT : also added the master stats option to have the full support of the plugin on replication.