### PR TITLE
http monitor: optional aggregation and last url option

### DIFF
--- a/docs/monitors/http.md
+++ b/docs/monitors/http.md
@@ -57,6 +57,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `urls` | no | `list of strings` | DEPRECATED: list of HTTP URLs to monitor. Use `host`/`port`/`useHTTPS`/`path` instead. |
 | `regex` | no | `string` | Optional Regex to match on URL(s) response(s). |
 | `desiredCode` | no | `integer` | Desired code to match for URL(s) response(s). (**default:** `200`) |
+| `addLastURL` | no | `bool` | Add `last_url` dimension which could differ from `url` when redirection is followed. (**default:** `false`) |
 
 
 ## Metrics
@@ -67,8 +68,10 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
- - ***`http.cert_expiry`*** (*gauge*)<br>    Certificate expiry in seconds. This metric is reported only if HTTPS is available (from last followed URL).
+ - ***`http.cert_expiry`*** (*gauge*)<br>    Certificate expiry in seconds. This metric is reported only if HTTPS  is available (from last followed URL).
+
  - ***`http.cert_valid`*** (*gauge*)<br>    Value is 1 if certificate is valid (including expiration test) or 0 else. This metric is reported only if HTTPS is available (from last followed URL).
+
  - ***`http.code_matched`*** (*gauge*)<br>    Value is 1 if `status_code` value match `desiredCode` set in config. Always reported.
  - ***`http.content_length`*** (*gauge*)<br>    HTTP response body length. Always reported.
  - ***`http.regex_matched`*** (*gauge*)<br>    Value is 1 if pattern match in response body. Only reported if `regex` is configured.
@@ -92,10 +95,9 @@ dimensions may be specific to certain metrics.
 
 | Name | Description |
 | ---  | ---         |
+| `last_url` | Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`. |
 | `method` | HTTP method used to do request. Not available on `http.cert_*` metrics. |
-| `original_url` | The original URL used in the configuration of this monitor.  May differ from `url` if the URL responds with a redirect and `noRedirects: false`. |
-| `server_name` | ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric. |
-| `url` | Last URL retrieved (after redirects) from configured one. Always available on every metrics. |
+| `url` | The normalized URL (including port and path) from the configuration of this monitor. Always available on every metrics. |
 
 
 

--- a/docs/monitors/http.md
+++ b/docs/monitors/http.md
@@ -57,7 +57,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `urls` | no | `list of strings` | DEPRECATED: list of HTTP URLs to monitor. Use `host`/`port`/`useHTTPS`/`path` instead. |
 | `regex` | no | `string` | Optional Regex to match on URL(s) response(s). |
 | `desiredCode` | no | `integer` | Desired code to match for URL(s) response(s). (**default:** `200`) |
-| `addLastURL` | no | `bool` | Add `last_url` dimension which could differ from `url` when redirection is followed. (**default:** `false`) |
+| `addRedirectURL` | no | `bool` | Add `redirect_url` dimension which could differ from `url` when redirection is followed. (**default:** `false`) |
 
 
 ## Metrics
@@ -95,8 +95,8 @@ dimensions may be specific to certain metrics.
 
 | Name | Description |
 | ---  | ---         |
-| `last_url` | Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`. |
 | `method` | HTTP method used to do request. Not available on `http.cert_*` metrics. |
+| `redirect_url` | Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`. |
 | `url` | The normalized URL (including port and path) from the configuration of this monitor. Always available on every metrics. |
 
 

--- a/pkg/monitors/http/metadata.yaml
+++ b/pkg/monitors/http/metadata.yaml
@@ -16,7 +16,7 @@ monitors:
       description: >
         The normalized URL (including port and path) from the configuration of this monitor.
         Always available on every metrics.
-    last_url:
+    redirect_url:
       description: >
         Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false`
         and `addLastURL: true` and if URL responds with a redirect different from the original `url`.

--- a/pkg/monitors/http/metadata.yaml
+++ b/pkg/monitors/http/metadata.yaml
@@ -13,13 +13,13 @@ monitors:
 
   dimensions:
     url:
-      description: Last URL retrieved (after redirects) from configured one. Always available on every metrics.
-    original_url:
       description: >
-        The original URL used in the configuration of this monitor.  May differ
-        from `url` if the URL responds with a redirect and `noRedirects: false`.
-    server_name:
-      description: ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric.
+        The normalized URL (including port and path) from the configuration of this monitor.
+        Always available on every metrics.
+    last_url:
+      description: >
+        Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false`
+        and `addLastURL: true` and if URL responds with a redirect different from the original `url`.
     method:
       description: HTTP method used to do request. Not available on `http.cert_*` metrics.
   metrics:
@@ -44,11 +44,15 @@ monitors:
       default: true
       type: gauge
     http.cert_expiry:
-      description: Certificate expiry in seconds. This metric is reported only if HTTPS is available (from last followed URL).
+      description: >
+        Certificate expiry in seconds. This metric is reported only if HTTPS 
+        is available (from last followed URL).
       default: true
       type: gauge
     http.cert_valid:
-      description: Value is 1 if certificate is valid (including expiration test) or 0 else. This metric is reported only if HTTPS is available (from last followed URL).
+      description: >
+        Value is 1 if certificate is valid (including expiration test) or 0 else.
+        This metric is reported only if HTTPS is available (from last followed URL).
       default: true
       type: gauge
   monitorType: http

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -30798,17 +30798,14 @@
       "sendAll": false,
       "sendUnknown": false,
       "dimensions": {
+        "last_url": {
+          "description": "Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`.\n"
+        },
         "method": {
           "description": "HTTP method used to do request. Not available on `http.cert_*` metrics."
         },
-        "original_url": {
-          "description": "The original URL used in the configuration of this monitor.  May differ from `url` if the URL responds with a redirect and `noRedirects: false`.\n"
-        },
-        "server_name": {
-          "description": "ServerName used for TLS validation. Always and only available on `http.cert_expiry` metric."
-        },
         "url": {
-          "description": "Last URL retrieved (after redirects) from configured one. Always available on every metrics."
+          "description": "The normalized URL (including port and path) from the configuration of this monitor. Always available on every metrics.\n"
         }
       },
       "doc": "This monitor will generate metrics based on whether the HTTP responses from\nthe configured URLs match expectations (e.g. correct body, status code,\netc).\n\nTLS information will automatically be fetched if applicable (from base URL\nor redirection).\n\nThe configuration will be applied to every requests URLs from configured\nlist so you need to instance multiple times this monitor for different\nbehavior on multiple URLs.\n",
@@ -30829,13 +30826,13 @@
       "metrics": {
         "http.cert_expiry": {
           "type": "gauge",
-          "description": "Certificate expiry in seconds. This metric is reported only if HTTPS is available (from last followed URL).",
+          "description": "Certificate expiry in seconds. This metric is reported only if HTTPS  is available (from last followed URL).\n",
           "group": null,
           "default": true
         },
         "http.cert_valid": {
           "type": "gauge",
-          "description": "Value is 1 if certificate is valid (including expiration test) or 0 else. This metric is reported only if HTTPS is available (from last followed URL).",
+          "description": "Value is 1 if certificate is valid (including expiration test) or 0 else. This metric is reported only if HTTPS is available (from last followed URL).\n",
           "group": null,
           "default": true
         },
@@ -31018,6 +31015,14 @@
             "default": 200,
             "required": false,
             "type": "int",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "addLastURL",
+            "doc": "Add `last_url` dimension which could differ from `url` when redirection is followed.",
+            "default": false,
+            "required": false,
+            "type": "bool",
             "elementKind": ""
           }
         ]

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -30798,11 +30798,11 @@
       "sendAll": false,
       "sendUnknown": false,
       "dimensions": {
-        "last_url": {
-          "description": "Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`.\n"
-        },
         "method": {
           "description": "HTTP method used to do request. Not available on `http.cert_*` metrics."
+        },
+        "redirect_url": {
+          "description": "Last URL retrieved (after redirects) from configured one. Only sent if `noRedirects: false` and `addLastURL: true` and if URL responds with a redirect different from the original `url`.\n"
         },
         "url": {
           "description": "The normalized URL (including port and path) from the configuration of this monitor. Always available on every metrics.\n"
@@ -31018,8 +31018,8 @@
             "elementKind": ""
           },
           {
-            "yamlName": "addLastURL",
-            "doc": "Add `last_url` dimension which could differ from `url` when redirection is followed.",
+            "yamlName": "addRedirectURL",
+            "doc": "Add `redirect_url` dimension which could differ from `url` when redirection is followed.",
             "default": false,
             "required": false,
             "type": "bool",


### PR DESCRIPTION
Hello @keitwb 

related to https://github.com/signalfx/signalfx-agent/pull/1459 and https://github.com/signalfx/signalfx-agent/issues/1458

thanks for taking care of that during my holidays. Nevertheless, I would like to change little the behavior.

- remove `original_url` and restore the original purpose to `url`.
- add option to add optional dimension for `last_url`, false by default to keep compat. this is sent only if different from original url.
- add url normalization to force consistency between client http config and deprecated url lists. this also allow to compare url and lastURL.
- log as debug a redirected url for troubleshooting purpose (even when `addLastURL: false`)

I understand the purpose of the previous PR and I think this one respects the logic and the ability to have a "dynamic" dimension which change when redirection changes even if it uses last url instead of original one but:

- I think it is a little less breaking now while `last_url` dimension is disabled by default and the existing `url` one has the same purpose than originally.
- avoiding dynamic change on dimension will help implement a "generic" detector for this. indeed, while `last_url` can change time to time this will generate false alert without explicit aggregation (on `url` to ignore `last_url`). without `original_url` or `last_url` we can simply not use aggregation and this will work in every cases (not matter the env, standard deployment or not, `disabledHostDimensions: true` ...)

Additional context: for now, recent changes are broke our http detectors https://github.com/claranet/terraform-signalfx-detectors/blob/master/network/http/ and I prefer to not have to use aggregation to keep compatibility everywhere.

thanks in advance 

here is a sample result:
![image](https://user-images.githubusercontent.com/2693213/93855024-13d28580-fcb7-11ea-8dc4-51e1720a5bc1.png)


with following conf: 

```yaml
  - type: http
    host: "splunk.com"
    #port: 80
    path: "/en_us/investor-relations/acquisitions/signalfx.html"
    addLastURL: true
  - type: http
    host: "signalfx.com"
    #port: 80
    addLastURL: true
  - type: http
    urls:
      - "https://www.google.com"
      - "https://google.com"
      - "http://monip.org/"
    addLastURL: true
```

