### PR TITLE
ability to enable perCpu for load monitor in helm

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -106,6 +106,9 @@ data:
     - type: disk-io
     - type: net-io
     - type: load
+      {{- if .Values.loadPerCPU }}
+      perCPU: true
+      {{- end }}
     - type: memory
     - type: host-metadata
     - type: processlist

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -263,6 +263,11 @@ hostFSPath: /hostfs
 # monitors will be configured.
 configureStandardMonitors: true
 
+# If true, this will set the `perCPU` config option to `true` on `load`
+# standard monitor so the metric will be the average load per CPU.
+# Has no effect if `configureStandardMonitors: false`
+loadPerCPU: false
+
 # A list of monitor configurations to include in the agent config.  These
 # values correspond exactly to what goes under 'monitors' in the agent config.
 monitors:


### PR DESCRIPTION
I understand we do not want to enable perCPU by default for retro compability purpose with collectd but, in my opinion, this metric is not usable withtout perCPU in a detector / alerting scope so we need, at least, an easy way override default value. 