### PR TITLE
Add new 'mode' dimension to filesystems monitor

### DIFF
--- a/docs/monitors/filesystems.md
+++ b/docs/monitors/filesystems.md
@@ -66,6 +66,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `hostFSPath` | no | `string` | Path to the root of the host filesystem.  Useful when running in a container and the host filesystem is mounted in some subdirectory under /.  The disk usage metrics emitted will be based at this path. |
 | `fsTypes` | no | `list of strings` | The filesystem types to include/exclude.  This is an [overridable set](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html#overridable-filters). If this is not set, the default value is the set of all **non-logical/virtual filesystems** on the system.  On Linux this list is determined by reading the `/proc/filesystems` file and choosing the filesystems that do not have the `nodev` modifier. |
 | `mountPoints` | no | `list of strings` | The mount paths to include/exclude. This is an [overridable set](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html#overridable-filters). NOTE: If you are using the hostFSPath option you should not include the `/hostfs/` mount in the filter.  If both this and `fsTypes` is specified, the two filters combine in an AND relationship. |
+| `sendModeDimension` | no | `bool` | Set to true to emit the "mode" dimension, which represents whether the mount is "rw" or "ro". (**default:** `false`) |
 
 
 ## Metrics

--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -46,17 +46,22 @@ type Config struct {
 	// `/hostfs/` mount in the filter.  If both this and `fsTypes` is
 	// specified, the two filters combine in an AND relationship.
 	MountPoints []string `yaml:"mountPoints"`
+
+	// Set to true to emit the "mode" dimension, which represents
+	// whether the mount is "rw" or "ro".
+	SendModeDimension bool `yaml:"sendModeDimension" default:"false"`
 }
 
 // Monitor for Utilization
 type Monitor struct {
-	Output      types.FilteringOutput
-	cancel      func()
-	conf        *Config
-	hostFSPath  string
-	fsTypes     *filter.OverridableStringFilter
-	mountPoints *filter.OverridableStringFilter
-	logger      logrus.FieldLogger
+	Output            types.FilteringOutput
+	cancel            func()
+	conf              *Config
+	hostFSPath        string
+	fsTypes           *filter.OverridableStringFilter
+	mountPoints       *filter.OverridableStringFilter
+	sendModeDimension bool
+	logger            logrus.FieldLogger
 }
 
 // returns common dimensions map for every filesystem
@@ -65,6 +70,21 @@ func (m *Monitor) getCommonDimensions(partition *gopsutil.PartitionStat) map[str
 		"mountpoint": strings.Replace(partition.Mountpoint, " ", "_", -1),
 		"device":     strings.Replace(partition.Device, " ", "_", -1),
 		"fs_type":    strings.Replace(partition.Fstype, " ", "_", -1),
+	}
+	if m.sendModeDimension {
+		var mode string
+		opts := strings.Split(partition.Opts, ",")
+		for _, opt := range opts {
+			if opt == "ro" || opt == "rw" {
+				mode = opt
+				break
+			}
+		}
+		if mode == "ro" || mode == "rw" {
+			dims["mode"] = mode
+		} else {
+			m.logger.Infof("Failed to parse filesystem 'mode' for device `%s` - mountpoint `%s`", partition.Device, partition.Mountpoint)
+		}
 	}
 	// sanitize hostfs path in mountpoint
 	if m.hostFSPath != "" {
@@ -226,6 +246,8 @@ func (m *Monitor) Configure(conf *Config) error {
 	if err != nil {
 		return err
 	}
+
+	m.sendModeDimension = m.conf.SendModeDimension
 
 	// gather metrics on the specified interval
 	utils.RunOnInterval(ctx, func() {

--- a/pkg/monitors/filesystems/filesystems_test.go
+++ b/pkg/monitors/filesystems/filesystems_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	gopsutil "github.com/shirou/gopsutil/disk"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,11 +21,13 @@ func TestCommonDimensions(t *testing.T) {
 				Device:     "/dev/sdb1",
 				Mountpoint: "/hostfs/var/lib",
 				Fstype:     "ext4",
+				Opts:       "rw,relatime",
 			},
 			expectedDims: map[string]string{
 				"mountpoint": "/var/lib",
 				"device":     "/dev/sdb1",
 				"fs_type":    "ext4",
+				"mode":       "rw",
 			},
 		},
 		{
@@ -32,11 +36,13 @@ func TestCommonDimensions(t *testing.T) {
 				Device:     "/dev/sdb1",
 				Mountpoint: "/hostfs",
 				Fstype:     "ext4",
+				Opts:       "ro,relatime",
 			},
 			expectedDims: map[string]string{
 				"mountpoint": "/",
 				"device":     "/dev/sdb1",
 				"fs_type":    "ext4",
+				"mode":       "ro",
 			},
 		},
 		{
@@ -45,6 +51,7 @@ func TestCommonDimensions(t *testing.T) {
 				Device:     "/dev/sdb1",
 				Mountpoint: "/",
 				Fstype:     "ext4",
+				Opts:       "rx,relatime",
 			},
 			expectedDims: map[string]string{
 				"mountpoint": "/",
@@ -54,9 +61,12 @@ func TestCommonDimensions(t *testing.T) {
 		},
 	}
 
+	logger := logrus.WithFields(log.Fields{"monitorType": monitorType})
 	for _, tt := range cases {
 		m := Monitor{
-			hostFSPath: tt.hostFSPath,
+			hostFSPath:        tt.hostFSPath,
+			sendModeDimension: true,
+			logger:            logger,
 		}
 
 		dims := m.getCommonDimensions(tt.ps)

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -28072,6 +28072,14 @@
             "required": false,
             "type": "slice",
             "elementKind": "string"
+          },
+          {
+            "yamlName": "sendModeDimension",
+            "doc": "Set to true to emit the \"mode\" dimension, which represents whether the mount is \"rw\" or \"ro\".",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
           }
         ]
       },


### PR DESCRIPTION
- Enable by setting the new config option `sendModeDimension` to true
- Added as a config option to not churn MTSs for existing users upon upgrade 