### PR TITLE
postgresql group for replication and auto disable for aurora

### DIFF
--- a/docs/monitors/postgresql.md
+++ b/docs/monitors/postgresql.md
@@ -35,6 +35,16 @@ Tested with PostgreSQL `9.2+`.
 
 If you want to collect additional metrics about PostgreSQL, use the [sql monitor](./sql.md).
 
+## Metrics about Replication
+
+Replication metrics could not be available on some PostgreSQL servers. For now, this monitor 
+automatically disable `replication` metrics group if it detects Aurora to avoid following error:
+  
+> Function pg_last_xlog_receive_location() is currently not supported for Aurora
+
+The metric `postgres_replication_state` will only be reported for `master` and 
+`postgres_replication_lag` only for `standby` role (replica).
+
 <!--- SETUP --->
 ## Example Configuration
 
@@ -116,8 +126,6 @@ Metrics that are categorized as
  - ***`postgres_query_count`*** (*cumulative*)<br>    Total number of queries executed on the `database`, broken down by `user`.  Note that the accuracy of this metric depends on the PostgreSQL [pg_stat_statements.max config option](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631) being large enough to hold all queries.
 
  - ***`postgres_query_time`*** (*cumulative*)<br>    Total time taken to execute queries on the `database`, broken down by `user`.
- - `postgres_replication_lag` (*gauge*)<br>    The current replication delay in seconds. Always = 0 on master.
- - `postgres_replication_state` (*gauge*)<br>    The current replication state.
  - ***`postgres_rows_deleted`*** (*cumulative*)<br>    Number of rows deleted from the `table`.
  - ***`postgres_rows_inserted`*** (*cumulative*)<br>    Number of rows inserted into the `table`.
  - ***`postgres_rows_updated`*** (*cumulative*)<br>    Number of rows updated in the `table`.
@@ -135,6 +143,13 @@ monitor config option `extraGroups`:
  - `postgres_queries_average_time` (*cumulative*)<br>    Top N queries based on the average execution time broken down by `database`
  - `postgres_queries_calls` (*cumulative*)<br>    Top N most frequently executed queries broken down by `database`
  - `postgres_queries_total_time` (*cumulative*)<br>    Top N queries based on the total execution time broken down by `database`
+
+#### Group replication
+All of the following metrics are part of the `replication` metric group. All of
+the non-default metrics below can be turned on by adding `replication` to the
+monitor config option `extraGroups`:
+ - `postgres_replication_lag` (*gauge*)<br>    The current replication delay in seconds. Always = 0 on master.
+ - `postgres_replication_state` (*gauge*)<br>    The current replication state.
 
 ### Non-default metrics (version 4.7.0+)
 

--- a/pkg/monitors/postgresql/genmetadata.go
+++ b/pkg/monitors/postgresql/genmetadata.go
@@ -10,11 +10,13 @@ import (
 const monitorType = "postgresql"
 
 const (
-	groupQueries = "queries"
+	groupQueries     = "queries"
+	groupReplication = "replication"
 )
 
 var groupSet = map[string]bool{
-	groupQueries: true,
+	groupQueries:     true,
+	groupReplication: true,
 }
 
 const (
@@ -57,8 +59,8 @@ var metricSet = map[string]monitors.MetricInfo{
 	postgresQueriesTotalTime:   {Type: datapoint.Counter, Group: groupQueries},
 	postgresQueryCount:         {Type: datapoint.Counter},
 	postgresQueryTime:          {Type: datapoint.Counter},
-	postgresReplicationLag:     {Type: datapoint.Gauge},
-	postgresReplicationState:   {Type: datapoint.Gauge},
+	postgresReplicationLag:     {Type: datapoint.Gauge, Group: groupReplication},
+	postgresReplicationState:   {Type: datapoint.Gauge, Group: groupReplication},
 	postgresRowsDeleted:        {Type: datapoint.Counter},
 	postgresRowsInserted:       {Type: datapoint.Counter},
 	postgresRowsUpdated:        {Type: datapoint.Counter},
@@ -90,6 +92,10 @@ var groupMetricsMap = map[string][]string{
 		postgresQueriesAverageTime,
 		postgresQueriesCalls,
 		postgresQueriesTotalTime,
+	},
+	groupReplication: []string{
+		postgresReplicationLag,
+		postgresReplicationState,
 	},
 }
 

--- a/pkg/monitors/postgresql/metadata.yaml
+++ b/pkg/monitors/postgresql/metadata.yaml
@@ -26,6 +26,16 @@ monitors:
 
     If you want to collect additional metrics about PostgreSQL, use the [sql monitor](./sql.md).
 
+    ## Metrics about Replication
+
+    Replication metrics could not be available on some PostgreSQL servers. For now, this monitor 
+    automatically disable `replication` metrics group if it detects Aurora to avoid following error:
+      
+    > Function pg_last_xlog_receive_location() is currently not supported for Aurora
+
+    The metric `postgres_replication_state` will only be reported for `master` and 
+    `postgres_replication_lag` only for `standby` role (replica).
+
     <!--- SETUP --->
     ## Example Configuration
 
@@ -148,31 +158,8 @@ monitors:
       description: Number of rows live (not deleted) in the `table`.
       default: true
       type: gauge
-    postgres_queries_calls:
-      description: Top N most frequently executed queries broken down by `database`
-      default: false
-      type: cumulative
-      group: queries
-    postgres_queries_total_time:
-      description: Top N queries based on the total execution time broken down by `database`
-      default: false
-      type: cumulative
-      group: queries
-    postgres_queries_average_time:
-      description: Top N queries based on the average execution time broken down by `database`
-      default: false
-      type: cumulative
-      group: queries
     postgres_pct_connections:
       description: The number of connections to this database as a fraction of the maximum number of allowed connections.
-      default: false
-      type: gauge
-    postgres_replication_lag:
-      description: The current replication delay in seconds. Always = 0 on master.
-      default: false
-      type: gauge
-    postgres_replication_state:
-      description: The current replication state.
       default: false
       type: gauge
     postgres_locks:
@@ -191,3 +178,28 @@ monitors:
       description: The number of transactions that have been rolled back in this database.
       default: false
       type: cumulative
+    postgres_queries_calls:
+      description: Top N most frequently executed queries broken down by `database`
+      default: false
+      type: cumulative
+      group: queries
+    postgres_queries_total_time:
+      description: Top N queries based on the total execution time broken down by `database`
+      default: false
+      type: cumulative
+      group: queries
+    postgres_queries_average_time:
+      description: Top N queries based on the average execution time broken down by `database`
+      default: false
+      type: cumulative
+      group: queries
+    postgres_replication_lag:
+      description: The current replication delay in seconds. Always = 0 on master.
+      default: false
+      type: gauge
+      group: replication
+    postgres_replication_state:
+      description: The current replication state.
+      default: false
+      type: gauge
+      group: replication

--- a/pkg/monitors/postgresql/queries.go
+++ b/pkg/monitors/postgresql/queries.go
@@ -58,26 +58,6 @@ var defaultServerQueries = []sql.Query{
 		},
 	},
 	{
-		Query: `SELECT GREATEST (0, (EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()))) AS lag, CASE WHEN pg_is_in_recovery() THEN 'standby' ELSE 'master' END AS replication_role;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_replication_lag",
-				ValueColumn:      "lag",
-				DimensionColumns: []string{"replication_role"},
-			},
-		},
-	},
-	{
-		Query: `SELECT slot_name, slot_type, database, case when active then 1 else 0 end AS active FROM pg_replication_slots;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_replication_state",
-				ValueColumn:      "active",
-				DimensionColumns: []string{"slot_name", "slot_type", "database"},
-			},
-		},
-	},
-	{
 		Query: `SELECT COUNT(*) AS locks FROM pg_locks WHERE NOT granted;`,
 		Metrics: []sql.Metric{
 			{
@@ -239,4 +219,27 @@ var makeDefaultStatementsQueries = func(limit int) []sql.Query {
 			},
 		},
 	}
+}
+
+var defaultReplicationQueries = []sql.Query{
+	{
+		Query: `SELECT GREATEST (0, (EXTRACT (EPOCH FROM now() - pg_last_xact_replay_timestamp()))) AS lag, CASE WHEN pg_is_in_recovery() THEN 'standby' ELSE 'master' END AS replication_role;`,
+		Metrics: []sql.Metric{
+			{
+				MetricName:       "postgres_replication_lag",
+				ValueColumn:      "lag",
+				DimensionColumns: []string{"replication_role"},
+			},
+		},
+	},
+	{
+		Query: `SELECT slot_name, slot_type, database, case when active then 1 else 0 end AS active FROM pg_replication_slots;`,
+		Metrics: []sql.Metric{
+			{
+				MetricName:       "postgres_replication_state",
+				ValueColumn:      "active",
+				DimensionColumns: []string{"slot_name", "slot_type", "database"},
+			},
+		},
+	},
 }

--- a/pkg/monitors/sql/querier.go
+++ b/pkg/monitors/sql/querier.go
@@ -93,10 +93,10 @@ func (q *querier) doQuery(ctx context.Context, database *sql.DB, output types.Ou
 	if err != nil {
 		return fmt.Errorf("error executing statement %s: %v", q.query.Query, err)
 	}
-	defer rows.Close()
 	for rows.Next() {
 		dps, dims, err := q.convertCurrentRowToDatapointAndDimensions(rows)
 		if err != nil {
+			rows.Close()
 			return err
 		}
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42631,7 +42631,7 @@
           "description": "For query metrics, the user name of the user that executed the queries."
         }
       },
-      "doc": "This monitor pulls metrics from all PostgreSQL databases from a specific\nPostgres server instance.  It pulls basic information that is applicable\nto any database.  It gathers these metrics via SQL queries.\n\n\u003c!--- OVERVIEW ---\u003e\n## Metrics about Queries\n\nIn order to get metrics about query execution time, you must enable the\n`pg_stat_statements` extension.  This extension must be specified in the\n`shared_preload_libraries` config option in the main PostgreSQL\nconfiguration at server start up.  Then the extension must be enabled for\neach database by running `CREATE EXTENSION IF NOT EXISTS\npg_stat_statements;` on each database.\n\nNote that in order to get consistent and accurate query execution time\nmetrics, you must set the [pg_stat_statements.max config\noption](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631)\nto larger than the number of distinct queries on the server.\n\nHere is a [sample configuration of Postgres to enable statement tracking](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631).\n\nTested with PostgreSQL `9.2+`.\n\nIf you want to collect additional metrics about PostgreSQL, use the [sql monitor](./sql.md).\n\n\u003c!--- SETUP ---\u003e\n## Example Configuration\n\nThis example uses the [Vault remote config\nsource](https://github.com/signalfx/signalfx-agent/blob/master/docs/remote-config.md#nested-values-vault-only)\nto connect to PostgreSQL using the `params` map that allows you to pull\nout the username and password individually from Vault and interpolate\nthem into the `connectionString` config option.\n\n```yaml\nmonitors:\n - type: postgresql\n   connectionString: 'sslmode=disable user={{.username}} password={{.password}}'\n   params: \u0026psqlParams\n     username: {\"#from\": \"vault:secret/my-database[username]\"}\n     password: {\"#from\": \"vault:secret/my-database[password]\"}\n   discoveryRule: 'container_image =~ \"postgres\" \u0026\u0026 port == 5432'\n\n # This monitor will monitor additional queries from PostgreSQL using the\n # provided SQL queries.\n - type: sql\n   dbDriver: postgres\n   connectionString: 'sslmode=disable user={{.username}} password={{.password}}'\n   # This is a YAML reference to avoid duplicating the above config.\n   params: *psqlParams\n   queries:\n     - query: 'SELECT COUNT(*) as count, country, status FROM customers GROUP BY country, status;'\n       metrics:\n         - metricName: \"customers\"\n           valueColumn: \"count\"\n           dimensionColumns: [\"country\", \"status\"]\n```\n",
+      "doc": "This monitor pulls metrics from all PostgreSQL databases from a specific\nPostgres server instance.  It pulls basic information that is applicable\nto any database.  It gathers these metrics via SQL queries.\n\n\u003c!--- OVERVIEW ---\u003e\n## Metrics about Queries\n\nIn order to get metrics about query execution time, you must enable the\n`pg_stat_statements` extension.  This extension must be specified in the\n`shared_preload_libraries` config option in the main PostgreSQL\nconfiguration at server start up.  Then the extension must be enabled for\neach database by running `CREATE EXTENSION IF NOT EXISTS\npg_stat_statements;` on each database.\n\nNote that in order to get consistent and accurate query execution time\nmetrics, you must set the [pg_stat_statements.max config\noption](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631)\nto larger than the number of distinct queries on the server.\n\nHere is a [sample configuration of Postgres to enable statement tracking](https://www.postgresql.org/docs/9.3/pgstatstatements.html#AEN160631).\n\nTested with PostgreSQL `9.2+`.\n\nIf you want to collect additional metrics about PostgreSQL, use the [sql monitor](./sql.md).\n\n## Metrics about Replication\n\nReplication metrics could not be available on some PostgreSQL servers. For now, this monitor \nautomatically disable `replication` metrics group if it detects Aurora to avoid following error:\n  \n\u003e Function pg_last_xlog_receive_location() is currently not supported for Aurora\n\nThe metric `postgres_replication_state` will only be reported for `master` and \n`postgres_replication_lag` only for `standby` role (replica).\n\n\u003c!--- SETUP ---\u003e\n## Example Configuration\n\nThis example uses the [Vault remote config\nsource](https://github.com/signalfx/signalfx-agent/blob/master/docs/remote-config.md#nested-values-vault-only)\nto connect to PostgreSQL using the `params` map that allows you to pull\nout the username and password individually from Vault and interpolate\nthem into the `connectionString` config option.\n\n```yaml\nmonitors:\n - type: postgresql\n   connectionString: 'sslmode=disable user={{.username}} password={{.password}}'\n   params: \u0026psqlParams\n     username: {\"#from\": \"vault:secret/my-database[username]\"}\n     password: {\"#from\": \"vault:secret/my-database[password]\"}\n   discoveryRule: 'container_image =~ \"postgres\" \u0026\u0026 port == 5432'\n\n # This monitor will monitor additional queries from PostgreSQL using the\n # provided SQL queries.\n - type: sql\n   dbDriver: postgres\n   connectionString: 'sslmode=disable user={{.username}} password={{.password}}'\n   # This is a YAML reference to avoid duplicating the above config.\n   params: *psqlParams\n   queries:\n     - query: 'SELECT COUNT(*) as count, country, status FROM customers GROUP BY country, status;'\n       metrics:\n         - metricName: \"customers\"\n           valueColumn: \"count\"\n           dimensionColumns: [\"country\", \"status\"]\n```\n",
       "groups": {
         "": {
           "description": "",
@@ -42646,8 +42646,6 @@
             "postgres_pct_connections",
             "postgres_query_count",
             "postgres_query_time",
-            "postgres_replication_lag",
-            "postgres_replication_state",
             "postgres_rows_deleted",
             "postgres_rows_inserted",
             "postgres_rows_updated",
@@ -42664,6 +42662,13 @@
             "postgres_queries_average_time",
             "postgres_queries_calls",
             "postgres_queries_total_time"
+          ]
+        },
+        "replication": {
+          "description": "",
+          "metrics": [
+            "postgres_replication_lag",
+            "postgres_replication_state"
           ]
         }
       },
@@ -42749,13 +42754,13 @@
         "postgres_replication_lag": {
           "type": "gauge",
           "description": "The current replication delay in seconds. Always = 0 on master.",
-          "group": null,
+          "group": "replication",
           "default": false
         },
         "postgres_replication_state": {
           "type": "gauge",
           "description": "The current replication state.",
-          "group": null,
+          "group": "replication",
           "default": false
         },
         "postgres_rows_deleted": {


### PR DESCRIPTION
Hello,

AWS Postgresql Aurora does not support `pg_last_xlog_receive_location()` and replication metrics (state or lag) could only be collected from cloudwatch.

This PR aims to auto disable replications metrics when aurora is detected. For that it uses group metrics.

Also, please note it also change the fix implementation from https://github.com/signalfx/signalfx-agent/pull/1429/files.
Indeed, call 2 times `rows.Close()` function when everything works is not efficient.