### PR TITLE
improve varnish doc and remove number of backends

### DIFF
--- a/docs/monitors/telegraf-varnish.md
+++ b/docs/monitors/telegraf-varnish.md
@@ -13,6 +13,18 @@ Monitor Type: `telegraf/varnish` ([Source](https://github.com/signalfx/signalfx-
 This is an embedded form of the [Telegraf Varnish
 plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).
 
+Keep in mind this monitor will use `varnishstat` command so the signalfx-agent needs
+to be run on the same host as the varnish server.
+
+Also, signalfx-agent should have permission to run this command properly:
+
+```bash
+usermod -a -G varnish signalfx-agent
+```
+
+For more information check [telegraf official documentation](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish#permissions)
+but do not forget to adapt commands using `signalfx-agent` instead of `telegraf`.
+
 
 ## Configuration
 
@@ -57,7 +69,6 @@ Metrics that are categorized as
  - `varnish.cache_hitpass` (*cumulative*)<br>    Requests passed to a backend where the decision to pass them found in the cache..
  - ***`varnish.cache_miss`*** (*cumulative*)<br>    Requests fetched from a backend server.
  - ***`varnish.client_req`*** (*cumulative*)<br>    Good client requests.
- - `varnish.n_backend` (*gauge*)<br>    Number of backends.
  - `varnish.n_lru_nuked` (*cumulative*)<br>    Objects forcefully evicted from the cache because of a lack of space.
  - ***`varnish.sess_dropped`*** (*gauge*)<br>    Sessions dropped due to a full queue.
  - ***`varnish.sess_queued`*** (*gauge*)<br>    Client connections queued to wait for a thread..

--- a/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
+++ b/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
@@ -24,7 +24,6 @@ const (
 	varnishCacheHitpass     = "varnish.cache_hitpass"
 	varnishCacheMiss        = "varnish.cache_miss"
 	varnishClientReq        = "varnish.client_req"
-	varnishNBackend         = "varnish.n_backend"
 	varnishNLruNuked        = "varnish.n_lru_nuked"
 	varnishSessDropped      = "varnish.sess_dropped"
 	varnishSessQueued       = "varnish.sess_queued"
@@ -48,7 +47,6 @@ var metricSet = map[string]monitors.MetricInfo{
 	varnishCacheHitpass:     {Type: datapoint.Counter},
 	varnishCacheMiss:        {Type: datapoint.Counter},
 	varnishClientReq:        {Type: datapoint.Counter},
-	varnishNBackend:         {Type: datapoint.Gauge},
 	varnishNLruNuked:        {Type: datapoint.Counter},
 	varnishSessDropped:      {Type: datapoint.Gauge},
 	varnishSessQueued:       {Type: datapoint.Gauge},

--- a/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
+++ b/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
@@ -3,6 +3,18 @@ monitors:
     This is an embedded form of the [Telegraf Varnish
     plugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).
 
+    Keep in mind this monitor will use `varnishstat` command so the signalfx-agent needs
+    to be run on the same host as the varnish server.
+
+    Also, signalfx-agent should have permission to run this command properly:
+
+    ```bash
+    usermod -a -G varnish signalfx-agent
+    ```
+
+    For more information check [telegraf official documentation](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish#permissions)
+    but do not forget to adapt commands using `signalfx-agent` instead of `telegraf`.
+
   dimensions:
     plugin:
       description: The plugin name "telegraf/varnish".
@@ -88,10 +100,6 @@ monitors:
     varnish.backend_req:
       description: Number of requests to the backend.
       default: true
-      type: gauge
-    varnish.n_backend:
-      description: Number of backends.
-      default: false
       type: gauge
   monitorType: telegraf/varnish
   sendAll: false

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -51741,7 +51741,7 @@
           "description": "Varnish section (\"MAIN\", \"MGT\", \"MEMPOOL\", \"SMA\", \"VBE\", \"LCK\")."
         }
       },
-      "doc": "This is an embedded form of the [Telegraf Varnish\nplugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).\n",
+      "doc": "This is an embedded form of the [Telegraf Varnish\nplugin](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).\n\nKeep in mind this monitor will use `varnishstat` command so the signalfx-agent needs\nto be run on the same host as the varnish server.\n\nAlso, signalfx-agent should have permission to run this command properly:\n\n```bash\nusermod -a -G varnish signalfx-agent\n```\n\nFor more information check [telegraf official documentation](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish#permissions)\nbut do not forget to adapt commands using `signalfx-agent` instead of `telegraf`.\n",
       "groups": {
         "": {
           "description": "",
@@ -51758,7 +51758,6 @@
             "varnish.cache_hitpass",
             "varnish.cache_miss",
             "varnish.client_req",
-            "varnish.n_backend",
             "varnish.n_lru_nuked",
             "varnish.sess_dropped",
             "varnish.sess_queued",
@@ -51842,12 +51841,6 @@
           "description": "Good client requests.",
           "group": null,
           "default": true
-        },
-        "varnish.n_backend": {
-          "type": "gauge",
-          "description": "Number of backends.",
-          "group": null,
-          "default": false
         },
         "varnish.n_lru_nuked": {
           "type": "cumulative",


### PR DESCRIPTION
Hello,

I add some notes about requirements for varnish config.

also I removed backend number metric from https://github.com/signalfx/signalfx-agent/pull/1448 because after checking it is not possible to get the number of "healthy" backends from `varnishstat` .. only `varnishadm` will allow that so I will probably do a PR on telegraf in future.

In any case for now the total number of backends are useless without the number of (un)healty backends.