### PR TITLE
Do not manage the service user and group if it is already defined.

### DIFF
--- a/deployments/puppet/manifests/service_owner.pp
+++ b/deployments/puppet/manifests/service_owner.pp
@@ -3,11 +3,14 @@
 class signalfx_agent::service_owner ($service_name, $service_user, $service_group) {
 
   if $service_group == 'signalfx-agent' or $service_group in split($::local_groups, ',') {
-    if !defined(Group[$service_group]) {
-      group { $service_group:
-        ensure => present,
-        system => true,
-      }
+    group { $service_group:
+      noop => true,
+    }
+  }
+  else {
+    group { $service_group:
+      ensure => present,
+      system => true,
     }
   }
 

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-signalfx_agent",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "author": "SignalFx, Inc.",
   "summary": "This module installs the SignalFx SmartAgent via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixes:  Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: User[xxx] is already declared