### PR TITLE
K8S deployment add new chart values parameter to split monitors configuration in multiple files

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap-monitorsd.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap-monitorsd.yaml
@@ -1,0 +1,16 @@
+{{- if (.Values.monitorsd) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "configmap-name" . }}-monitorsd
+  namespace: {{ template "signalfx-agent.namespace" . }}
+  labels:
+    app: {{ template "signalfx-agent.name" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    chart: {{ template "signalfx-agent.chart" . }}
+data:
+{{- if .Values.monitorsd }}
+{{ tpl (toYaml .Values.monitorsd) . | indent 2 }}
+{{- end }}
+{{- end -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap-monitorsd.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap-monitorsd.yaml
@@ -10,7 +10,5 @@ metadata:
     release: {{ .Release.Name }}
     chart: {{ template "signalfx-agent.chart" . }}
 data:
-{{- if .Values.monitorsd }}
 {{ tpl (toYaml .Values.monitorsd) . | indent 2 }}
-{{- end }}
 {{- end -}}

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -237,6 +237,10 @@ data:
 
     {{ end }}
 
+{{- if (.Values.monitorsd) }}
+    - {"#from": "/etc/signalfx/monitors.d/*.yaml", flatten: true, optional: true}
+{{- end }}
+
     collectd:
       {{ if or .Values.isWindows .Values.collectd.disableCollectd -}}
       disableCollectd: true

--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -94,6 +94,11 @@ spec:
           name: etc-passwd
           readOnly: true
         {{- end }}
+        {{- if (.Values.monitorsd) }}
+        - name: monitorsd
+          mountPath: /etc/signalfx/monitors.d
+          readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | trim | nindent 10 }}
         env:
@@ -145,5 +150,10 @@ spec:
       - name: etc-passwd
         hostPath:
           path: /etc/passwd
+      {{- end }}
+      {{- if (.Values.monitorsd)}}
+      - name: monitorsd
+        configMap:
+          name: {{ include "configmap-name" . }}-monitorsd
       {{- end }}
 {{- end }}

--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
         volumeMounts:
         - mountPath: /etc/signalfx
           name: config
+        {{- if (.Values.monitorsd) }}
+        - name: monitorsd
+          mountPath: /etc/signalfx/monitors.d
+          readOnly: true
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | trim | nindent 10 }}
         env:
@@ -88,4 +93,9 @@ spec:
       - name: config
         configMap:
           name: {{ include "configmap-name" . }}
+      {{- if (.Values.monitorsd)}}
+      - name: monitorsd
+        configMap:
+          name: {{ include "configmap-name" . }}-monitorsd
+      {{- end }}
 {{- end }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -285,3 +285,12 @@ monitors:
 # included into a configmap. These files are automatically included in the previous
 # monitors section if it used.
 monitorsd:
+# All file names in the configmap will create a file in /etc/signalfx/monitors.d repository.
+# They must ended by '.yaml' to be valid.
+#  monitors-cpu.yaml: |-
+#    - type: cpu
+#      # Additional config
+#  monitors-nginx.yaml: |-
+#    - type: collectd/nginx
+#      # Additional config
+#  [...]

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -280,3 +280,8 @@ loadPerCPU: false
 # A list of monitor configurations to include in the agent config.  These
 # values correspond exactly to what goes under 'monitors' in the agent config.
 monitors:
+
+# For a complex monitor configurations, split into multiple files that will be
+# included into a configmap. These files are automatically included in the previous
+# monitors section if it used.
+monitorsd:


### PR DESCRIPTION
Monitor parameters are automatically loaded from /etc/signalfx/monitors.d repository in container.

It's more easy to managed multiple small files than a one longer file.

To use this feature, you need add all files in helm arguments.

**Example**
Build helm parameters command:
```
files_args=""
for config_yaml in $(ls config/*.yaml)
do
    files_args="$files_args -f $config_yaml"
done
echo $files_args
```
and use `$files_args` in your helm command : 
```
helm_args="${release} ${chart_name} ${files_args} --namespace=${namespace}"
helm upgrade --install ${helm_args}
```