### PR TITLE
add number of backends metric for varnish

### DIFF
--- a/docs/monitors/telegraf-varnish.md
+++ b/docs/monitors/telegraf-varnish.md
@@ -57,6 +57,7 @@ Metrics that are categorized as
  - `varnish.cache_hitpass` (*cumulative*)<br>    Requests passed to a backend where the decision to pass them found in the cache..
  - ***`varnish.cache_miss`*** (*cumulative*)<br>    Requests fetched from a backend server.
  - ***`varnish.client_req`*** (*cumulative*)<br>    Good client requests.
+ - `varnish.n_backend` (*gauge*)<br>    Number of backends.
  - `varnish.n_lru_nuked` (*cumulative*)<br>    Objects forcefully evicted from the cache because of a lack of space.
  - ***`varnish.sess_dropped`*** (*gauge*)<br>    Sessions dropped due to a full queue.
  - ***`varnish.sess_queued`*** (*gauge*)<br>    Client connections queued to wait for a thread..

--- a/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
+++ b/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
@@ -24,6 +24,7 @@ const (
 	varnishCacheHitpass     = "varnish.cache_hitpass"
 	varnishCacheMiss        = "varnish.cache_miss"
 	varnishClientReq        = "varnish.client_req"
+	varnishNBackend         = "varnish.n_backend"
 	varnishNLruNuked        = "varnish.n_lru_nuked"
 	varnishSessDropped      = "varnish.sess_dropped"
 	varnishSessQueued       = "varnish.sess_queued"
@@ -47,6 +48,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	varnishCacheHitpass:     {Type: datapoint.Counter},
 	varnishCacheMiss:        {Type: datapoint.Counter},
 	varnishClientReq:        {Type: datapoint.Counter},
+	varnishNBackend:         {Type: datapoint.Gauge},
 	varnishNLruNuked:        {Type: datapoint.Counter},
 	varnishSessDropped:      {Type: datapoint.Gauge},
 	varnishSessQueued:       {Type: datapoint.Gauge},

--- a/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
+++ b/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
@@ -89,7 +89,10 @@ monitors:
       description: Number of requests to the backend.
       default: true
       type: gauge
-
+    varnish.n_backend:
+      description: Number of backends.
+      default: false
+      type: gauge
   monitorType: telegraf/varnish
   sendAll: false
   properties:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -51758,6 +51758,7 @@
             "varnish.cache_hitpass",
             "varnish.cache_miss",
             "varnish.client_req",
+            "varnish.n_backend",
             "varnish.n_lru_nuked",
             "varnish.sess_dropped",
             "varnish.sess_queued",
@@ -51841,6 +51842,12 @@
           "description": "Good client requests.",
           "group": null,
           "default": true
+        },
+        "varnish.n_backend": {
+          "type": "gauge",
+          "description": "Number of backends.",
+          "group": null,
+          "default": false
         },
         "varnish.n_lru_nuked": {
           "type": "cumulative",


### PR DESCRIPTION
hello,

mini PR related to https://github.com/signalfx/signalfx-agent/pull/1446 sorry I forgot this metric which could be useful.

may be defining `sendAll: true` and use default value for `stats` option with every "default" metrics could:

- keep the current behavior collecting all metrics defined in metadata.yml
- but also allow user to easily grap "non" default metrics without need to make a PR here

If I am not wrong we could achieve with metrics filtering at signalfx agent level but in this case the telegraf plugin will always collect ALL metrics (even if only few are accepted by signalfx agent config) which is not the most efficicent way to do I think.

just an idea, I think there already have lot of useful metrics here but this could make this monitor more flexible.