### PR TITLE
Add pod labels as datapoint dimensions

### DIFF
--- a/pkg/monitors/kubernetes/cluster/metrics/pods.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/pods.go
@@ -23,6 +23,9 @@ func datapointsForPod(pod *v1.Pod) []*datapoint.Datapoint {
 		"kubernetes_node":      pod.Spec.NodeName,
 	}
 
+	props := dimensionForPod(pod).Properties
+	dimensions = datapoint.AddMaps(dimensions, props)
+
 	dps := []*datapoint.Datapoint{
 		datapoint.New(
 			"kubernetes.pod_phase",

--- a/pkg/monitors/kubernetes/cluster/monitor_test.go
+++ b/pkg/monitors/kubernetes/cluster/monitor_test.go
@@ -119,7 +119,8 @@ var _ = Describe("Kubernetes plugin", func() {
 					UID:       "abcd",
 					Namespace: "default",
 					Labels: map[string]string{
-						"env": "test",
+						"env":          "test",
+						"custom_label": "label_value",
 					},
 					OwnerReferences: []metav1.OwnerReference{
 						{
@@ -160,6 +161,7 @@ var _ = Describe("Kubernetes plugin", func() {
 
 		Expect(dps[0].Metric).To(Equal("kubernetes.pod_phase"))
 		Expect(intValue(dps[0].Value)).To(Equal(int64(2)))
+		Expect(dps[0].Dimensions["custom_label"]).To(Equal("label_value"))
 		Expect(dps[1].Metric).To(Equal("kubernetes.container_restart_count"))
 		Expect(intValue(dps[1].Value)).To(Equal(int64(5)))
 		Expect(dps[2].Metric).To(Equal("kubernetes.container_ready"))
@@ -178,6 +180,7 @@ var _ = Describe("Kubernetes plugin", func() {
 				"daemonSet":                "MySet",
 				"daemonSet_uid":            "",
 				"env":                      "test",
+				"custom_label":             "label_value",
 			},
 			Tags:              map[string]bool{},
 			MergeIntoExisting: true,


### PR DESCRIPTION
We would like for resource labels, such as Pod labels, to show up as metadata on datapoints so they can be pulled in with other metadata with the `signalfx-go` client when queried via Signalflow.

Currently, only `kubernetes_namespace`, `kubernetes_pod_uid`, `kubernetes_pod_name`, and `kubernetes_node` are visible, this change would add label values by adding them to the dimensions map.

If there are issues with changing pod dimensions, it might be possible to change the function to use `dimensions.NewWithMeta` and place the labels in the Meta map, however I am not yet sure that would be picked up in the signalflow metadata.
