### PR TITLE
Add writer block agent configuration to helm chart

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -68,7 +68,9 @@ data:
         {{- end }}
         skipTLSVerify: {{ .Values.splunkSkipTLSVerify | default "false" }}
     {{- end }}
-
+    {{- if .Values.writer }}
+      {{ toYaml .Values.writer | indent 6 | trim }}
+    {{- end }}
 {{- if lt $agentSemver.Major 5 }}
     sendMachineID: false
 {{- end }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -39,7 +39,10 @@ splunkSkipTLSVerify: false
 # An additional set of global dimension to set on all datapoints coming out of
 # the agent.  The `kubernetes_cluster` dimension will always be set as a global
 # dimension based on the `clusterName` value.
-globalDimensions:
+globalDimensions: {}
+
+# Additional writer options for the agent
+writer: {}
 
 # Docker image configuration
 image:


### PR DESCRIPTION
This PR includes a new feature and a minor bug fix:

-  (feat) Adds the writer map to the helm chart for greater flexibility when customizing the writer configuration.
-  (fix) solves a coalesce warning when adding globalDimensions by initializing the value in the values file as an empty map.

The values file used to test both of these updates where

```
writer:
  traceExportFormat: sapm
  addGlobalDimensionsAsSpanTags: true
globalDimensions:
  environment: dev
```