### PR TITLE
addressing physical root mount

### DIFF
--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -158,6 +158,9 @@ func (m *Monitor) emitDatapoints() {
 		var mount string
 		if m.hostFSPath != "" {
 			mount = strings.Replace(partition.Mountpoint, m.hostFSPath, "", 1)
+			if mount == "" {
+				mount = "/"
+			}
 		} else {
 			mount = partition.Mountpoint
 		}


### PR DESCRIPTION
if `hostFSPath="/hostfs"` and processing a partition `{"device":"/dev/sda1","mountpoint":"/hostfs","fstype":"xfs","opts":"ro,relatime,attr2,inode64,noquota"}` 
`mount` will end an empty string and if user is filtering mountPoints like this, then we'll end up skipping this partition 
```
- type: filesystems
    hostFSPath: '/hostfs'
    mountPoints:
      - '/'
```
Signed-off-by: Dani Louca <dlouca@splunk.com>