### PR TITLE
Allow configuration of gpg key url for puppet

### DIFF
--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -64,8 +64,11 @@ class accepts the following parameters:
    (**default:** 'signalfx-agent')
 
  - `$manage_repo`: Valid only on Linux. In cases where the agent apt/yum repository
-   is managed by an external module, set this to `false` to disable management of
-   the agent repository by this module. (**default:** `true`)
+   is managed externally, set this to `false` to disable management of the agent
+   repository by this module. **Note:** If set to `false`, the repository definition
+   files, i.e. `/etc/apt/sources.list.d/signalfx-agent.list` for apt and
+   `/etc/yum.repos.d/signalfx-agent.repo` for yum, will be deleted if they exist to
+   avoid any conflicts. (**default:** `true`)
 
 ## Dependencies
 On Linux-based systems, the

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -63,6 +63,10 @@ class accepts the following parameters:
    signalfx-agent service. The user/group will be created if they do not exist.
    (**default:** 'signalfx-agent')
 
+ - `$manage_repo`: Valid only on Linux. In cases where the agent apt/yum repository
+   is managed by an external module, set this to `false` to disable management of
+   the agent repository by this module. (**default:** `true`)
+
 ## Dependencies
 On Linux-based systems, the
 [puppetlabs/stdlib](https://forge.puppet.com/puppetlabs/stdlib) module is

--- a/deployments/puppet/manifests/debian_repo.pp
+++ b/deployments/puppet/manifests/debian_repo.pp
@@ -24,5 +24,9 @@ class signalfx_agent::debian_repo ($repo_base, $package_stage, $apt_gpg_key, $ma
         source => $apt_gpg_key,
       },
     }
+  } else {
+    file { '/etc/apt/sources.list.d/signalfx-agent.list':
+      ensure => absent,
+    }
   }
 }

--- a/deployments/puppet/manifests/debian_repo.pp
+++ b/deployments/puppet/manifests/debian_repo.pp
@@ -1,7 +1,5 @@
 # Installs the Debian package repository config
-class signalfx_agent::debian_repo ($repo_base, $package_stage, $apt_gpg_key) {
-
-  Exec['apt_update'] -> Package['signalfx-agent']
+class signalfx_agent::debian_repo ($repo_base, $package_stage, $apt_gpg_key, $manage_repo) {
 
   exec { 'delete old apt key':
     path    => '/bin:/usr/bin',
@@ -14,13 +12,17 @@ class signalfx_agent::debian_repo ($repo_base, $package_stage, $apt_gpg_key) {
     path   => '/etc/apt/trusted.gpg.d/signalfx.gpg',
   }
 
-  apt::source { 'signalfx-agent':
-    location => "https://${repo_base}/signalfx-agent-deb",
-    release  => $package_stage,
-    repos    => 'main',
-    key      => {
-      id     => '58C33310B7A354C1279DB6695EFA01EDB3CD4420',
-      source => $apt_gpg_key,
-    },
+  if $manage_repo {
+    Exec['apt_update'] -> Package['signalfx-agent']
+
+    apt::source { 'signalfx-agent':
+      location => "https://${repo_base}/signalfx-agent-deb",
+      release  => $package_stage,
+      repos    => 'main',
+      key      => {
+        id     => '58C33310B7A354C1279DB6695EFA01EDB3CD4420',
+        source => $apt_gpg_key,
+      },
+    }
   }
 }

--- a/deployments/puppet/manifests/debian_repo.pp
+++ b/deployments/puppet/manifests/debian_repo.pp
@@ -1,5 +1,5 @@
 # Installs the Debian package repository config
-class signalfx_agent::debian_repo ($repo_base, $package_stage) {
+class signalfx_agent::debian_repo ($repo_base, $package_stage, $apt_gpg_key) {
 
   Exec['apt_update'] -> Package['signalfx-agent']
 
@@ -20,7 +20,7 @@ class signalfx_agent::debian_repo ($repo_base, $package_stage) {
     repos    => 'main',
     key      => {
       id     => '58C33310B7A354C1279DB6695EFA01EDB3CD4420',
-      source => "https://${repo_base}/signalfx-agent-deb/splunk-B3CD4420.gpg",
+      source => $apt_gpg_key,
     },
   }
 }

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -15,7 +15,8 @@ class signalfx_agent (
   $service_user           = 'signalfx-agent',  # linux only
   $service_group          = 'signalfx-agent',  # linux only
   $apt_gpg_key            = 'https://splunk.jfrog.io/splunk/signalfx-agent-deb/splunk-B3CD4420.gpg',
-  $yum_gpg_key            = 'https://splunk.jfrog.io/splunk/signalfx-agent-rpm/splunk-B3CD4420.pub'
+  $yum_gpg_key            = 'https://splunk.jfrog.io/splunk/signalfx-agent-rpm/splunk-B3CD4420.pub',
+  $manage_repo            = true  # linux only
 ) {
 
   $service_name = 'signalfx-agent'
@@ -65,6 +66,7 @@ class signalfx_agent (
         repo_base     => $repo_base,
         package_stage => $package_stage,
         apt_gpg_key   => $apt_gpg_key,
+        manage_repo   => $manage_repo,
       }
     }
     'redhat': {
@@ -72,6 +74,7 @@ class signalfx_agent (
         repo_base     => $repo_base,
         package_stage => $package_stage,
         yum_gpg_key   => $yum_gpg_key,
+        manage_repo   => $manage_repo,
       }
     }
     'windows': {

--- a/deployments/puppet/manifests/init.pp
+++ b/deployments/puppet/manifests/init.pp
@@ -14,6 +14,8 @@ class signalfx_agent (
   $installation_directory = 'C:\\Program Files\\SignalFx',
   $service_user           = 'signalfx-agent',  # linux only
   $service_group          = 'signalfx-agent',  # linux only
+  $apt_gpg_key            = 'https://splunk.jfrog.io/splunk/signalfx-agent-deb/splunk-B3CD4420.gpg',
+  $yum_gpg_key            = 'https://splunk.jfrog.io/splunk/signalfx-agent-rpm/splunk-B3CD4420.pub'
 ) {
 
   $service_name = 'signalfx-agent'
@@ -62,12 +64,14 @@ class signalfx_agent (
       class { 'signalfx_agent::debian_repo':
         repo_base     => $repo_base,
         package_stage => $package_stage,
+        apt_gpg_key   => $apt_gpg_key,
       }
     }
     'redhat': {
       class { 'signalfx_agent::yum_repo':
         repo_base     => $repo_base,
         package_stage => $package_stage,
+        yum_gpg_key   => $yum_gpg_key,
       }
     }
     'windows': {

--- a/deployments/puppet/manifests/yum_repo.pp
+++ b/deployments/puppet/manifests/yum_repo.pp
@@ -1,21 +1,22 @@
 # Installs the yum package repostitory for the given stage
-class signalfx_agent::yum_repo ($repo_base, $package_stage, $yum_gpg_key) {
+class signalfx_agent::yum_repo ($repo_base, $package_stage, $yum_gpg_key, $manage_repo) {
 
   package { 'gpg-pubkey-098acf3b-55a5351a':
     ensure => absent
   }
 
-  file { '/etc/yum.repos.d/signalfx-agent.repo':
-    content => @("EOH")
-      [signalfx-agent]
-      name=SignalFx Agent Repository
-      baseurl=https://${repo_base}/signalfx-agent-rpm/${package_stage}
-      gpgcheck=1
-      gpgkey=${yum_gpg_key}
-      enabled=1
-      | EOH
-      ,
-    mode    => '0644',
+  if $manage_repo {
+    file { '/etc/yum.repos.d/signalfx-agent.repo':
+      content => @("EOH")
+        [signalfx-agent]
+        name=SignalFx Agent Repository
+        baseurl=https://${repo_base}/signalfx-agent-rpm/${package_stage}
+        gpgcheck=1
+        gpgkey=${yum_gpg_key}
+        enabled=1
+        | EOH
+    ,
+    mode      => '0644',
+    }
   }
-
 }

--- a/deployments/puppet/manifests/yum_repo.pp
+++ b/deployments/puppet/manifests/yum_repo.pp
@@ -1,5 +1,5 @@
 # Installs the yum package repostitory for the given stage
-class signalfx_agent::yum_repo ($repo_base, $package_stage) {
+class signalfx_agent::yum_repo ($repo_base, $package_stage, $yum_gpg_key) {
 
   package { 'gpg-pubkey-098acf3b-55a5351a':
     ensure => absent
@@ -11,7 +11,7 @@ class signalfx_agent::yum_repo ($repo_base, $package_stage) {
       name=SignalFx Agent Repository
       baseurl=https://${repo_base}/signalfx-agent-rpm/${package_stage}
       gpgcheck=1
-      gpgkey=https://${repo_base}/signalfx-agent-rpm/splunk-B3CD4420.pub
+      gpgkey=${yum_gpg_key}
       enabled=1
       | EOH
       ,

--- a/deployments/puppet/manifests/yum_repo.pp
+++ b/deployments/puppet/manifests/yum_repo.pp
@@ -18,5 +18,9 @@ class signalfx_agent::yum_repo ($repo_base, $package_stage, $yum_gpg_key, $manag
     ,
     mode      => '0644',
     }
+  } else {
+    file { '/etc/yum.repos.d/signalfx-agent.repo':
+      ensure => absent,
+    }
   }
 }

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-signalfx_agent",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "SignalFx, Inc.",
   "summary": "This module installs the SignalFx SmartAgent via distro packages and configures it.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Unties gpg key from `repo_base` if configured for a custom mirror.