### PR TITLE
Fix leak of tokens in processlist monitor on Windows

### DIFF
--- a/pkg/monitors/processlist/processlist_windows.go
+++ b/pkg/monitors/processlist/processlist_windows.go
@@ -63,8 +63,7 @@ var getUsername = func(id uint32) (username string, err error) {
 	}
 	// Deferring CloseHandle(h) before it is set require a reference on the closure, avoid that
 	// by only deferring it only after the handle is successfully opened.
-	defer windows.CloseHandle(h)
-
+	defer func(h windows.Handle) { _ = windows.CloseHandle(h) }(h)
 
 	// the windows api docs suggest that windows.TOKEN_READ is a super set of windows.TOKEN_QUERY,
 	// but in practice windows.TOKEN_READ seems to be less permissive for the admin user


### PR DESCRIPTION
The defer call of token.Close() can only be made after the value of the
token is set, otherwise, it "closes" an invalid handle.