### PR TITLE
kubernetes-cluster Monitor: Add Node Allocatable metrics

### DIFF
--- a/docs/monitors/kubernetes-cluster.md
+++ b/docs/monitors/kubernetes-cluster.md
@@ -101,6 +101,10 @@ This monitor will also emit by default any metrics that are not listed below.
  - `kubernetes.job.parallelism` (*gauge*)<br>    The max desired number of pods the job should run at any given time.
  - `kubernetes.job.succeeded` (*counter*)<br>    The number of pods which reached phase Succeeded for a job.
  - ***`kubernetes.namespace_phase`*** (*gauge*)<br>    The current phase of namespaces (`1` for _active_ and `0` for _terminating_)
+ - `kubernetes.node_allocatable_cpu` (*gauge*)<br>    How many CPU cores remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_ephemeral_storage` (*gauge*)<br>    How many bytes of ephemeral storage remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_memory` (*gauge*)<br>    How many bytes of RAM memory remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_storage` (*gauge*)<br>    How many bytes of storage remaining that the node can allocate to pods
  - ***`kubernetes.node_ready`*** (*gauge*)<br>    Whether this node is ready (1), not ready (0) or in an unknown state (-1)
  - ***`kubernetes.pod_phase`*** (*gauge*)<br>    Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
  - ***`kubernetes.replica_set.available`*** (*gauge*)<br>    Total number of available pods (ready for at least minReadySeconds) targeted by this replica set

--- a/docs/monitors/openshift-cluster.md
+++ b/docs/monitors/openshift-cluster.md
@@ -102,6 +102,10 @@ This monitor will also emit by default any metrics that are not listed below.
  - `kubernetes.job.parallelism` (*gauge*)<br>    The max desired number of pods the job should run at any given time.
  - `kubernetes.job.succeeded` (*counter*)<br>    The number of pods which reached phase Succeeded for a job.
  - ***`kubernetes.namespace_phase`*** (*gauge*)<br>    The current phase of namespaces (`1` for _active_ and `0` for _terminating_)
+ - `kubernetes.node_allocatable_cpu` (*gauge*)<br>    How many CPU cores remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_ephemeral_storage` (*gauge*)<br>    How many bytes of ephemeral storage remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_memory` (*gauge*)<br>    How many bytes of RAM memory remaining that the node can allocate to pods
+ - `kubernetes.node_allocatable_storage` (*gauge*)<br>    How many bytes of storage remaining that the node can allocate to pods
  - ***`kubernetes.node_ready`*** (*gauge*)<br>    Whether this node is ready (1), not ready (0) or in an unknown state (-1)
  - ***`kubernetes.pod_phase`*** (*gauge*)<br>    Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded, 4 - Failed, 5 - Unknown)
  - ***`kubernetes.replica_set.available`*** (*gauge*)<br>    Total number of available pods (ready for at least minReadySeconds) targeted by this replica set

--- a/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
+++ b/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
@@ -46,6 +46,10 @@ const (
 	KubernetesJobParallelism                               = "kubernetes.job.parallelism"
 	KubernetesJobSucceeded                                 = "kubernetes.job.succeeded"
 	KubernetesNamespacePhase                               = "kubernetes.namespace_phase"
+	KubernetesNodeAllocatableCPU                           = "kubernetes.node_allocatable_cpu"
+	KubernetesNodeAllocatableEphemeralStorage              = "kubernetes.node_allocatable_ephemeral_storage"
+	KubernetesNodeAllocatableMemory                        = "kubernetes.node_allocatable_memory"
+	KubernetesNodeAllocatableStorage                       = "kubernetes.node_allocatable_storage"
 	KubernetesNodeReady                                    = "kubernetes.node_ready"
 	KubernetesPodPhase                                     = "kubernetes.pod_phase"
 	KubernetesReplicaSetAvailable                          = "kubernetes.replica_set.available"
@@ -119,6 +123,10 @@ var MetricSet = map[string]monitors.MetricInfo{
 	KubernetesJobParallelism:                               {Type: datapoint.Gauge},
 	KubernetesJobSucceeded:                                 {Type: datapoint.Count},
 	KubernetesNamespacePhase:                               {Type: datapoint.Gauge},
+	KubernetesNodeAllocatableCPU:                           {Type: datapoint.Gauge},
+	KubernetesNodeAllocatableEphemeralStorage:              {Type: datapoint.Gauge},
+	KubernetesNodeAllocatableMemory:                        {Type: datapoint.Gauge},
+	KubernetesNodeAllocatableStorage:                       {Type: datapoint.Gauge},
 	KubernetesNodeReady:                                    {Type: datapoint.Gauge},
 	KubernetesPodPhase:                                     {Type: datapoint.Gauge},
 	KubernetesReplicaSetAvailable:                          {Type: datapoint.Gauge},

--- a/pkg/monitors/kubernetes/cluster/metadata.yaml
+++ b/pkg/monitors/kubernetes/cluster/metadata.yaml
@@ -125,6 +125,22 @@ common:
         state (-1)
       default: true
       type: gauge
+    kubernetes.node_allocatable_cpu:
+      description: How many CPU cores remaining that the node can allocate to pods
+      default: false
+      type: gauge
+    kubernetes.node_allocatable_memory:
+      description: How many bytes of RAM memory remaining that the node can allocate to pods
+      default: false
+      type: gauge
+    kubernetes.node_allocatable_storage:
+      description: How many bytes of storage remaining that the node can allocate to pods
+      default: false
+      type: gauge
+    kubernetes.node_allocatable_ephemeral_storage:
+      description: How many bytes of ephemeral storage remaining that the node can allocate to pods
+      default: false
+      type: gauge
     kubernetes.pod_phase:
       description: Current phase of the pod (1 - Pending, 2 - Running, 3 - Succeeded,
         4 - Failed, 5 - Unknown)

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -37893,6 +37893,10 @@
             "kubernetes.job.parallelism",
             "kubernetes.job.succeeded",
             "kubernetes.namespace_phase",
+            "kubernetes.node_allocatable_cpu",
+            "kubernetes.node_allocatable_ephemeral_storage",
+            "kubernetes.node_allocatable_memory",
+            "kubernetes.node_allocatable_storage",
             "kubernetes.node_ready",
             "kubernetes.pod_phase",
             "kubernetes.replica_set.available",
@@ -38100,6 +38104,30 @@
           "description": "The current phase of namespaces (`1` for _active_ and `0` for _terminating_)",
           "group": null,
           "default": true
+        },
+        "kubernetes.node_allocatable_cpu": {
+          "type": "gauge",
+          "description": "How many CPU cores remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_ephemeral_storage": {
+          "type": "gauge",
+          "description": "How many bytes of ephemeral storage remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_memory": {
+          "type": "gauge",
+          "description": "How many bytes of RAM memory remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_storage": {
+          "type": "gauge",
+          "description": "How many bytes of storage remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
         },
         "kubernetes.node_ready": {
           "type": "gauge",
@@ -42030,6 +42058,10 @@
             "kubernetes.job.parallelism",
             "kubernetes.job.succeeded",
             "kubernetes.namespace_phase",
+            "kubernetes.node_allocatable_cpu",
+            "kubernetes.node_allocatable_ephemeral_storage",
+            "kubernetes.node_allocatable_memory",
+            "kubernetes.node_allocatable_storage",
             "kubernetes.node_ready",
             "kubernetes.pod_phase",
             "kubernetes.replica_set.available",
@@ -42265,6 +42297,30 @@
           "description": "The current phase of namespaces (`1` for _active_ and `0` for _terminating_)",
           "group": null,
           "default": true
+        },
+        "kubernetes.node_allocatable_cpu": {
+          "type": "gauge",
+          "description": "How many CPU cores remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_ephemeral_storage": {
+          "type": "gauge",
+          "description": "How many bytes of ephemeral storage remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_memory": {
+          "type": "gauge",
+          "description": "How many bytes of RAM memory remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
+        },
+        "kubernetes.node_allocatable_storage": {
+          "type": "gauge",
+          "description": "How many bytes of storage remaining that the node can allocate to pods",
+          "group": null,
+          "default": false
         },
         "kubernetes.node_ready": {
           "type": "gauge",

--- a/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
+++ b/tests/monitors/kubernetes_cluster/kubernetes_cluster_test.py
@@ -1,5 +1,6 @@
 from functools import partial as p
 from pathlib import Path
+
 import pytest
 from kubernetes import client as k8s_client
 from tests.helpers.assertions import has_all_dim_props, has_datapoint, has_dim_prop, has_no_datapoint
@@ -519,18 +520,21 @@ def test_node_metrics_and_props(k8s_cluster):
     config = """
     monitors:
      - type: kubernetes-cluster
+       extraMetrics:
+        - kubernetes.node*
     """
     with k8s_cluster.run_agent(agent_yaml=config) as agent:
         for node in k8s_cluster.client.CoreV1Api().list_node().items:
-            assert wait_for(
-                p(
-                    has_datapoint,
-                    agent.fake_services,
-                    metric_name="kubernetes.node_ready",
-                    dimensions={"kubernetes_node": node.metadata.name, "kubernetes_node_uid": node.metadata.uid},
-                ),
-                timeout_seconds=100,
-            ), "timed out waiting for node ready metric"
+            for metric in ["kubernetes.node_ready", "kubernetes.node_allocatable_cpu"]:
+                assert wait_for(
+                    p(
+                        has_datapoint,
+                        agent.fake_services,
+                        metric_name=metric,
+                        dimensions={"kubernetes_node": node.metadata.name, "kubernetes_node_uid": node.metadata.uid},
+                    ),
+                    timeout_seconds=100,
+                ), f"timed out waiting for {metric} metric"
 
             expected_props = {k: v for k, v in node.metadata.labels.items() if len(v) > 0}
             expected_props["kubernetes_node"] = node.metadata.name


### PR DESCRIPTION
These show how much of a resource is allocatable to pods.  They
are all non-default metrics.

Fixes #1467.