### PR TITLE
Add Windows Docker Support

### DIFF
--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,0 +1,24 @@
+FROM golang:1.14-windowsservercore-1809 as builder
+
+WORKDIR C:\\SignalFxAgent
+
+COPY go.* ./
+
+RUN go mod download -x
+
+RUN go get github.com/mauricelam/genny
+
+COPY ./cmd/ ./cmd/
+COPY ./scripts/windows/ ./scripts/windows/
+COPY ./pkg/ ./pkg/
+
+ARG AGENT_VERSION="latest"
+
+RUN powershell .\scripts\windows\make.ps1 signalfx-agent
+
+FROM mcr.microsoft.com/windows/servercore:1809
+
+WORKDIR C:\\SignalFxAgent
+COPY --from=builder C:\\SignalFxAgent\\signalfx-agent.exe .
+CMD ["signalfx-agent.exe", "-service", "bypass"]
+

--- a/cmd/agent/agentmain/windows.go
+++ b/cmd/agent/agentmain/windows.go
@@ -80,6 +80,11 @@ func (p *program) Stop(s service.Service) error {
 func runAgentPlatformSpecific(flags *flags, interruptCh chan os.Signal, exitCh chan struct{}) {
 	initializeWMI()
 
+	if flags.service == "bypass" {
+		runAgent(flags, interruptCh, exitCh)
+		return
+	}
+
 	config := &service.Config{
 		Name:        flags.serviceName,
 		DisplayName: flags.serviceDisplayName,

--- a/deployments/k8s/README.md
+++ b/deployments/k8s/README.md
@@ -85,6 +85,9 @@ The [serverless](./serverless) directory contains a set of sample YAML
 resources that you can start from to deploy the agent in a serverless K8s
 environment.
 
+## Windows
+If you are deploying to a mixed Windows/Linux Kubernetes cluster, see [Windows](./helm/signalfx-agent#windows) in the Helm chart README.
+
 ## Development
 
 These resources can be refreshed from the Helm chart by using the

--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   - namespaces/status
   - nodes
   - nodes/spec
+  - nodes/proxy
   - pods
   - pods/status
   - replicationcontrollers

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -56,6 +56,8 @@ data:
         authType: serviceAccount
       usePodsEndpoint: true
 
+
+
     # Collects k8s cluster-level metrics
     - type: kubernetes-cluster
 
@@ -72,6 +74,7 @@ data:
 
 
     collectd:
+
       readThreads: 5
       writeQueueLimitHigh: 500000
       writeQueueLimitLow: 400000

--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -31,6 +31,8 @@ spec:
       restartPolicy: Always
       serviceAccountName: signalfx-agent
 
+      nodeSelector:
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         key: node.alpha.kubernetes.io/role
@@ -48,9 +50,6 @@ spec:
         volumeMounts:
         - mountPath: /etc/signalfx
           name: config
-        - mountPath: /etc/machine-id
-          name: machine-id
-          readOnly: true
         - mountPath: /hostfs
           name: hostfs
           readOnly: true
@@ -78,6 +77,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: MY_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
         - name: MY_NAMESPACE
           valueFrom:
             fieldRef:
@@ -93,9 +97,6 @@ spec:
       - name: docker
         hostPath:
           path: /var/run/docker.sock
-      - name: machine-id
-        hostPath:
-          path: /etc/machine-id
       - name: etc-passwd
         hostPath:
           path: /etc/passwd

--- a/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - namespaces/status
   - nodes
   - nodes/spec
+  - nodes/proxy
   - pods
   - pods/status
   - replicationcontrollers

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -33,6 +33,10 @@ data:
     traceEndpointUrl: {{ .Values.traceEndpointUrl }}
     {{- end }}
 
+    {{- if.Values.isWindows }}
+    hostname: {"#from": "env:MY_NODE_NAME"}
+    {{- end }}
+
     disableHostDimensions: {{ toYaml .Values.isServerless }}
 
     etcPath: {{ .Values.etcPath }}
@@ -105,10 +109,12 @@ data:
       hostFSPath: {{ .Values.hostFSPath }}
     - type: disk-io
     - type: net-io
+    {{- if not .Values.isWindows }}
     - type: load
       {{- if .Values.loadPerCPU }}
       perCPU: true
       {{- end }}
+    {{- end }}
     - type: memory
     - type: host-metadata
     - type: processlist
@@ -166,6 +172,14 @@ data:
           - '*'
           - '!*network*'
       {{- end }}
+      {{ with .Values.kubeletExtraMetrics -}}
+      extraMetrics:
+        {{ toYaml . | indent 8 | trim }}
+      {{- end }}
+      {{ with .Values.kubeletMetricNameTransformations -}}
+      metricNameTransformations:
+        {{ toYaml . | indent 8 | trim }}
+      {{- end }}
 
     {{ if .Values.gatherClusterMetrics -}}
     # Collects k8s cluster-level metrics
@@ -205,6 +219,9 @@ data:
     {{ end }}
 
     collectd:
+      {{ if or .Values.isWindows .Values.collectd.disableCollectd -}}
+      disableCollectd: true
+      {{- end }}
       readThreads: {{ .Values.readThreads | default 5 }}
       writeQueueLimitHigh: {{ .Values.writeQueueLimitHigh | default 500000 }}
       writeQueueLimitLow: {{ .Values.writeQueueLimitLow | default 400000 }}

--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -35,8 +35,10 @@ spec:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
     spec:
       # Use host network so we can access kubelet directly
+      {{ if not .Values.isWindows -}}
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
+      dnsPolicy: {{ .Values.isWindows | ternary "ClusterFirst" "ClusterFirstWithHostNet" }}
       {{- if .Values.dnsConfig }}
       dnsConfig:
       {{ toYaml .Values.dnsConfig | nindent 8 }}
@@ -47,10 +49,12 @@ spec:
       imagePullSecrets:
       - name: {{ . }}
       {{- end }}
-      {{- with .Values.nodeSelector -}}
       nodeSelector:
-        {{ toYaml . | indent 8 | trim }}
-      {{- end}}
+        {{ if .Values.nodeSelector -}}
+          {{ toYaml .Values.nodeSelector | indent 8 | trim }}
+        {{- else -}}
+          kubernetes.io/os: {{ .Values.isWindows | ternary "windows" "linux" }}
+        {{- end}}
       tolerations:
       {{ if .Values.runOnMaster -}}
       - effect: NoSchedule
@@ -68,23 +72,28 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Values.agentVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
+        {{ if .Values.isWindows -}}
+        - 'C:\\SignalFxAgent\signalfx-agent.exe'
+        - '-service'
+        - 'bypass'
+        {{ else -}}
         - /bin/signalfx-agent
+        {{- end }}
         volumeMounts:
-        - mountPath: /etc/signalfx
+        - mountPath: {{ .Values.isWindows | ternary "C:\\ProgramData\\SignalFxAgent" "/etc/signalfx" }}
           name: config
-        - mountPath: /etc/machine-id
-          name: machine-id
-          readOnly: true
-        - mountPath: /hostfs
+        - mountPath: {{ .Values.hostFSPath }}
           name: hostfs
           readOnly: true
           mountPropagation: HostToContainer
+        {{ if not .Values.isWindows -}}
         - mountPath: /var/run/docker.sock
           name: docker
           readOnly: true
         - mountPath: /etc/passwd
           name: etc-passwd
           readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | trim | nindent 10 }}
         env:
@@ -109,6 +118,11 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
+        - name: MY_NODE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
         - name: MY_NAMESPACE
           valueFrom:
             fieldRef:
@@ -123,14 +137,13 @@ spec:
           name: {{ include "configmap-name" . }}
       - name: hostfs
         hostPath:
-          path: /
+          path: {{ .Values.isWindows | ternary "C:\\" "/" }}
+      {{ if not .Values.isWindows -}}
       - name: docker
         hostPath:
           path: /var/run/docker.sock
-      - name: machine-id
-        hostPath:
-          path: /etc/machine-id
       - name: etc-passwd
         hostPath:
           path: /etc/passwd
+      {{- end }}
 {{- end }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -52,6 +52,8 @@ image:
   # pullSecret is not needed for our standard image
   pullSecret:
 
+isWindows: false
+
 # How many agent pods can be unavailable at a time when rolling out a new
 # version of the agent
 rollingUpdateMaxUnavailable: 1

--- a/deployments/k8s/serverless/clusterrole.yaml
+++ b/deployments/k8s/serverless/clusterrole.yaml
@@ -15,6 +15,7 @@ rules:
   - namespaces/status
   - nodes
   - nodes/spec
+  - nodes/proxy
   - pods
   - pods/status
   - replicationcontrollers

--- a/deployments/k8s/serverless/configmap.yaml
+++ b/deployments/k8s/serverless/configmap.yaml
@@ -57,6 +57,8 @@ data:
         authType: serviceAccount
       usePodsEndpoint: true
 
+
+
     # Collects k8s cluster-level metrics
     - type: kubernetes-cluster
       alwaysClusterReporter: true
@@ -65,6 +67,7 @@ data:
 
 
     collectd:
+
       readThreads: 5
       writeQueueLimitHigh: 500000
       writeQueueLimitLow: 400000


### PR DESCRIPTION
This is just a simple Go compilation of the agent for Windows,
without any Python or Java subsystems.

In order to make this work, there need to be a special value `bypass` to
the `-service` cli flag that causes the Windows service framework to be
skipped and the agent executed directly.

The Helm chart is also updated to deploy the Windows agent container
more seamlessly.