### PR TITLE
Update devstack release to stein

### DIFF
--- a/test-services/devstack/Dockerfile
+++ b/test-services/devstack/Dockerfile
@@ -48,13 +48,13 @@ RUN systemctl enable rabbitmq-server
 RUN useradd -s /bin/bash -d /opt/stack -m stack && echo "stack ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/stack && \
     usermod -a -G mysql,rabbitmq stack
 
-RUN su - stack -c 'git clone git://git.openstack.org/openstack-dev/devstack -b stable/rocky /opt/stack/devstack'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/cinder -b stable/rocky /opt/stack/cinder'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/glance -b stable/rocky /opt/stack/glance'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/keystone -b stable/rocky /opt/stack/keystone'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/neutron -b stable/rocky /opt/stack/neutron'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/nova -b stable/rocky /opt/stack/nova'
-RUN su - stack -c 'git clone git://git.openstack.org/openstack/requirements -b stable/rocky /opt/stack/requirements'
+RUN su - stack -c 'git clone https://opendev.org/openstack/devstack -b stable/stein /opt/stack/devstack'
+RUN su - stack -c 'git clone https://opendev.org/openstack/cinder -b stable/stein /opt/stack/cinder'
+RUN su - stack -c 'git clone https://opendev.org/openstack/glance -b stable/stein /opt/stack/glance'
+RUN su - stack -c 'git clone https://opendev.org/openstack/keystone -b stable/stein /opt/stack/keystone'
+RUN su - stack -c 'git clone https://opendev.org/openstack/neutron -b stable/stein /opt/stack/neutron'
+RUN su - stack -c 'git clone https://opendev.org/openstack/nova -b stable/stein /opt/stack/nova'
+RUN su - stack -c 'git clone https://opendev.org/openstack/requirements -b stable/stein /opt/stack/requirements'
 
 RUN find /opt/stack/ -name "test-requirements.txt" -delete
 RUN find /opt/stack/ -mindepth 3 -name "*requirements.txt" -delete

--- a/tests/monitors/openstack/openstack_test.py
+++ b/tests/monitors/openstack/openstack_test.py
@@ -23,7 +23,7 @@ DEFAULT_METRICS = METADATA.default_metrics - {
 
 
 @pytest.mark.flaky(reruns=1)
-def test_openstacki_default(devstack):
+def test_openstack_default(devstack):
     host = container_ip(devstack)
     run_agent_verify(
         f"""


### PR DESCRIPTION
- Workaround for https://bugs.launchpad.net/devstack/+bug/1883468 which
causes devstack to fail on startup on older versions
- Update relocated git urls for devstack repos