### PR TITLE
kubernetes-cluster Monitor: Use floating point value for CPU limit/re…

### DIFF
--- a/pkg/monitors/kubernetes/cluster/metrics/containers.go
+++ b/pkg/monitors/kubernetes/cluster/metrics/containers.go
@@ -37,7 +37,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 			datapoint.New(
 				"kubernetes.container_cpu_request",
 				contDims,
-				datapoint.NewIntValue(val.Value()),
+				datapoint.NewFloatValue(float64(val.MilliValue())/1000.0),
 				datapoint.Gauge,
 				time.Time{}))
 	}
@@ -47,7 +47,7 @@ func datapointsForContainerSpec(c v1.Container, contDims map[string]string) []*d
 			datapoint.New(
 				"kubernetes.container_cpu_limit",
 				contDims,
-				datapoint.NewIntValue(val.Value()),
+				datapoint.NewFloatValue(float64(val.MilliValue())/1000.0),
 				datapoint.Gauge,
 				time.Time{}))
 	}


### PR DESCRIPTION
…quest

Previously these metrics were truncated to the nearest integer reducing
their usefulness.

This is a replacement for #1486 which got messed up somehow when I pushed an update.