### PR TITLE
http Monitor: Add original_url dimension

### DIFF
--- a/docs/monitors/http.md
+++ b/docs/monitors/http.md
@@ -90,8 +90,9 @@ dimensions may be specific to certain metrics.
 | Name | Description |
 | ---  | ---         |
 | `method` | HTTP method used to do request. Not available on `http.cert_*` metrics. |
+| `original_url` | The original URL used in the configuration of this monitor.  May differ from `url` if the URL responds with a redirect and `noRedirects: false`. |
 | `server_name` | ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric. |
-| `url` | Last URL retrieved from configured one. Always available on every metrics. |
+| `url` | Last URL retrieved (after redirects) from configured one. Always available on every metrics. |
 
 
 

--- a/pkg/monitors/http/http.go
+++ b/pkg/monitors/http/http.go
@@ -106,6 +106,10 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 				logger.WithError(err).Error("Failed gathering HTTP stats, ignore other stats")
 			}
 
+			for i := range dps {
+				dps[i].Dimensions["original_url"] = site
+			}
+
 			m.Output.SendDatapoints(dps...)
 		}
 	}, time.Duration(conf.IntervalSeconds)*time.Second)

--- a/pkg/monitors/http/metadata.yaml
+++ b/pkg/monitors/http/metadata.yaml
@@ -13,7 +13,11 @@ monitors:
 
   dimensions:
     url:
-      description: Last URL retrieved from configured one. Always available on every metrics.
+      description: Last URL retrieved (after redirects) from configured one. Always available on every metrics.
+    original_url:
+      description: >
+        The original URL used in the configuration of this monitor.  May differ
+        from `url` if the URL responds with a redirect and `noRedirects: false`.
     server_name:
       description: ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric.
     method:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -30775,11 +30775,14 @@
         "method": {
           "description": "HTTP method used to do request. Not available on `http.cert_*` metrics."
         },
+        "original_url": {
+          "description": "The original URL used in the configuration of this monitor.  May differ from `url` if the URL responds with a redirect and `noRedirects: false`.\n"
+        },
         "server_name": {
           "description": "ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric."
         },
         "url": {
-          "description": "Last URL retrieved from configured one. Always available on every metrics."
+          "description": "Last URL retrieved (after redirects) from configured one. Always available on every metrics."
         }
       },
       "doc": "This monitor will generate metrics based on whether the HTTP responses from\nthe configured URLs match expectations (e.g. correct body, status code,\netc).\n\nTLS information will automatically be fetched if applicable (from base URL\nor redirection).\n\nThe configuration will be applied to every requests URLs from configured\nlist so you need to instance multiple times this monitor for different\nbehavior on multiple URLs.\n",

--- a/tests/monitors/http/http_test.py
+++ b/tests/monitors/http/http_test.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 import pytest
 from tests.helpers.agent import Agent
-from tests.helpers.assertions import all_datapoints_have_dim_key, has_datapoint_with_metric_name
+from tests.helpers.assertions import all_datapoints_have_dim_key, has_all_dims, has_datapoint_with_metric_name
 from tests.helpers.metadata import Metadata
 from tests.helpers.util import wait_for
 from tests.helpers.verify import run_agent_verify_default_metrics, verify_expected_is_subset
@@ -132,3 +132,8 @@ def test_http_tls_stats():
     ) as agent:
         # url should has a bad certificate
         check_values(agent.fake_services.datapoints, 200, cert=0)
+
+        for dp in agent.fake_services.datapoints:
+            assert has_all_dims(dp, {"original_url": URL_HTTPS_SELFSIGNED}) or has_all_dims(
+                dp, {"original_url": URL_HTTPS_EXPIRED}
+            )


### PR DESCRIPTION
This makes it easier to monitor URLs that might change their
redirect targets.

Fixes #1458.