### PR TITLE
fix sql causes too many connections

### DIFF
--- a/pkg/monitors/sql/querier.go
+++ b/pkg/monitors/sql/querier.go
@@ -93,6 +93,7 @@ func (q *querier) doQuery(ctx context.Context, database *sql.DB, output types.Ou
 	if err != nil {
 		return fmt.Errorf("error executing statement %s: %v", q.query.Query, err)
 	}
+	defer rows.Close()
 	for rows.Next() {
 		dps, dims, err := q.convertCurrentRowToDatapointAndDimensions(rows)
 		if err != nil {


### PR DESCRIPTION
Hello,

when `sql` monitor fails to convert row to datapoints or dimensions it does not close the connection.

while there is not any system to "pause" a query similar to what collectd does with plugin fails this will continue to grow until reaching max connections on server depending of the number of errored queries and collection interval.