### PR TITLE
Re-run failed tests if xdist worker crashed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,9 @@ commands:
       markers:
         type: string
         default: ""
+      workers:
+        type: string
+        default: "2"
       pytest_options:
         type: string
         default: ""
@@ -117,7 +120,8 @@ commands:
           no_output_timeout: 30m
           environment:
             MARKERS: << parameters.markers >>
-            PYTEST_OPTIONS: --verbose --junitxml=~/testresults/results.xml --html=~/testresults/results.html --self-contained-html << parameters.pytest_options >>
+            WORKERS: << parameters.workers >>
+            PYTEST_OPTIONS: << parameters.pytest_options >>
             TESTS_DIR: << parameters.tests_dir >>
             WITH_SUDO: << parameters.with_sudo >>
             SPLIT: << parameters.split >>
@@ -351,7 +355,6 @@ jobs:
       - import_image
       - run: .circleci/scripts/setup-integration-tests.sh
       - run_pytest:
-          pytest_options: -n auto
           with_sudo: true
           split: true
 
@@ -385,7 +388,7 @@ jobs:
                 k8s_version: << parameters.k8s_version >>
       - run_pytest:
           markers: kubernetes
-          pytest_options: -n auto --no-use-minikube --agent-image-name=localhost:5000/signalfx-agent:latest --kubeconfig=/home/circleci/.kube/config
+          pytest_options: --no-use-minikube --agent-image-name=localhost:5000/signalfx-agent:latest --kubeconfig=/home/circleci/.kube/config
 
   installer_tests:
     executor: machine_image
@@ -394,7 +397,6 @@ jobs:
       - run: .circleci/scripts/setup-installer-tests.sh
       - run_pytest:
           markers: installer
-          pytest_options: -n auto
           tests_dir: ./tests/packaging/
 
   package_tests:
@@ -412,7 +414,6 @@ jobs:
             PACKAGE_TYPE: << parameters.package_type >>
           command: .circleci/scripts/setup-package-tests.sh
       - run_pytest:
-          pytest_options: -n auto
           tests_dir: ./tests/packaging
 
   bundle_tests:
@@ -424,7 +425,7 @@ jobs:
       - run: .circleci/scripts/setup-bundle-tests.sh
       - run_pytest:
           markers: bundle
-          pytest_options: -n auto --test-bundle-path=/tmp/workspace/signalfx-agent-latest.tar.gz
+          pytest_options: --test-bundle-path=/tmp/workspace/signalfx-agent-latest.tar.gz
           tests_dir: ./tests/packaging
 
   deployment_tests:
@@ -443,7 +444,6 @@ jobs:
           command: .circleci/scripts/run-deployment-tests.sh
       - save_test_results
       - run_pytest:
-          pytest_options: -n auto
           tests_dir: ./tests/deployments/
 
   pylint_black:

--- a/.circleci/scripts/run-deployment-tests.sh
+++ b/.circleci/scripts/run-deployment-tests.sh
@@ -6,7 +6,7 @@ set -eo pipefail
 
 mkdir -p ~/testresults
 if [ "$CIRCLE_BRANCH" != "master" ]; then
-    if ! scripts/changes-include-dir deployments/${DEPLOYMENT_TYPE} tests/deployments/${DEPLOYMENT_TYPE} tests/packaging/common.py ${BASH_SOURCE[0]}; then
+    if ! scripts/changes-include-dir deployments/${DEPLOYMENT_TYPE} tests/deployments/${DEPLOYMENT_TYPE} tests/packaging/common.py .circleci/scripts/run-pytest.sh ${BASH_SOURCE[0]}; then
         echo "${DEPLOYMENT_TYPE} code has not changed, skipping tests!"
         touch ~/.skip
         exit 0

--- a/.circleci/scripts/setup-bundle-tests.sh
+++ b/.circleci/scripts/setup-bundle-tests.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ "$CIRCLE_BRANCH" != "master" ]; then
-    if ! scripts/changes-include-dir Dockerfile packaging tests/packaging scripts/patch-interpreter scripts/patch-rpath scripts/build ${BASH_SOURCE[0]}; then
+    if ! scripts/changes-include-dir Dockerfile packaging tests/packaging scripts/patch-interpreter scripts/patch-rpath scripts/build .circleci/scripts/run-pytest.sh ${BASH_SOURCE[0]}; then
         echo "packaging code has not changed, skipping tests!"
         touch ~/.skip
         exit 0

--- a/.circleci/scripts/setup-installer-tests.sh
+++ b/.circleci/scripts/setup-installer-tests.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ "$CIRCLE_BRANCH" != "master" ]; then
-    if ! scripts/changes-include-dir deployments/installer tests/packaging/installer_test.py tests/packaging/common.py tests/packaging/images ${BASH_SOURCE[0]}; then
+    if ! scripts/changes-include-dir deployments/installer tests/packaging/installer_test.py tests/packaging/common.py tests/packaging/images .circleci/scripts/run-pytest.sh ${BASH_SOURCE[0]}; then
         echo "Installer code has not changed, skipping tests!"
         touch ~/.skip
         exit 0

--- a/.circleci/scripts/setup-k8s-tests.sh
+++ b/.circleci/scripts/setup-k8s-tests.sh
@@ -14,6 +14,7 @@ CHANGES_INCLUDE="deployments/k8s \
     Dockerfile \
     go.mod \
     go.sum \
+    .circleci/scripts/run-pytest.sh \
     ${BASH_SOURCE[0]} \
     $(find . -iname '*k8s*' -o -iname '*kube*' | sed 's|^\./||' | grep -v '^docs/')"
 

--- a/.circleci/scripts/setup-package-tests.sh
+++ b/.circleci/scripts/setup-package-tests.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 if [ "$CIRCLE_BRANCH" != "master" ]; then
-    if ! scripts/changes-include-dir Dockerfile packaging tests/packaging scripts/patch-interpreter scripts/patch-rpath ${BASH_SOURCE[0]}; then
+    if ! scripts/changes-include-dir Dockerfile packaging tests/packaging scripts/patch-interpreter scripts/patch-rpath .circleci/scripts/run-pytest.sh ${BASH_SOURCE[0]}; then
         echo "packaging code has not changed, skipping tests!"
         touch ~/.skip
         exit 0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -10,8 +10,8 @@ psutil==5.6.6
 pylint==2.4.4
 pytest-html==1.22
 pytest-rerunfailures==4.1
-pytest-xdist==1.31.0
-pytest==5.3.1
+pytest-xdist==2.0.0
+pytest==6.0.1
 redis==2.10.6
 requests==2.22.0
 sanic==18.12.0


### PR DESCRIPTION
xdist worker occasionally crashes due to bug in xdist or circleci load.