### PR TITLE
Cleanup patch for aarch64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,9 +127,9 @@ RUN wget -O /tmp/Python-${PYTHON_VERSION}.tgz https://www.python.org/ftp/python/
 
 # Compile patchelf statically from source
 RUN cd /tmp &&\
-    wget https://nixos.org/releases/patchelf/patchelf-0.10/patchelf-0.10.tar.gz &&\
+    wget https://nixos.org/releases/patchelf/patchelf-0.11/patchelf-0.11.tar.gz &&\
     tar -xf patchelf*.tar.gz &&\
-    cd patchelf-0.10 &&\
+    cd patchelf-0.11* &&\
     ./configure LDFLAGS="-static" &&\
     make &&\
     make install

--- a/scripts/patch-rpath
+++ b/scripts/patch-rpath
@@ -11,7 +11,7 @@ echo "Using final root directory of $root"
 
 cd $root
 
-for f in $(find bin lib jre -type f -executable -or -name "*.so*" | grep -v libc.so.6 | grep -v libpthread.so.0); do
+for f in $(find bin lib jre -type f -executable -or -name "*.so*"); do
   existing_rpath=$(patchelf --print-rpath $f 2>/dev/null || true)
   patchelf --set-rpath '$ORIGIN/'$(/usr/bin/realpath --relative-to $(dirname $f) ${root%/}/lib):$existing_rpath $f 2>/dev/null || true
 done


### PR DESCRIPTION
PR #1436 was a bit of a hack- this achieves the same results without ignoring a magic list of shared objects.