### PR TITLE
Prometheus operator integration

### DIFF
--- a/deployments/prometheus-operator/.gitignore
+++ b/deployments/prometheus-operator/.gitignore
@@ -1,0 +1,1 @@
+enable-signalfx.com.yaml

--- a/deployments/prometheus-operator/README.md
+++ b/deployments/prometheus-operator/README.md
@@ -1,0 +1,131 @@
+# Deploying SignalFx with prometheus-operator
+
+[kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) is a complete solution to help collect Prometheus metrics and federate them to a Prometheus server.
+
+Using the SignalFx agent, we aim to reuse this architecture and poll the master Prometheus server for data.
+
+Note this may introduce delay in metric reporting and may not always be the preferred option.
+
+This sample uses Minikube to install prometheus-operator, installs SignalFx and points it at Splunk for collection.
+
+## Dependencies
+
+* Docker 19.03 or later
+* Minikube 1.12 or later
+* Helm v3 or later
+
+## Start the sample
+
+Open a terminal window.
+
+###Start a minikube environment
+```bash
+$> minikube start --driver=docker
+```
+### Deploy prometheus-operator
+```bash
+$> helm repo add stable https://kubernetes-charts.storage.googleapis.com
+$> helm repo update
+$> helm upgrade --install prometheus-operator --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false stable/prometheus-operator
+```
+
+### Deploy Splunk
+
+Note: this section assumes you would want to deploy Splunk alongside in Minikube for evaluation purposes. Please skip if you deployed Splunk already.
+
+Check [splunk-kube/templates/configmap.yaml](splunk-kube/templates/configmap.yaml).
+
+Note the following:
+
+We are going to create a metrics index named `sfx`:
+```yaml
+        indexes:
+          directory: /opt/splunk/etc/apps/search/local
+          content:
+            sfx:
+              datatype: metric
+              coldPath: $SPLUNK_DB/sfx/colddb
+              homePath: $SPLUNK_DB/sfx/db
+              thawedPath: $SPLUNK_DB/sfx/thaweddb
+```
+
+We create a HEC data input:
+```yaml
+        inputs:
+          directory: /opt/splunk/etc/apps/search/local
+          content:
+            http://signalfx-agent:
+              disabled: 0
+              index: sfx
+              token: 12345678-ABCD-EFGH-IJKL-123456789012
+```
+
+Now use helm to install Splunk:
+```bash
+$> helm install splunk ./splunk-kube  -f ./splunk-kube/splunk.yaml
+```
+
+###Deploy the signalfx-agent daemonset
+
+We configure the SignalFx agent with the [values file signalfx-values.yml](./signalfx-values.yaml) to send data to the local Splunk installation.
+
+Note: change as required to target your remote Splunk installation, if applicable.
+
+```yaml
+    splunk:
+      enabled: true
+      url: https://splunk-splunk-kube:8088/services/collector
+      token: 12345678-ABCD-EFGH-IJKL-123456789012
+      index: sfx
+      source: sfx
+      eventsIndex: traces
+      eventsSource: traces
+      skipTLSVerify: true
+```
+
+We also configure the agent to connect to the Prometheus pod:
+```yaml
+    - type: prometheus-exporter
+      discoveryRule: kubernetes_pod_name =~ "prometheus-prometheus" && target == "pod"
+      extraDimensions:
+        metric_source: prometheus
+      host: prometheus
+      metricPath: /federate?match[]=%7Bendpoint%3D%22operations%22%7D
+      port: 9090
+```
+
+See the metric path is going to the `/federate` endpoint, associated with a PromQL query.
+
+The query in this sample just captures the `up` metric. You will want to replace this with something meaningful to your deployment.
+
+Please note you will need to escape PromQL as a query string parameter: the query `{endpoint="operations"}` is encoded as `%7Bendpoint%3D%22operations%22%7D`.
+
+To learn more about Prometheus federation, see [here](https://prometheus.io/docs/prometheus/latest/federation/).
+
+To learn more about PromQL, see [the Prometheus docs](https://prometheus.io/docs/prometheus/latest/querying/basics/).
+
+You can also choose to enable sending to signalfx.com or to only send data to Splunk.
+
+By default, we only send data to Splunk by adding the values file `disable-signalfx.com.yaml`.
+
+If you would like to enable sending to signalfx.com, adapt `enable-signalfx.com.yaml.tmpl` to add your token and realm information.
+
+Use Helm to install SignalFx:
+```bash
+$> helm repo add signalfx https://dl.signalfx.com/helm-repo
+$> helm repo update
+$> helm upgrade --install signalfx-agent -f signalfx-values.yaml -f disable-signalfx.com.yaml signalfx/signalfx-agent
+```
+
+### Check the up metric
+
+Our system should now report to Splunk. Enter `minikube service splunk` to map the Splunk port 8000 to a host port.
+
+Proceed to the Analytics Workspace (`/en-US/app/search/analytics_workspace`) and look for the `up` metric.
+
+### Stop the sample
+
+Delete minikube:
+```bash
+$> minikube delete
+```

--- a/deployments/prometheus-operator/disable-signalfx.com.yaml
+++ b/deployments/prometheus-operator/disable-signalfx.com.yaml
@@ -1,0 +1,3 @@
+
+# Disable sending to SignalFx
+signalFxEnabled: false

--- a/deployments/prometheus-operator/enable-signalfx.com.yaml.tmpl
+++ b/deployments/prometheus-operator/enable-signalfx.com.yaml.tmpl
@@ -1,0 +1,7 @@
+
+# Enable sending to SignalFx
+signalFxEnabled: true
+
+# Provide your token and realm:
+signalFxAccessToken: ""
+signalFxRealm: ""

--- a/deployments/prometheus-operator/signalfx-values.yaml
+++ b/deployments/prometheus-operator/signalfx-values.yaml
@@ -1,0 +1,111 @@
+# An arbitrary value that identifies this K8s cluster in SignalFx.  This value
+# must match the configured cluster name in the SignalFx Smart Gateway if it is
+# being used. This will be the value of the 'kubernetes_cluster' dimension on
+# every metric sent by the agent (unless overriden by `kubernetesClusterName`).
+# It will also be the value of the `cluster` config option that is used to set a
+# `cluster` property on the `host` dimension. (REQUIRED)
+clusterName: dev-cluster
+
+kubeletAPI:
+  # Our minikube sample uses a self-signed certificate.
+  skipVerify: true
+
+agentConfig:
+  signalFxAccessToken: ${SFX_ACCESS_TOKEN}
+
+  signalFxRealm: us0
+
+  disableHostDimensions: false
+
+  etcPath: /hostfs/etc
+  procPath: /hostfs/proc
+
+  enableBuiltInFiltering: true
+
+  intervalSeconds: 10
+
+  cluster: dev-cluster
+
+  writer:
+    traceExportFormat: sapm
+    signalFxEnabled: true
+    splunk:
+      enabled: true
+      url: https://splunk-splunk-kube:8088/services/collector
+      token: 12345678-ABCD-EFGH-IJKL-123456789012
+      index: sfx
+      source: sfx
+      eventsIndex: traces
+      eventsSource: traces
+      skipTLSVerify: true
+
+  logging:
+    level: info
+    format: text
+
+  globalDimensions:
+    kubernetes_cluster: dev-cluster
+
+  observers:
+    - type: k8s-api
+      discoverAllPods: false
+      discoverNodes: false
+
+  monitors:
+    - type: cpu
+    - type: filesystems
+      hostFSPath: /hostfs
+    - type: disk-io
+    - type: net-io
+    - type: load
+    - type: memory
+    - type: host-metadata
+    - type: processlist
+    - type: vmem
+
+
+    - type: kubelet-metrics
+      kubeletAPI:
+        authType: serviceAccount
+        skipVerify: true
+      usePodsEndpoint: true
+
+    # Collects k8s cluster-level metrics
+    - type: kubernetes-cluster
+
+    - type: docker-container-stats
+      dockerURL: unix:///var/run/docker.sock
+      excludedImages:
+        - '*pause-amd64*'
+        - 'k8s.gcr.io/pause*'
+      labelsToDimensions:
+        io.kubernetes.container.name: container_spec_name
+        io.kubernetes.pod.name: kubernetes_pod_name
+        io.kubernetes.pod.uid: kubernetes_pod_uid
+        io.kubernetes.pod.namespace: kubernetes_namespace
+    - type: kube-controller-manager
+      discoveryRule: kubernetes_pod_name =~ "kube-controller-manager" && target == "pod"
+      extraDimensions:
+        metric_source: kube-controller-manager
+      port: 10252
+
+    - type: prometheus-exporter
+      discoveryRule: kubernetes_pod_name =~ "prometheus-prometheus" && target == "pod"
+      extraDimensions:
+        metric_source: prometheus
+      host: prometheus
+      metricPath: /federate?match[]=up # change this as needed
+      port: 9090
+
+  collectd:
+    readThreads: 5
+    writeQueueLimitHigh: 500000
+    writeQueueLimitLow: 400000
+    timeout: 40
+    logLevel: info
+
+  metricsToExclude:
+    # The StackDriver metadata-agent pod on GKE restarts every few minutes so
+    # ignore its containers
+    - dimensions:
+        container_spec_name: metadata-agent

--- a/deployments/prometheus-operator/splunk-kube/.helmignore
+++ b/deployments/prometheus-operator/splunk-kube/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployments/prometheus-operator/splunk-kube/Chart.yaml
+++ b/deployments/prometheus-operator/splunk-kube/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "7.3"
+description: A Helm chart to deploy Splunk and Splunk Connect for K8s
+name: splunk-kube
+version: 0.1.0

--- a/deployments/prometheus-operator/splunk-kube/splunk.yaml
+++ b/deployments/prometheus-operator/splunk-kube/splunk.yaml
@@ -1,0 +1,49 @@
+# Default values for splunk.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+splunk:
+  varSize: 92Gi
+
+image:
+  repository: splunk/splunk
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: LoadBalancer
+  webport: 8080
+  hecport: 8088
+  statsdport: 8125
+
+ingress:
+  enabled: false
+  annotations:
+    #kubernetes.io/ingress.class: nginx
+  paths: [/]
+  hosts:
+  tls: []
+
+resources: {}
+ 
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  logLevel: info 
+  splunk:
+    password: changeme
+    apps:
+    hec:
+      protocol: https
+      insecureSSL: true
+      # host: splunk-splunk-kube
+      token: 00000000-0000-0000-0000-000000000000

--- a/deployments/prometheus-operator/splunk-kube/templates/NOTES.txt
+++ b/deployments/prometheus-operator/splunk-kube/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range $.Values.ingress.paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "splunk.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ include "splunk.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "splunk.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "splunk.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/deployments/prometheus-operator/splunk-kube/templates/_helpers.tpl
+++ b/deployments/prometheus-operator/splunk-kube/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "splunk.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "splunk.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "splunk.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/deployments/prometheus-operator/splunk-kube/templates/configmap.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: splunk-defaults
+data:
+  default.yml: |-
+    retry_num: 50
+    splunk:
+      app_paths:
+        default: /opt/splunk/etc/apps
+        httpinput: /opt/splunk/etc/apps/splunk_httpinput
+        idxc: /opt/splunk/etc/master-apps
+        shc: /opt/splunk/etc/shcluster/apps
+      enable_service: false
+      exec: /opt/splunk/bin/splunk
+      group: splunk
+      hec_disabled: 0
+      hec_enableSSL: 1
+      hec_port: {{ .Values.service.hecport }}
+      hec_token: {{ .Values.global.splunk.hec.token }}
+      home: /opt/splunk
+      http_port: {{ .Values.service.webport }}
+      idxc:
+        enable: false
+      opt: /opt
+      password: {{ .Values.global.splunk.password }}
+      pid: /opt/splunk/var/run/splunk/splunkd.pid
+      s2s_port: 9997
+      secret: null
+      shc:
+        enable: false
+        label: shc_label
+        replication_factor: 3
+        replication_port: 4001
+        secret: lS5aoPDHdganlLBWJP/1DwK0wcHpaJaD
+      smartstore: null
+      svc_port: 8089
+      user: splunk
+      conf:
+        inputs:
+          directory: /opt/splunk/etc/apps/search/local
+          content:
+            http://signalfx-agent:
+              disabled: 0
+              index: sfx
+              token: 12345678-ABCD-EFGH-IJKL-123456789012
+        indexes:
+          directory: /opt/splunk/etc/apps/search/local
+          content:
+            sfx:
+              datatype: metric
+              coldPath: $SPLUNK_DB/sfx/colddb
+              homePath: $SPLUNK_DB/sfx/db
+              thawedPath: $SPLUNK_DB/sfx/thaweddb

--- a/deployments/prometheus-operator/splunk-kube/templates/deployment.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "splunk.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "splunk.name" . }}
+    helm.sh/chart: {{ include "splunk.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "splunk.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "splunk.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          volumeMounts:
+            - name: splunkvar
+              mountPath: /opt/splunk/var
+            - name: splunk-defaults
+              mountPath: /tmp/defaults/
+          env:
+            - name: SPLUNK_START_ARGS
+              value: --accept-license
+            - name: SPLUNK_APPS_URL
+              value: {{ join "," .Values.global.splunk.apps }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.webport }}
+              protocol: TCP
+            - name: hec
+              containerPort: {{ .Values.service.hecport }}
+              protocol: TCP
+            - name: statsd
+              containerPort: {{ .Values.service.statsdport }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+            timeoutSeconds: 60
+            periodSeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 120
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+      - name: splunkvar
+        persistentVolumeClaim:
+          claimName: splunkvar
+      - name: splunk-defaults
+        configMap:
+            name: splunk-defaults
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/deployments/prometheus-operator/splunk-kube/templates/ingress.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "splunk.fullname" . -}}
+{{- $ingressPaths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "splunk.name" . }}
+    helm.sh/chart: {{ include "splunk.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+    - http:
+        paths:
+	{{- range $ingressPaths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: 8000
+	{{- end }}
+{{- end }}

--- a/deployments/prometheus-operator/splunk-kube/templates/persistent-volume-claim.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/persistent-volume-claim.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: splunkvar
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.splunk.varSize }}

--- a/deployments/prometheus-operator/splunk-kube/templates/service.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "splunk.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "splunk.name" . }}
+    helm.sh/chart: {{ include "splunk.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.webport }}
+      targetPort: {{ .Values.service.webport }}
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.hecport }}
+      targetPort: {{ .Values.service.hecport }}
+      protocol: TCP
+      name: hec
+    - port: {{ .Values.service.statsdport }}
+      targetPort: {{ .Values.service.statsdport }}
+      protocol: TCP
+      name: statsd
+  selector:
+    app.kubernetes.io/name: {{ include "splunk.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deployments/prometheus-operator/splunk-kube/templates/tests/test-connection.yaml
+++ b/deployments/prometheus-operator/splunk-kube/templates/tests/test-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "splunk.fullname" . }}-test-connection"
+  labels:
+    app.kubernetes.io/name: {{ include "splunk.name" . }}
+    helm.sh/chart: {{ include "splunk.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args:  ['{{ include "splunk.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never


### PR DESCRIPTION
This adds a sample showing how one can integrate SignalFx agent with an existing Prometheus operator deployment.

The sample allows sending to Splunk and/or SignalFx.