### PR TITLE
make correlation config settings more intuitive

### DIFF
--- a/pkg/apm/correlations/client_test.go
+++ b/pkg/apm/correlations/client_test.go
@@ -139,12 +139,12 @@ func setup(t *testing.T) (CorrelationClient, chan *request, *atomic.Value, *atom
 
 	conf := ClientConfig{
 		Config: Config{
-			MaxRequests:         10,
-			MaxBuffered:         10,
-			MaxRetries:          4,
-			LogDimensionUpdates: true,
-			SendDelay:           0,
-			PurgeInterval:       0,
+			MaxRequests:     10,
+			MaxBuffered:     10,
+			MaxRetries:      4,
+			LogUpdates:      true,
+			RetryDelay:      0,
+			CleanupInterval: 0,
 		},
 		AccessToken: "",
 		URL:         serverURL,

--- a/pkg/core/config/correlation.go
+++ b/pkg/core/config/correlation.go
@@ -9,12 +9,12 @@ import (
 func ClientConfigFromWriterConfig(conf *WriterConfig) correlations.ClientConfig {
 	return correlations.ClientConfig{
 		Config: correlations.Config{
-			MaxRequests:         conf.PropertiesMaxRequests,
-			MaxBuffered:         conf.PropertiesMaxBuffered,
-			MaxRetries:          conf.TraceHostCorrelationMaxRequestRetries,
-			LogDimensionUpdates: conf.LogDimensionUpdates,
-			SendDelay:           time.Duration(conf.PropertiesSendDelaySeconds) * time.Second,
-			PurgeInterval:       conf.TraceHostCorrelationPurgeInterval.AsDuration(),
+			MaxRequests:     conf.PropertiesMaxRequests,
+			MaxBuffered:     conf.PropertiesMaxBuffered,
+			MaxRetries:      conf.TraceHostCorrelationMaxRequestRetries,
+			LogUpdates:      conf.LogDimensionUpdates,
+			RetryDelay:      time.Duration(conf.PropertiesSendDelaySeconds) * time.Second,
+			CleanupInterval: conf.TraceHostCorrelationPurgeInterval.AsDuration(),
 		},
 		AccessToken: conf.SignalFxAccessToken,
 		URL:         conf.ParsedAPIURL(),


### PR DESCRIPTION
This doesn't change the config settings in the agent yaml, just internal names such that they align with names used in otel and that more accurately reflect their usage.