### PR TITLE
add some postgresql metrics

### DIFF
--- a/docs/monitors/postgresql.md
+++ b/docs/monitors/postgresql.md
@@ -112,12 +112,12 @@ Metrics that are categorized as
  - ***`postgres_index_scans`*** (*cumulative*)<br>    Total number of index scans on the `table`.
  - ***`postgres_live_rows`*** (*gauge*)<br>    Number of rows live (not deleted) in the `table`.
  - `postgres_locks` (*gauge*)<br>    The number of locks active.
- - ***`postgres_pct_connections`*** (*gauge*)<br>    The number of connections to this database as a fraction of the maximum number of allowed connections.
+ - `postgres_pct_connections` (*gauge*)<br>    The number of connections to this database as a fraction of the maximum number of allowed connections.
  - ***`postgres_query_count`*** (*cumulative*)<br>    Total number of queries executed on the `database`, broken down by `user`.  Note that the accuracy of this metric depends on the PostgreSQL [pg_stat_statements.max config option](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631) being large enough to hold all queries.
 
  - ***`postgres_query_time`*** (*cumulative*)<br>    Total time taken to execute queries on the `database`, broken down by `user`.
- - `postgres_replication_lag` (*gauge*)<br>    The current replication delay in seconds.
- - ***`postgres_replication_state`*** (*gauge*)<br>    The current replication state.
+ - `postgres_replication_lag` (*gauge*)<br>    The current replication delay in seconds. Always = 0 on master.
+ - `postgres_replication_state` (*gauge*)<br>    The current replication state.
  - ***`postgres_rows_deleted`*** (*cumulative*)<br>    Number of rows deleted from the `table`.
  - ***`postgres_rows_inserted`*** (*cumulative*)<br>    Number of rows inserted into the `table`.
  - ***`postgres_rows_updated`*** (*cumulative*)<br>    Number of rows updated in the `table`.
@@ -125,8 +125,8 @@ Metrics that are categorized as
  - ***`postgres_sessions`*** (*gauge*)<br>    Number of sessions currently on the server instance.  The `state` dimension will specify which which type of session (see `state` row of [pg_stat_activity](https://www.postgresql.org/docs/9.2/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW)).
 
  - ***`postgres_table_size`*** (*gauge*)<br>    The size in bytes of the `table` on disk.
- - ***`postgres_xact_commits`*** (*cumulative*)<br>    The number of transactions that have been committed in this database.
- - ***`postgres_xact_rollbacks`*** (*cumulative*)<br>    The number of transactions that have been rolled back in this database.
+ - `postgres_xact_commits` (*cumulative*)<br>    The number of transactions that have been committed in this database.
+ - `postgres_xact_rollbacks` (*cumulative*)<br>    The number of transactions that have been rolled back in this database.
 
 #### Group queries
 All of the following metrics are part of the `queries` metric group. All of
@@ -155,7 +155,10 @@ dimensions may be specific to certain metrics.
 | ---  | ---         |
 | `database` | The name of the database within a PostgreSQL server to which the metric pertains. |
 | `index` | For index metrics, the name of the index |
+| `replication_role` | For "replication_lag" metric only, could be "master" or "standby". |
 | `schemaname` | The name of the schema within which the object being monitored resides (e.g. `public`). |
+| `slot_name` | For "replication_state" metric only, the name of replication slot. |
+| `slot_type` | For "replication_state" metric only, the type of replication. |
 | `table` | The name of the table to which the metric pertains. |
 | `tablespace` | For table metrics, the tablespace in which the table belongs, if not null. |
 | `type` | Whether the object (table, index, function, etc.) belongs to the `system` or `user`. |

--- a/docs/monitors/postgresql.md
+++ b/docs/monitors/postgresql.md
@@ -106,13 +106,18 @@ Metrics that are categorized as
 
 
  - ***`postgres_block_hit_ratio`*** (*gauge*)<br>    The proportion (between 0 and 1, inclusive) of block reads that used the cache and did not have to go to the disk.  Is sent for `table`, `index`, and the `database` as a whole.
+ - `postgres_conflicts` (*cumulative*)<br>    The number of conflicts.
  - ***`postgres_database_size`*** (*gauge*)<br>    Size in bytes of the database on disk
  - ***`postgres_deadlocks`*** (*cumulative*)<br>    Total number of deadlocks detected by the system
  - ***`postgres_index_scans`*** (*cumulative*)<br>    Total number of index scans on the `table`.
  - ***`postgres_live_rows`*** (*gauge*)<br>    Number of rows live (not deleted) in the `table`.
+ - `postgres_locks` (*gauge*)<br>    The number of locks active.
+ - ***`postgres_pct_connections`*** (*gauge*)<br>    The number of connections to this database as a fraction of the maximum number of allowed connections.
  - ***`postgres_query_count`*** (*cumulative*)<br>    Total number of queries executed on the `database`, broken down by `user`.  Note that the accuracy of this metric depends on the PostgreSQL [pg_stat_statements.max config option](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631) being large enough to hold all queries.
 
  - ***`postgres_query_time`*** (*cumulative*)<br>    Total time taken to execute queries on the `database`, broken down by `user`.
+ - `postgres_replication_lag` (*gauge*)<br>    The current replication delay in seconds.
+ - ***`postgres_replication_state`*** (*gauge*)<br>    The current replication state.
  - ***`postgres_rows_deleted`*** (*cumulative*)<br>    Number of rows deleted from the `table`.
  - ***`postgres_rows_inserted`*** (*cumulative*)<br>    Number of rows inserted into the `table`.
  - ***`postgres_rows_updated`*** (*cumulative*)<br>    Number of rows updated in the `table`.
@@ -120,6 +125,8 @@ Metrics that are categorized as
  - ***`postgres_sessions`*** (*gauge*)<br>    Number of sessions currently on the server instance.  The `state` dimension will specify which which type of session (see `state` row of [pg_stat_activity](https://www.postgresql.org/docs/9.2/monitoring-stats.html#PG-STAT-ACTIVITY-VIEW)).
 
  - ***`postgres_table_size`*** (*gauge*)<br>    The size in bytes of the `table` on disk.
+ - ***`postgres_xact_commits`*** (*cumulative*)<br>    The number of transactions that have been committed in this database.
+ - ***`postgres_xact_rollbacks`*** (*cumulative*)<br>    The number of transactions that have been rolled back in this database.
 
 #### Group queries
 All of the following metrics are part of the `queries` metric group. All of

--- a/pkg/monitors/postgresql/genmetadata.go
+++ b/pkg/monitors/postgresql/genmetadata.go
@@ -19,40 +19,54 @@ var groupSet = map[string]bool{
 
 const (
 	postgresBlockHitRatio      = "postgres_block_hit_ratio"
+	postgresConflicts          = "postgres_conflicts"
 	postgresDatabaseSize       = "postgres_database_size"
 	postgresDeadlocks          = "postgres_deadlocks"
 	postgresIndexScans         = "postgres_index_scans"
 	postgresLiveRows           = "postgres_live_rows"
+	postgresLocks              = "postgres_locks"
+	postgresPctConnections     = "postgres_pct_connections"
 	postgresQueriesAverageTime = "postgres_queries_average_time"
 	postgresQueriesCalls       = "postgres_queries_calls"
 	postgresQueriesTotalTime   = "postgres_queries_total_time"
 	postgresQueryCount         = "postgres_query_count"
 	postgresQueryTime          = "postgres_query_time"
+	postgresReplicationLag     = "postgres_replication_lag"
+	postgresReplicationState   = "postgres_replication_state"
 	postgresRowsDeleted        = "postgres_rows_deleted"
 	postgresRowsInserted       = "postgres_rows_inserted"
 	postgresRowsUpdated        = "postgres_rows_updated"
 	postgresSequentialScans    = "postgres_sequential_scans"
 	postgresSessions           = "postgres_sessions"
 	postgresTableSize          = "postgres_table_size"
+	postgresXactCommits        = "postgres_xact_commits"
+	postgresXactRollbacks      = "postgres_xact_rollbacks"
 )
 
 var metricSet = map[string]monitors.MetricInfo{
 	postgresBlockHitRatio:      {Type: datapoint.Gauge},
+	postgresConflicts:          {Type: datapoint.Counter},
 	postgresDatabaseSize:       {Type: datapoint.Gauge},
 	postgresDeadlocks:          {Type: datapoint.Counter},
 	postgresIndexScans:         {Type: datapoint.Counter},
 	postgresLiveRows:           {Type: datapoint.Gauge},
+	postgresLocks:              {Type: datapoint.Gauge},
+	postgresPctConnections:     {Type: datapoint.Gauge},
 	postgresQueriesAverageTime: {Type: datapoint.Counter, Group: groupQueries},
 	postgresQueriesCalls:       {Type: datapoint.Counter, Group: groupQueries},
 	postgresQueriesTotalTime:   {Type: datapoint.Counter, Group: groupQueries},
 	postgresQueryCount:         {Type: datapoint.Counter},
 	postgresQueryTime:          {Type: datapoint.Counter},
+	postgresReplicationLag:     {Type: datapoint.Gauge},
+	postgresReplicationState:   {Type: datapoint.Gauge},
 	postgresRowsDeleted:        {Type: datapoint.Counter},
 	postgresRowsInserted:       {Type: datapoint.Counter},
 	postgresRowsUpdated:        {Type: datapoint.Counter},
 	postgresSequentialScans:    {Type: datapoint.Counter},
 	postgresSessions:           {Type: datapoint.Gauge},
 	postgresTableSize:          {Type: datapoint.Gauge},
+	postgresXactCommits:        {Type: datapoint.Counter},
+	postgresXactRollbacks:      {Type: datapoint.Counter},
 }
 
 var defaultMetrics = map[string]bool{
@@ -61,6 +75,7 @@ var defaultMetrics = map[string]bool{
 	postgresDeadlocks:       true,
 	postgresIndexScans:      true,
 	postgresLiveRows:        true,
+	postgresPctConnections:  true,
 	postgresQueryCount:      true,
 	postgresQueryTime:       true,
 	postgresRowsDeleted:     true,
@@ -69,6 +84,8 @@ var defaultMetrics = map[string]bool{
 	postgresSequentialScans: true,
 	postgresSessions:        true,
 	postgresTableSize:       true,
+	postgresXactCommits:     true,
+	postgresXactRollbacks:   true,
 }
 
 var groupMetricsMap = map[string][]string{

--- a/pkg/monitors/postgresql/genmetadata.go
+++ b/pkg/monitors/postgresql/genmetadata.go
@@ -75,7 +75,6 @@ var defaultMetrics = map[string]bool{
 	postgresDeadlocks:       true,
 	postgresIndexScans:      true,
 	postgresLiveRows:        true,
-	postgresPctConnections:  true,
 	postgresQueryCount:      true,
 	postgresQueryTime:       true,
 	postgresRowsDeleted:     true,
@@ -84,8 +83,6 @@ var defaultMetrics = map[string]bool{
 	postgresSequentialScans: true,
 	postgresSessions:        true,
 	postgresTableSize:       true,
-	postgresXactCommits:     true,
-	postgresXactRollbacks:   true,
 }
 
 var groupMetricsMap = map[string][]string{

--- a/pkg/monitors/postgresql/metadata.yaml
+++ b/pkg/monitors/postgresql/metadata.yaml
@@ -73,14 +73,18 @@ monitors:
         resides (e.g. `public`).
     index:
       description: For index metrics, the name of the index
-    granted:
-      description: For locks metric, is granted or
     user:
       description: For query metrics, the user name of the user that executed the
         queries.
     tablespace:
       description: For table metrics, the tablespace in which the table belongs, if
         not null.
+    replication_role:
+      description: For "replication_lag" metric only, could be "master" or "standby".
+    slot_name:
+      description: For "replication_state" metric only, the name of replication slot.
+    slot_type:
+      description: For "replication_state" metric only, the type of replication.
   metrics:
     postgres_sessions:
       description: >
@@ -161,10 +165,10 @@ monitors:
       group: queries
     postgres_pct_connections:
       description: The number of connections to this database as a fraction of the maximum number of allowed connections.
-      default: true
+      default: false
       type: gauge
     postgres_replication_lag:
-      description: The current replication delay in seconds.
+      description: The current replication delay in seconds. Always = 0 on master.
       default: false
       type: gauge
     postgres_replication_state:
@@ -181,9 +185,9 @@ monitors:
       type: cumulative
     postgres_xact_commits:
       description: The number of transactions that have been committed in this database.
-      default: true
+      default: false
       type: cumulative
     postgres_xact_rollbacks:
       description: The number of transactions that have been rolled back in this database.
-      default: true
+      default: false
       type: cumulative

--- a/pkg/monitors/postgresql/metadata.yaml
+++ b/pkg/monitors/postgresql/metadata.yaml
@@ -73,6 +73,8 @@ monitors:
         resides (e.g. `public`).
     index:
       description: For index metrics, the name of the index
+    granted:
+      description: For locks metric, is granted or
     user:
       description: For query metrics, the user name of the user that executed the
         queries.
@@ -157,3 +159,31 @@ monitors:
       default: false
       type: cumulative
       group: queries
+    postgres_pct_connections:
+      description: The number of connections to this database as a fraction of the maximum number of allowed connections.
+      default: true
+      type: gauge
+    postgres_replication_lag:
+      description: The current replication delay in seconds.
+      default: false
+      type: gauge
+    postgres_replication_state:
+      description: The current replication state.
+      default: false
+      type: gauge
+    postgres_locks:
+      description: The number of locks active.
+      default: false
+      type: gauge
+    postgres_conflicts:
+      description: The number of conflicts.
+      default: false
+      type: cumulative
+    postgres_xact_commits:
+      description: The number of transactions that have been committed in this database.
+      default: true
+      type: cumulative
+    postgres_xact_rollbacks:
+      description: The number of transactions that have been rolled back in this database.
+      default: true
+      type: cumulative

--- a/pkg/monitors/postgresql/monitor.go
+++ b/pkg/monitors/postgresql/monitor.go
@@ -59,13 +59,11 @@ type Config struct {
 	TopQueryLimit int `default:"10" yaml:"topQueryLimit"`
 }
 
-func (c *Config) connStr() (template string, host string, port string, err error) {
+func (c *Config) connStr() (template string, port string, err error) {
 	connStr := c.ConnectionString
-	host = "localhost"
 	port = "5432"
 	if c.Host != "" {
 		connStr += " host=" + c.Host
-		host = c.Host
 	}
 	if c.Port != 0 {
 		connStr += fmt.Sprintf(" port=%d", c.Port)
@@ -98,11 +96,10 @@ func (m *Monitor) Configure(conf *Config) error {
 
 	queriesGroupEnabled := m.Output.HasEnabledMetricInGroup(groupQueries)
 
-	connStr, host, port, err := conf.connStr()
+	connStr, port, err := conf.connStr()
 	if err != nil {
 		return fmt.Errorf("could not render connectionString template: %v", err)
 	}
-	m.Output.AddExtraDimension("postgres_host", host)
 	m.Output.AddExtraDimension("postgres_port", port)
 
 	m.database, err = dbsql.Open("postgres", connStr+" dbname="+m.conf.MasterDBName)
@@ -196,7 +193,7 @@ func (m *Monitor) Configure(conf *Config) error {
 }
 
 func (m *Monitor) startMonitoringDatabase(name string) (*sql.Monitor, error) {
-	connStr, _, _, err := m.conf.connStr()
+	connStr, _, err := m.conf.connStr()
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +243,7 @@ func (m *Monitor) determineDatabases() ([]string, error) {
 func (m *Monitor) monitorServer() (*sql.Monitor, error) {
 	sqlMon := &sql.Monitor{Output: m.Output.Copy()}
 
-	connStr, _, _, err := m.conf.connStr()
+	connStr, _, err := m.conf.connStr()
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +260,7 @@ func (m *Monitor) monitorServer() (*sql.Monitor, error) {
 func (m *Monitor) monitorStatements() (*sql.Monitor, error) {
 	sqlMon := &sql.Monitor{Output: m.Output.Copy()}
 
-	connStr, _, _, err := m.conf.connStr()
+	connStr, _, err := m.conf.connStr()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/monitors/postgresql/monitor.go
+++ b/pkg/monitors/postgresql/monitor.go
@@ -113,7 +113,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	databaseDatapointFilter, err := dpfilters.NewOverridable(nil, map[string][]string{
-		"database": conf.Databases,
+		"database?": conf.Databases,
 	})
 	if err != nil {
 		m.database.Close()
@@ -249,6 +249,7 @@ func (m *Monitor) monitorServer() (*sql.Monitor, error) {
 		ConnectionString: connStr + " dbname=" + m.conf.MasterDBName,
 		DBDriver:         "postgres",
 		Queries:          defaultServerQueries,
+		LogQueries:       m.conf.LogQueries,
 	})
 }
 
@@ -265,6 +266,7 @@ func (m *Monitor) monitorStatements() (*sql.Monitor, error) {
 		ConnectionString: connStr + " dbname=" + m.conf.MasterDBName,
 		DBDriver:         "postgres",
 		Queries:          makeDefaultStatementsQueries(m.conf.TopQueryLimit),
+		LogQueries:       m.conf.LogQueries,
 	})
 }
 

--- a/pkg/monitors/postgresql/queries.go
+++ b/pkg/monitors/postgresql/queries.go
@@ -79,12 +79,10 @@ var defaultServerQueries = []sql.Query{
 	},
 	{
 		Query: `SELECT COUNT(*) AS locks FROM pg_locks WHERE NOT granted;`,
-		//Query: `SELECT count(*) AS locks, granted AS database FROM pg_locks GROUP BY granted;`,
 		Metrics: []sql.Metric{
 			{
 				MetricName:  "postgres_locks",
 				ValueColumn: "locks",
-				//DimensionColumns: []string{"database"},
 			},
 		},
 	},

--- a/pkg/utils/filter/filter_test.go
+++ b/pkg/utils/filter/filter_test.go
@@ -139,6 +139,22 @@ func TestStringMapFilter(t *testing.T) {
 		},
 		{
 			filter: map[string][]string{
+				"app?": {"test"},
+			},
+			input:       map[string]string{},
+			shouldMatch: true,
+		},
+		{
+			filter: map[string][]string{
+				"app?": {"test"},
+			},
+			input: map[string]string{
+				"version": "latest",
+			},
+			shouldMatch: true,
+		},
+		{
+			filter: map[string][]string{
 				"app":     {"test"},
 				"version": {"*"},
 			},

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42606,8 +42606,17 @@
         "index": {
           "description": "For index metrics, the name of the index"
         },
+        "replication_role": {
+          "description": "For \"replication_lag\" metric only, could be \"master\" or \"standby\"."
+        },
         "schemaname": {
           "description": "The name of the schema within which the object being monitored resides (e.g. `public`)."
+        },
+        "slot_name": {
+          "description": "For \"replication_state\" metric only, the name of replication slot."
+        },
+        "slot_type": {
+          "description": "For \"replication_state\" metric only, the type of replication."
         },
         "table": {
           "description": "The name of the table to which the metric pertains."
@@ -42705,7 +42714,7 @@
           "type": "gauge",
           "description": "The number of connections to this database as a fraction of the maximum number of allowed connections.",
           "group": null,
-          "default": true
+          "default": false
         },
         "postgres_queries_average_time": {
           "type": "cumulative",
@@ -42739,7 +42748,7 @@
         },
         "postgres_replication_lag": {
           "type": "gauge",
-          "description": "The current replication delay in seconds.",
+          "description": "The current replication delay in seconds. Always = 0 on master.",
           "group": null,
           "default": false
         },
@@ -42747,7 +42756,7 @@
           "type": "gauge",
           "description": "The current replication state.",
           "group": null,
-          "default": true
+          "default": false
         },
         "postgres_rows_deleted": {
           "type": "cumulative",
@@ -42789,13 +42798,13 @@
           "type": "cumulative",
           "description": "The number of transactions that have been committed in this database.",
           "group": null,
-          "default": true
+          "default": false
         },
         "postgres_xact_rollbacks": {
           "type": "cumulative",
           "description": "The number of transactions that have been rolled back in this database.",
           "group": null,
-          "default": true
+          "default": false
         }
       },
       "properties": null,

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42628,18 +42628,25 @@
           "description": "",
           "metrics": [
             "postgres_block_hit_ratio",
+            "postgres_conflicts",
             "postgres_database_size",
             "postgres_deadlocks",
             "postgres_index_scans",
             "postgres_live_rows",
+            "postgres_locks",
+            "postgres_pct_connections",
             "postgres_query_count",
             "postgres_query_time",
+            "postgres_replication_lag",
+            "postgres_replication_state",
             "postgres_rows_deleted",
             "postgres_rows_inserted",
             "postgres_rows_updated",
             "postgres_sequential_scans",
             "postgres_sessions",
-            "postgres_table_size"
+            "postgres_table_size",
+            "postgres_xact_commits",
+            "postgres_xact_rollbacks"
           ]
         },
         "queries": {
@@ -42657,6 +42664,12 @@
           "description": "The proportion (between 0 and 1, inclusive) of block reads that used the cache and did not have to go to the disk.  Is sent for `table`, `index`, and the `database` as a whole.",
           "group": null,
           "default": true
+        },
+        "postgres_conflicts": {
+          "type": "cumulative",
+          "description": "The number of conflicts.",
+          "group": null,
+          "default": false
         },
         "postgres_database_size": {
           "type": "gauge",
@@ -42679,6 +42692,18 @@
         "postgres_live_rows": {
           "type": "gauge",
           "description": "Number of rows live (not deleted) in the `table`.",
+          "group": null,
+          "default": true
+        },
+        "postgres_locks": {
+          "type": "gauge",
+          "description": "The number of locks active.",
+          "group": null,
+          "default": false
+        },
+        "postgres_pct_connections": {
+          "type": "gauge",
+          "description": "The number of connections to this database as a fraction of the maximum number of allowed connections.",
           "group": null,
           "default": true
         },
@@ -42709,6 +42734,18 @@
         "postgres_query_time": {
           "type": "cumulative",
           "description": "Total time taken to execute queries on the `database`, broken down by `user`.",
+          "group": null,
+          "default": true
+        },
+        "postgres_replication_lag": {
+          "type": "gauge",
+          "description": "The current replication delay in seconds.",
+          "group": null,
+          "default": false
+        },
+        "postgres_replication_state": {
+          "type": "gauge",
+          "description": "The current replication state.",
           "group": null,
           "default": true
         },
@@ -42745,6 +42782,18 @@
         "postgres_table_size": {
           "type": "gauge",
           "description": "The size in bytes of the `table` on disk.",
+          "group": null,
+          "default": true
+        },
+        "postgres_xact_commits": {
+          "type": "cumulative",
+          "description": "The number of transactions that have been committed in this database.",
+          "group": null,
+          "default": true
+        },
+        "postgres_xact_rollbacks": {
+          "type": "cumulative",
+          "description": "The number of transactions that have been rolled back in this database.",
           "group": null,
           "default": true
         }


### PR DESCRIPTION
Hello,

I create this PR as a draft hoping you could help me.

I would like to add some necessary metrics for our usage on `postgresql` monitor.

For now, I use this monitor with `sql` to add these queries but I am pretty sure it could be useful for others and will ease our configuration.

```
  - type: postgresql
    host: &psqlHost 127.0.0.1
    port: &psqlPort 5432
    params: &psqlParams
      username: {"#from": "vault:secret/my-database[username]"}
      password: {"#from": "vault:secret/my-database[password]"}
    masterDBName: &psqlDBName postgres
    # Do not add host, port and dbname
    connectionString: "user={{.username}} password={{.password}} sslmode=disable"
    # Do not change this, needed for detectors
    extraDimensions: &psqlDimensions
      postgres_host: *psqlHost
      postgres_port: *psqlPort
  # You should not have to change this while it uses postgresql monitor config
  - type: sql
    dbDriver: postgres
    extraDimensions: *psqlDimensions
    params:
      << : [ {host: *psqlHost}, {port: *psqlPort}, {dbname: *psqlDBName}, *psqlParams ]
    connectionString: "host={{.host}} port={{.port}} dbname={{.dbname}} user={{.username}} password={{.password}} sslmode=disable"
    queries:
      - query: >-
          WITH max_con AS (SELECT setting::float FROM pg_settings WHERE name = 'max_connections')
          SELECT COUNT(*)/MAX(setting) AS pct_connections FROM pg_stat_activity, max_con;
        metrics:
          - metricName: "postgres_pct_connections"
            valueColumn: "pct_connections"
      - query: >-
          SELECT GREATEST (0, (EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()))) AS lag,
          CASE WHEN pg_is_in_recovery() THEN 'standby' ELSE 'master' END AS replication_role;
        metrics:
          - metricName: "postgres_replication_lag"
            valueColumn: "lag"
            dimensionColumns: ["replication_role"]
      - query: "SELECT slot_name, slot_type, database, case when active then 1 else 0 end AS active FROM pg_replication_slots;"
        metrics:
          - metricName: "postgres_replication_state"
            valueColumn: "active"
            dimensionColumns: ["slot_name", "slot_type", "database"]
      - query: "SELECT COUNT(*) AS locks FROM pg_locks WHERE NOT granted;"
        metrics:
          - metricName: "postgres_locks"
            valueColumn: "locks"
      - query: "SELECT datname AS database, xact_commit, xact_rollback, conflicts FROM pg_stat_database;"
        metrics:
          - metricName: "postgres_conflicts"
            valueColumn: "conflicts"
            dimensionColumns: ["database"]
            isCumulative: true
          - metricName: "postgres_xact_commits"
            valueColumn: "xact_commit"
            dimensionColumns: ["database"]
            isCumulative: true
          - metricName: "postgres_xact_rollbacks"
            valueColumn: "xact_rollback"
            dimensionColumns: ["database"]
            isCumulative: true
```

I use this configuration and every queries work fine, all metrics are collected properly this way.

Sadly, with my current changes on `postgresql` some metrics are not collected anymore:

```
  - type: postgresql
    host: &psqlHost 127.0.0.1
    port: &psqlPort 5432
    params: &psqlParams
      username:  {"#from": "vault:secret/my-database[username]"}
      password:  {"#from": "vault:secret/my-database[password]"}
    masterDBName: &psqlDBName postgres
    # Do not add host, port and dbname
    connectionString: "user={{.username}} password={{.password}} sslmode=disable"
    # Do not change this, needed for detectors
    extraDimensions: &psqlDimensions
      postgres_host: *psqlHost
      postgres_port: *psqlPort
    extraMetrics:
      - "postgres_conflicts"
      - "postgres_locks"
      - "postgres_replication_lag"
```

these metrics work:
- `postgres_deadlocks`
- `postgres_xact_rollbacks`
- `postgres_xact_commits`

but these metrics do not work;
- `postgres_pct_connections`
- `postgres_locks`

I run my 2 configurations (sql & postgres or new postgres only) on the same postgresql server and I don't see any log error about not collected metrics (or underlying queries).

do you have an idea ? may be @keitwb 