### PR TITLE
K8s deployment add persistent volume permissions

### DIFF
--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -30,6 +30,13 @@ rules:
   - list
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - persistentvolumes
+    - persistentvolumeclaims
+  verbs:
+    - get
+- apiGroups:
   - ""
   resources:
   - nodes/stats

--- a/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
@@ -35,6 +35,13 @@ rules:
   - list
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - persistentvolumes
+    - persistentvolumeclaims
+  verbs:
+    - get
+- apiGroups:
   - ""
   resources:
   - nodes/stats

--- a/deployments/k8s/serverless/clusterrole.yaml
+++ b/deployments/k8s/serverless/clusterrole.yaml
@@ -30,6 +30,13 @@ rules:
   - list
   - watch
 - apiGroups:
+    - ""
+  resources:
+    - persistentvolumes
+    - persistentvolumeclaims
+  verbs:
+    - get
+- apiGroups:
   - ""
   resources:
   - nodes/stats


### PR DESCRIPTION
Add Persistent Volume and Persistent Volume Claim permissions that are required by the `kubernetes-volumes` monitor to clusterrole.