### PR TITLE
Reduce stage cache invalidation when building deb/rpm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -424,12 +424,6 @@ RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 RUN curl -fsSL get.docker.com -o /tmp/get-docker.sh &&\
     sh /tmp/get-docker.sh
 
-# Get integration test deps in here
-RUN pip3 install ipython ipdb
-COPY tests/requirements.txt /tmp/
-RUN pip3 install -r /tmp/requirements.txt
-RUN ln -s /usr/bin/pip3 /usr/bin/pip
-
 ARG TARGET_ARCH
 
 RUN wget -O /usr/bin/gomplate https://github.com/hairyhenderson/gomplate/releases/download/v3.4.0/gomplate_linux-${TARGET_ARCH} &&\
@@ -449,6 +443,12 @@ RUN cd /tmp &&\
     curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/${TARGET_ARCH}/kubectl &&\
     chmod +x ./kubectl &&\
     mv ./kubectl /usr/bin/kubectl
+
+# Get integration test deps in here
+RUN pip3 install ipython ipdb
+COPY tests/requirements.txt /tmp/
+RUN pip3 install -r /tmp/requirements.txt
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 WORKDIR /usr/src/signalfx-agent
 


### PR DESCRIPTION
The `COPY tests/requirements.txt /tmp/` dev-extras step is invalidating
the stage cache when building deb/rpm packages in circleci, even if
the file has not changed. This causes the build to always run
subsequent steps in the dev-extras stage, like downloading kubectl and
helm, which has been flaky and causes CI jobs to fail.

Hopefully moving this to after the download steps will help reduce
build failures.