### PR TITLE
add missing metrics to redis

### DIFF
--- a/docs/monitors/collectd-redis.md
+++ b/docs/monitors/collectd-redis.md
@@ -113,6 +113,8 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
+ - `bytes.maxmemory` (*gauge*)<br>    Maximum memory configured on Redis server
+ - `bytes.total_system_memory` (*gauge*)<br>    Total memory available on the OS
  - ***`bytes.used_memory`*** (*gauge*)<br>    Number of bytes allocated by Redis
  - `bytes.used_memory_lua` (*gauge*)<br>    Number of bytes used by the Lua engine
  - `bytes.used_memory_peak` (*gauge*)<br>    Peak Number of bytes allocated by Redis
@@ -144,9 +146,12 @@ Metrics that are categorized as
  - `gauge.key_llen` (*gauge*)<br>    Length of an list key
  - `gauge.latest_fork_usec` (*gauge*)<br>    Duration of the latest fork operation in microseconds
  - `gauge.master_last_io_seconds_ago` (*gauge*)<br>    Number of seconds since the last interaction with master
+ - `gauge.master_link_down_since_seconds` (*gauge*)<br>    Number of seconds since the link is down
+ - `gauge.master_link_status` (*gauge*)<br>    Status of the link (up/down)
  - ***`gauge.master_repl_offset`*** (*gauge*)<br>    Master replication offset
  - `gauge.mem_fragmentation_ratio` (*gauge*)<br>    Ratio between used_memory_rss and used_memory
  - `gauge.rdb_bgsave_in_progress` (*gauge*)<br>    Flag indicating a RDB save is on-going
+ - `gauge.rdb_last_save_time` (*gauge*)<br>    Unix timestamp for last save to disk, when using persistence
  - `gauge.repl_backlog_first_byte_offset` (*gauge*)<br>    Slave replication backlog offset
  - ***`gauge.slave_repl_offset`*** (*gauge*)<br>    Slave replication offset
  - `gauge.uptime_in_days` (*gauge*)<br>    Number of days up

--- a/pkg/monitors/collectd/redis/genmetadata.go
+++ b/pkg/monitors/collectd/redis/genmetadata.go
@@ -12,6 +12,8 @@ const monitorType = "collectd/redis"
 var groupSet = map[string]bool{}
 
 const (
+	bytesMaxmemory                  = "bytes.maxmemory"
+	bytesTotalSystemMemory          = "bytes.total_system_memory"
 	bytesUsedMemory                 = "bytes.used_memory"
 	bytesUsedMemoryLua              = "bytes.used_memory_lua"
 	bytesUsedMemoryPeak             = "bytes.used_memory_peak"
@@ -43,9 +45,12 @@ const (
 	gaugeKeyLlen                    = "gauge.key_llen"
 	gaugeLatestForkUsec             = "gauge.latest_fork_usec"
 	gaugeMasterLastIoSecondsAgo     = "gauge.master_last_io_seconds_ago"
+	gaugeMasterLinkDownSinceSeconds = "gauge.master_link_down_since_seconds"
+	gaugeMasterLinkStatus           = "gauge.master_link_status"
 	gaugeMasterReplOffset           = "gauge.master_repl_offset"
 	gaugeMemFragmentationRatio      = "gauge.mem_fragmentation_ratio"
 	gaugeRdbBgsaveInProgress        = "gauge.rdb_bgsave_in_progress"
+	gaugeRdbLastSaveTime            = "gauge.rdb_last_save_time"
 	gaugeReplBacklogFirstByteOffset = "gauge.repl_backlog_first_byte_offset"
 	gaugeSlaveReplOffset            = "gauge.slave_repl_offset"
 	gaugeUptimeInDays               = "gauge.uptime_in_days"
@@ -53,6 +58,8 @@ const (
 )
 
 var metricSet = map[string]monitors.MetricInfo{
+	bytesMaxmemory:                  {Type: datapoint.Gauge},
+	bytesTotalSystemMemory:          {Type: datapoint.Gauge},
 	bytesUsedMemory:                 {Type: datapoint.Gauge},
 	bytesUsedMemoryLua:              {Type: datapoint.Gauge},
 	bytesUsedMemoryPeak:             {Type: datapoint.Gauge},
@@ -84,9 +91,12 @@ var metricSet = map[string]monitors.MetricInfo{
 	gaugeKeyLlen:                    {Type: datapoint.Gauge},
 	gaugeLatestForkUsec:             {Type: datapoint.Gauge},
 	gaugeMasterLastIoSecondsAgo:     {Type: datapoint.Gauge},
+	gaugeMasterLinkDownSinceSeconds: {Type: datapoint.Gauge},
+	gaugeMasterLinkStatus:           {Type: datapoint.Gauge},
 	gaugeMasterReplOffset:           {Type: datapoint.Gauge},
 	gaugeMemFragmentationRatio:      {Type: datapoint.Gauge},
 	gaugeRdbBgsaveInProgress:        {Type: datapoint.Gauge},
+	gaugeRdbLastSaveTime:            {Type: datapoint.Gauge},
 	gaugeReplBacklogFirstByteOffset: {Type: datapoint.Gauge},
 	gaugeSlaveReplOffset:            {Type: datapoint.Gauge},
 	gaugeUptimeInDays:               {Type: datapoint.Gauge},

--- a/pkg/monitors/collectd/redis/metadata.yaml
+++ b/pkg/monitors/collectd/redis/metadata.yaml
@@ -80,6 +80,14 @@ monitors:
       description: Number of bytes allocated by Redis as seen by the OS
       default: true
       type: gauge
+    bytes.total_system_memory:
+      description: Total memory available on the OS
+      default: false
+      type: gauge
+    bytes.maxmemory:
+      description: Maximum memory configured on Redis server
+      default: false
+      type: gauge
     counter.commands_processed:
       description: Total number of commands processed by the server
       default: true
@@ -214,6 +222,18 @@ monitors:
       type: gauge
     gauge.uptime_in_seconds:
       description: Number of seconds up
+      default: false
+      type: gauge
+    gauge.rdb_last_save_time:
+      description: Unix timestamp for last save to disk, when using persistence
+      default: false
+      type: gauge
+    gauge.master_link_down_since_seconds:
+      description: Number of seconds since the link is down
+      default: false
+      type: gauge
+    gauge.master_link_status:
+      description: Status of the link (up/down)
       default: false
       type: gauge
   monitorType: collectd/redis

--- a/pkg/monitors/collectd/redis/redis.go
+++ b/pkg/monitors/collectd/redis/redis.go
@@ -120,6 +120,8 @@ func (rm *Monitor) Configure(conf *Config) error {
 			"Redis_used_memory_rss":                "bytes",
 			"Redis_used_memory_peak":               "bytes",
 			"Redis_used_memory_lua":                "bytes",
+			"Redis_total_system_memory":            "bytes",
+			"Redis_maxmemory":                      "bytes",
 			"Redis_mem_fragmentation_ratio":        "gauge",
 			"Redis_changes_since_last_save":        "gauge",
 			"Redis_instantaneous_ops_per_sec":      "gauge",
@@ -134,6 +136,12 @@ func (rm *Monitor) Configure(conf *Config) error {
 			"Redis_connected_slaves":               "gauge",
 			"Redis_repl_backlog_first_byte_offset": "gauge",
 			"Redis_master_repl_offset":             "gauge",
+			"Redis_db0_avg_ttl":                    "gauge",
+			"Redis_db0_expires":                    "gauge",
+			"Redis_db0_keys":                       "gauge",
+			"Redis_rdb_last_save_time":             "gauge",
+			"Redis_master_link_down_since_seconds": "gauge",
+			"Redis_master_link_status":             "gauge",
 		},
 	}
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -19460,6 +19460,8 @@
         "": {
           "description": "",
           "metrics": [
+            "bytes.maxmemory",
+            "bytes.total_system_memory",
             "bytes.used_memory",
             "bytes.used_memory_lua",
             "bytes.used_memory_peak",
@@ -19491,9 +19493,12 @@
             "gauge.key_llen",
             "gauge.latest_fork_usec",
             "gauge.master_last_io_seconds_ago",
+            "gauge.master_link_down_since_seconds",
+            "gauge.master_link_status",
             "gauge.master_repl_offset",
             "gauge.mem_fragmentation_ratio",
             "gauge.rdb_bgsave_in_progress",
+            "gauge.rdb_last_save_time",
             "gauge.repl_backlog_first_byte_offset",
             "gauge.slave_repl_offset",
             "gauge.uptime_in_days",
@@ -19502,6 +19507,18 @@
         }
       },
       "metrics": {
+        "bytes.maxmemory": {
+          "type": "gauge",
+          "description": "Maximum memory configured on Redis server",
+          "group": null,
+          "default": false
+        },
+        "bytes.total_system_memory": {
+          "type": "gauge",
+          "description": "Total memory available on the OS",
+          "group": null,
+          "default": false
+        },
         "bytes.used_memory": {
           "type": "gauge",
           "description": "Number of bytes allocated by Redis",
@@ -19688,6 +19705,18 @@
           "group": null,
           "default": false
         },
+        "gauge.master_link_down_since_seconds": {
+          "type": "gauge",
+          "description": "Number of seconds since the link is down",
+          "group": null,
+          "default": false
+        },
+        "gauge.master_link_status": {
+          "type": "gauge",
+          "description": "Status of the link (up/down)",
+          "group": null,
+          "default": false
+        },
         "gauge.master_repl_offset": {
           "type": "gauge",
           "description": "Master replication offset",
@@ -19703,6 +19732,12 @@
         "gauge.rdb_bgsave_in_progress": {
           "type": "gauge",
           "description": "Flag indicating a RDB save is on-going",
+          "group": null,
+          "default": false
+        },
+        "gauge.rdb_last_save_time": {
+          "type": "gauge",
+          "description": "Unix timestamp for last save to disk, when using persistence",
           "group": null,
           "default": false
         },


### PR DESCRIPTION
hello,

`bytes.used_memory` could be used with `bytes.used_memory_rss` to calculate the fragmentation ratio (which is also available as extra metric) but currently this is not possible to detect high memory usage before out of memory (rejected_connections could inform of out of memory but little too late).

there is 2 solutions:

- using max memory which is probably better when set on redis but will be = 0 if not so not reliable in every situations.
- using total system memory will allow us to calculate a percentage of memory usage even if is not relevant for server running other services than redis

In any case, seems to be useful metrics to monitor redis.

Also, I added `db0*` metrics especially to get to total number ok keys `gauge.db0_keys`. The documentation says it is available as custom metric but this seems to be false.
