### PR TITLE
k8s: restrict configmap permissions to single namespace

### DIFF
--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -31,14 +31,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
-  - ""
-  resources:
   - nodes/stats
   verbs:
   - get

--- a/deployments/k8s/configmap-role.yaml
+++ b/deployments/k8s/configmap-role.yaml
@@ -1,0 +1,18 @@
+---
+# Source: signalfx-agent/templates/configmap-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE
+  labels:
+    app: signalfx-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create

--- a/deployments/k8s/configmap-rolebinding.yaml
+++ b/deployments/k8s/configmap-rolebinding.yaml
@@ -1,0 +1,17 @@
+---
+# Source: signalfx-agent/templates/configmap-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE
+  labels:
+    app: signalfx-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: signalfx-agent
+subjects:
+- kind: ServiceAccount
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE

--- a/deployments/k8s/generate-from-helm
+++ b/deployments/k8s/generate-from-helm
@@ -27,7 +27,7 @@ render() {
       --output-dir $tmpdir \
       $AGENT_CHART_DIR
 
-  templates="configmap.yaml daemonset.yaml deployment.yaml clusterrole.yaml clusterrolebinding.yaml serviceaccount.yaml"
+  templates="configmap.yaml daemonset.yaml deployment.yaml clusterrole.yaml clusterrolebinding.yaml serviceaccount.yaml configmap-role.yaml configmap-rolebinding.yaml"
   for f in $templates; do
 	fullpath=$tmpdir/signalfx-agent/templates/$f
 	if [[ "$f" == "daemonset.yaml" && $isServerless == "true" ]]; then
@@ -37,6 +37,16 @@ render() {
 	if [[ "$f" == "deployment.yaml" && $isServerless == "false" ]]; then
 	  continue
 	fi
+
+    if [[ "$f" == "configmap-role.yaml" || "$f" == "configmap-rolebinding.yaml" ]]; then
+        cat $fullpath | \
+            sed -e 's/namespace: signalfx-agent/namespace: MY_AGENT_NAMESPACE/' -e 's/[[:space:]]*$//'  | \
+            grep -v 'chart: signalfx-agent' | \
+            grep -v 'heritage: Helm' | \
+            grep -iv 'release: signalfx-agent' \
+          > $outdir/$f
+        continue
+    fi
 
     cat $fullpath | \
         sed -e 's/[[:space:]]*$//' | \

--- a/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
@@ -36,14 +36,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
-  - ""
-  resources:
   - nodes/stats
   verbs:
   - get

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap-role.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap-role.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
+  labels:
+    app: {{ template "signalfx-agent.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "signalfx-agent.chart" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create
+{{- end -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap-rolebinding.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap-rolebinding.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
+  labels:
+    app: {{ template "signalfx-agent.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "signalfx-agent.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "signalfx-agent.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "signalfx-agent.serviceAccountName" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
+{{- end -}}

--- a/deployments/k8s/serverless/clusterrole.yaml
+++ b/deployments/k8s/serverless/clusterrole.yaml
@@ -31,14 +31,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
-  verbs:
-  - get
-  - update
-  - create
-- apiGroups:
-  - ""
-  resources:
   - nodes/stats
   verbs:
   - get

--- a/deployments/k8s/serverless/configmap-role.yaml
+++ b/deployments/k8s/serverless/configmap-role.yaml
@@ -1,0 +1,18 @@
+---
+# Source: signalfx-agent/templates/configmap-role.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE
+  labels:
+    app: signalfx-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - create

--- a/deployments/k8s/serverless/configmap-rolebinding.yaml
+++ b/deployments/k8s/serverless/configmap-rolebinding.yaml
@@ -1,0 +1,17 @@
+---
+# Source: signalfx-agent/templates/configmap-rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE
+  labels:
+    app: signalfx-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: signalfx-agent
+subjects:
+- kind: ServiceAccount
+  name: signalfx-agent
+  namespace: MY_AGENT_NAMESPACE


### PR DESCRIPTION
Adds two new files configmap-role.yaml and configmap-rolebinding.yaml
and binds the role to the existing ServiceAccount. This allows
for the agent to only be permitted to view configmaps in the
namespace where the agent is running.