### PR TITLE
Make default dimensions to correlate to configurable

### DIFF
--- a/pkg/apm/tracetracker/tracker_test.go
+++ b/pkg/apm/tracetracker/tracker_test.go
@@ -41,7 +41,7 @@ func mergeStringMaps(maps ...map[string]string) map[string]string {
 func TestDatapointsAreGenerated(t *testing.T) {
 	correlationClient := &correlationTestClient{}
 
-	a := New(log.Nil, 5*time.Minute, correlationClient, nil, true, nil)
+	a := New(log.Nil, 5*time.Minute, correlationClient, nil, true, nil, DefaultDimsToSyncSource)
 
 	a.AddSpans(context.Background(), []*trace.Span{
 		{
@@ -75,7 +75,7 @@ func TestExpiration(t *testing.T) {
 	correlationClient := &correlationTestClient{}
 
 	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
-	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil)
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
 	setTime(a, time.Unix(100, 0))
 
 	a.AddSpans(context.Background(), []*trace.Span{
@@ -195,7 +195,7 @@ func TestCorrelationEmptyEnvironment(t *testing.T) {
 	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
 	wg.Add(len(hostIDDims))
 	containerLevelIDDims := map[string]string{"kubernetes_pod_uid": "testk8sPodUID", "container_id": "testContainerID"}
-	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil)
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
 	wg.Wait() // wait for the initial fetch of hostIDDims to complete
 
 	// for each container level ID we're going to perform a GET to check for an environment
@@ -246,7 +246,7 @@ func TestCorrelationUpdates(t *testing.T) {
 	hostIDDims := map[string]string{"host": "test", "AWSUniqueId": "randomAWSUniqueId"}
 	wg.Add(len(hostIDDims))
 	containerLevelIDDims := map[string]string{"kubernetes_pod_uid": "testk8sPodUID", "container_id": "testContainerID"}
-	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil)
+	a := New(log.Nil, 5*time.Minute, correlationClient, hostIDDims, true, nil, DefaultDimsToSyncSource)
 	wg.Wait()
 	assert.Equal(t, int64(1), a.hostServiceCache.ActiveCount, "activeServiceCount is not properly tracked")
 	assert.Equal(t, int64(1), a.hostEnvironmentCache.ActiveCount, "activeEnvironmentCount is not properly tracked")

--- a/pkg/core/writer/signalfx/spans.go
+++ b/pkg/core/writer/signalfx/spans.go
@@ -53,10 +53,18 @@ func (sw *Writer) startHostCorrelationTracking() *apmtracker.ActiveServiceTracke
 		sendTraceHostCorrelationMetrics = *sw.conf.SendTraceHostCorrelationMetrics
 	}
 
-	tracker := apmtracker.New(utils.NewAPMShim(log.StandardLogger()), sw.conf.StaleServiceTimeout.AsDuration(), sw.correlationClient, sw.hostIDDims, sendTraceHostCorrelationMetrics, func(dp *datapoint.Datapoint) {
-		// Immediately send correlation datapoints when we first see a service
-		sw.dpChan <- []*datapoint.Datapoint{dp}
-	})
+	tracker := apmtracker.New(
+		utils.NewAPMShim(log.StandardLogger()),
+		sw.conf.StaleServiceTimeout.AsDuration(),
+		sw.correlationClient,
+		sw.hostIDDims,
+		sendTraceHostCorrelationMetrics,
+		func(dp *datapoint.Datapoint) {
+			// Immediately send correlation datapoints when we first see a service
+			sw.dpChan <- []*datapoint.Datapoint{dp}
+		},
+		apmtracker.DefaultDimsToSyncSource,
+	)
 
 	// purge the active service tracker periodically
 	utils.RunOnInterval(sw.ctx, func() {

--- a/pkg/core/writer/tracetracker/host.go
+++ b/pkg/core/writer/tracetracker/host.go
@@ -9,7 +9,7 @@ import (
 	"github.com/signalfx/golib/v3/trace"
 	"github.com/sirupsen/logrus"
 
-	"github.com/signalfx/signalfx-agent/pkg/apm/tracetracker"
+	apmtracker "github.com/signalfx/signalfx-agent/pkg/apm/tracetracker"
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -50,7 +50,7 @@ func (st *SpanSourceTracker) AddSourceTagsToSpan(span *trace.Span) {
 	found := 0
 	for _, endpoint := range endpoints {
 		dims := endpoint.Dimensions()
-		for _, dim := range tracetracker.DimsToSyncSource {
+		for _, dim := range apmtracker.DefaultDimsToSyncSource {
 			if val := dims[dim]; val != "" {
 				found++
 
@@ -72,7 +72,7 @@ func (st *SpanSourceTracker) AddSourceTagsToSpan(span *trace.Span) {
 		}
 		// Short circuit it if we have added all the desired dimensions with
 		// this endpoint.
-		if found == len(tracetracker.DimsToSyncSource) {
+		if found == len(apmtracker.DefaultDimsToSyncSource) {
 			break
 		}
 	}


### PR DESCRIPTION
These dimensions are used to correlate services and environments to. In otel
these will need to correlate using otel semantic conventions if we are sending
metrics in that format (ie not using the SignalFx translations).