### PR TITLE
Fix docker image for aarch64 images

### DIFF
--- a/scripts/patch-rpath
+++ b/scripts/patch-rpath
@@ -11,7 +11,7 @@ echo "Using final root directory of $root"
 
 cd $root
 
-for f in $(find bin lib jre -type f -executable -or -name "*.so*"); do
+for f in $(find bin lib jre -type f -executable -or -name "*.so*" | grep -v libc.so.6 | grep -v libpthread.so.0); do
   existing_rpath=$(patchelf --print-rpath $f 2>/dev/null || true)
-  patchelf --set-rpath '$ORIGIN/'$($root/bin/realpath --relative-to $(dirname $f) ${root%/}/lib):$existing_rpath $f 2>/dev/null || true
+  patchelf --set-rpath '$ORIGIN/'$(/usr/bin/realpath --relative-to $(dirname $f) ${root%/}/lib):$existing_rpath $f 2>/dev/null || true
 done


### PR DESCRIPTION
While building the container, libs and binaries are patched so ld uses relative paths when loading binaries. It seems this is done because the final container is an amalgamation of different binaries with loading different shared libs.

The first change is to use `realpath` in a directory where it is not patched.

The second change is to skip patching `libc` and `libpthread` as these appear to get mangled by `patchelf`. They have no dependencies to be loaded, so leaving them unpatched is fine.