### PR TITLE
http hide default port

### DIFF
--- a/pkg/monitors/http/http.go
+++ b/pkg/monitors/http/http.go
@@ -98,10 +98,14 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 			m.URLs = append(m.URLs, clientURL)
 		}
 	} else {
-		// always try https if available. This is for backwards compat.
+		// always try https if available. This is for backwards compat with deprecated URLs.
 		m.conf.UseHTTPS = true
 	}
 	for _, site := range m.conf.URLs {
+		// add http scheme if not explicitely set
+		if !strings.HasPrefix(site, "http") {
+			site = fmt.Sprintf("http://%s", site)
+		}
 		stringURL, err := m.normalizeURL(site)
 		if err != nil {
 			m.logger.WithField("url", site).WithError(err).Error("error configuring url from list, ignore it")
@@ -163,18 +167,21 @@ func (m *Monitor) normalizeURL(site string) (normalizedURL *url.URL, err error) 
 	if err != nil {
 		return
 	}
+	host := stringURL.Hostname()
 	port := stringURL.Port()
-	if port == "" {
+	// for deprecated URLs only, set default port if not explicitely set
+	if host == stringURL.Host {
 		port = "80"
-		if stringURL.Scheme == "https" {
-			port = "443"
-		}
+	}
+	// keep port only if custom, hide default
+	if port != "80" && port != "443" {
+		host = fmt.Sprintf("%s:%s", host, port)
 	}
 	path := stringURL.Path
 	if path == "" {
 		path = "/"
 	}
-	normalizedURL, err = url.Parse(fmt.Sprintf("%s://%s:%s%s", stringURL.Scheme, stringURL.Hostname(), port, path))
+	normalizedURL, err = url.Parse(fmt.Sprintf("%s://%s%s", stringURL.Scheme, host, path))
 	if err != nil {
 		return
 	}

--- a/pkg/monitors/http/http.go
+++ b/pkg/monitors/http/http.go
@@ -102,7 +102,7 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 		m.conf.UseHTTPS = true
 	}
 	for _, site := range m.conf.URLs {
-		// add http scheme if not explicitely set
+		// add http scheme if not explicitly set
 		if !strings.HasPrefix(site, "http") {
 			site = fmt.Sprintf("http://%s", site)
 		}
@@ -169,7 +169,7 @@ func (m *Monitor) normalizeURL(site string) (normalizedURL *url.URL, err error) 
 	}
 	host := stringURL.Hostname()
 	port := stringURL.Port()
-	// for deprecated URLs only, set default port if not explicitely set
+	// for deprecated URLs only, set default port if not explicitly set
 	if host == stringURL.Host {
 		port = "80"
 	}


### PR DESCRIPTION
hello,

TLDR: this will hide port from reported `url` dimension and by extension this will avoid to append port (when it is the default 443/80) to host header of the request (which could cause problem not visible in curl or python/requests)

Explanation:

we noticed a "false" regression after https://github.com/signalfx/signalfx-agent/pull/1466/files#diff-09c5869e1f3558b54e8f6e5bdda3a471477975363b94d5aed0cc0978e2ab6122R94

indeed, one of our customer webcheck failed on regex (with 200 status code). After troubleshooting we understood the problem comes from the port in the host header in request sent by the monitor. Basically:

- `curl -H 'Host: myhost' https://myhost:443/mypath` works
- `curl -H 'Host: myhost:443' https://myhost:443/mypath` does not work

in fact golang `net/http` behaves differently than `curl`, `python/requests` or even our web browser like firefox because it defines the port for Host header even when port is the default (443 for https, 80 for http) which respects the HTTP spec.

So it works for curl with default behavior `curl https://myhost:443/mypath` (using "myhost" as host header) but not for golang (and the signalfx agent) which set host header to "myhost:443".

in my opinion, this is not a bug in true and this should not cause problem unless if backend does not parse host header properly (sadly this wase the case here) so the goal of this PR:

- is not to fix this specific and not desirable use case
- but it seems cleaner to remove port from normalized url when this is the default (like chromium or firefox browsers do (probably for esthetical and avoid space waste I suppose).
- AND the behavior from http monitor will be the same than curl or python/requests which should be more consistent and obvious for people and troubleshooting (in the same time this will fix the regex for our specific use case).