### PR TITLE
Add disk_ops.pending metric to diskio monitor

### DIFF
--- a/docs/monitors/disk-io.md
+++ b/docs/monitors/disk-io.md
@@ -61,6 +61,7 @@ Metrics that are categorized as
  - `disk_octets.write` (*cumulative*)<br>    (Linux Only) The number of bytes (octets) written to a disk.
  - ***`disk_ops.avg_read`*** (*gauge*)<br>    (Windows Only) The average disk read queue length.
  - ***`disk_ops.avg_write`*** (*gauge*)<br>    (Windows Only) The average disk write queue length.
+ - `disk_ops.pending` (*gauge*)<br>    Number of pending operations
  - ***`disk_ops.read`*** (*cumulative*)<br>    (Linux Only) The number of disk read operations.
  - ***`disk_ops.total`*** (*gauge*)<br>    (Linux Only) The number of both read and write disk operations across all disks in the last reporting interval.
  - ***`disk_ops.write`*** (*cumulative*)<br>    (Linux Only) The number of disk write operations.

--- a/pkg/monitors/diskio/diskio_others.go
+++ b/pkg/monitors/diskio/diskio_others.go
@@ -36,6 +36,7 @@ func (m *Monitor) makeLinuxDatapoints(disk disk.IOCountersStat, dimensions map[s
 		datapoint.New("disk_merged.write", dimensions, datapoint.NewIntValue(int64(disk.MergedWriteCount)), datapoint.Counter, time.Time{}),
 		datapoint.New("disk_time.read", dimensions, datapoint.NewIntValue(int64(disk.ReadTime)), datapoint.Counter, time.Time{}),
 		datapoint.New("disk_time.write", dimensions, datapoint.NewIntValue(int64(disk.WriteTime)), datapoint.Counter, time.Time{}),
+		datapoint.New(diskOpsPending, dimensions, datapoint.NewIntValue(int64(disk.IopsInProgress)), datapoint.Gauge, time.Time{}),
 	}
 }
 

--- a/pkg/monitors/diskio/diskio_windows.go
+++ b/pkg/monitors/diskio/diskio_windows.go
@@ -32,6 +32,7 @@ var metricNameMapping = map[string]string{
 	"logical_disk.Avg._Disk_sec/Read":           "disk_time.avg_read",
 	"logical_disk.Avg._Disk_sec/Write":          "disk_time.avg_write",
 	"logical_disk.Avg._Disk_Read_Queue_Length":  "disk_ops.avg_read",
+	"logical_disk.Current_Disk_Queue_Length":    diskOpsPending,
 }
 
 // applies exhuastive filter to measurements
@@ -96,6 +97,7 @@ func (m *Monitor) Configure(conf *Config) error {
 					"Avg. Disk Bytes/Write",
 					"Avg. Disk sec/Read",
 					"Avg. Disk sec/Write",
+					"Current Disk Queue Length",
 				},
 				// The windows performance counter instances to fetch for the performance counter object
 				Instances: []string{"*"},

--- a/pkg/monitors/diskio/genmetadata.go
+++ b/pkg/monitors/diskio/genmetadata.go
@@ -20,6 +20,7 @@ const (
 	diskOctetsWrite    = "disk_octets.write"
 	diskOpsAvgRead     = "disk_ops.avg_read"
 	diskOpsAvgWrite    = "disk_ops.avg_write"
+	diskOpsPending     = "disk_ops.pending"
 	diskOpsRead        = "disk_ops.read"
 	diskOpsTotal       = "disk_ops.total"
 	diskOpsWrite       = "disk_ops.write"
@@ -38,6 +39,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	diskOctetsWrite:    {Type: datapoint.Counter},
 	diskOpsAvgRead:     {Type: datapoint.Gauge},
 	diskOpsAvgWrite:    {Type: datapoint.Gauge},
+	diskOpsPending:     {Type: datapoint.Gauge},
 	diskOpsRead:        {Type: datapoint.Counter},
 	diskOpsTotal:       {Type: datapoint.Gauge},
 	diskOpsWrite:       {Type: datapoint.Counter},

--- a/pkg/monitors/diskio/metadata.yaml
+++ b/pkg/monitors/diskio/metadata.yaml
@@ -77,5 +77,9 @@ monitors:
       description: (Linux Only) The average amount of time it took to do a write operation.
       default: false
       type: cumulative
+    disk_ops.pending:
+      description: Number of pending operations
+      default: false
+      type: gauge
   monitorType: disk-io
   properties:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -22915,6 +22915,7 @@
             "disk_octets.write",
             "disk_ops.avg_read",
             "disk_ops.avg_write",
+            "disk_ops.pending",
             "disk_ops.read",
             "disk_ops.total",
             "disk_ops.write",
@@ -22973,6 +22974,12 @@
           "description": "(Windows Only) The average disk write queue length.",
           "group": null,
           "default": true
+        },
+        "disk_ops.pending": {
+          "type": "gauge",
+          "description": "Number of pending operations",
+          "group": null,
+          "default": false
         },
         "disk_ops.read": {
           "type": "cumulative",

--- a/tests/monitors/diskio/diskio_test.py
+++ b/tests/monitors/diskio/diskio_test.py
@@ -24,6 +24,7 @@ def test_diskio():
                 "disk_ops.total",
                 "disk_time.read",
                 "disk_time.write",
+                "disk_ops.pending",
             ]
         )
     elif sys.platform == "win32" or sys.platform == "cygwin":
@@ -35,6 +36,7 @@ def test_diskio():
                 "disk_octets.avg_write",
                 "disk_time.avg_read",
                 "disk_time.avg_write",
+                "disk_ops.pending",
             ]
         )
     with Agent.run(


### PR DESCRIPTION
The `disk_ops.pending` metric is for parity with the collectd/disk metric `pending_operations`