### PR TITLE
cassandra: add total, caswrite and casread latencies

### DIFF
--- a/docs/monitors/collectd-cassandra.md
+++ b/docs/monitors/collectd-cassandra.md
@@ -91,6 +91,18 @@ Metrics that are categorized as
 This monitor will also emit by default any metrics that are not listed below.
 
 
+ - `counter.cassandra.ClientRequest.CASRead.Latency.Count` (*cumulative*)<br>    Count of transactional read operations since server start.
+ - `counter.cassandra.ClientRequest.CASRead.TotalLatency.Count` (*cumulative*)<br>    The total number of microseconds elapsed in servicing client transactional read requests.
+
+    It can be devided by `counter.cassandra.ClientRequest.CASRead.Latency.Count`
+    to find the real time transactional read latency.
+
+ - `counter.cassandra.ClientRequest.CASWrite.Latency.Count` (*cumulative*)<br>    Count of transactional write operations since server start.
+ - `counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count` (*cumulative*)<br>    The total number of microseconds elapsed in servicing client transactional write requests.
+
+    It can be devided by `counter.cassandra.ClientRequest.CASWrite.Latency.Count`
+    to find the real time transactional write latency.
+
  - ***`counter.cassandra.ClientRequest.RangeSlice.Latency.Count`*** (*cumulative*)<br>    Count of range slice operations since server start. This typically indicates a server overload condition.
 
     If this value is increasing across the cluster then the cluster is too small for the application range slice load.
@@ -108,6 +120,7 @@ This monitor will also emit by default any metrics that are not listed below.
     - one or more clients are directing more load to this server than the others
     - the server is experiencing hardware or software issues and may require maintenance.
 
+ - `counter.cassandra.ClientRequest.RangeSlice.TotalLatency.Count` (*cumulative*)<br>    The total number of microseconds elapsed in servicing range slice requests.
  - ***`counter.cassandra.ClientRequest.RangeSlice.Unavailables.Count`*** (*cumulative*)<br>    Count of range slice unavailables since server start. A non-zero value
     means that insufficient replicas were available to fulfil a range slice
     request at the requested consistency level.
@@ -115,7 +128,7 @@ This monitor will also emit by default any metrics that are not listed below.
     This typically means that one or more nodes are down. To fix this condition,
     any down nodes must be restarted, or removed from the cluster.
 
- - ***`counter.cassandra.ClientRequest.Read.Latency.Count`*** (*cumulative*)<br>    Count of read operations since server start
+ - ***`counter.cassandra.ClientRequest.Read.Latency.Count`*** (*cumulative*)<br>    Count of read operations since server start.
  - ***`counter.cassandra.ClientRequest.Read.Timeouts.Count`*** (*cumulative*)<br>    Count of read timeouts since server start. This typically indicates a server overload condition.
 
     If this value is increasing across the cluster then the cluster is too small for the application read load.
@@ -123,6 +136,11 @@ This monitor will also emit by default any metrics that are not listed below.
     If this value is increasing for a single server in a cluster, then one of the following conditions may be true:
     - one or more clients are directing more load to this server than the others
     - the server is experiencing hardware or software issues and may require maintenance.
+
+ - `counter.cassandra.ClientRequest.Read.TotalLatency.Count` (*cumulative*)<br>    The total number of microseconds elapsed in servicing client read requests.
+
+    It can be devided by `counter.cassandra.ClientRequest.Read.Latency.Count`
+    to find the real time read latency.
 
  - ***`counter.cassandra.ClientRequest.Read.Unavailables.Count`*** (*cumulative*)<br>    Count of read unavailables since server start. A non-zero value means
     that insufficient replicas were available to fulfil a read request at
@@ -138,6 +156,11 @@ This monitor will also emit by default any metrics that are not listed below.
     If this value is increasing for a single server in a cluster, then one of the following conditions may be true:
     - one or more clients are directing more load to this server than the others
     - the server is experiencing hardware or software issues and may require maintenance.
+
+ - `counter.cassandra.ClientRequest.Write.TotalLatency.Count` (*cumulative*)<br>    The total number of microseconds elapsed in servicing client write requests.
+
+    It can be devided by `counter.cassandra.ClientRequest.Write.Latency.Count`
+    to find the real time write latency.
 
  - ***`counter.cassandra.ClientRequest.Write.Unavailables.Count`*** (*cumulative*)<br>    Count of write unavailables since server start. A non-zero value means
     that insufficient replicas were available to fulfil a write request at
@@ -169,6 +192,16 @@ This monitor will also emit by default any metrics that are not listed below.
     increasing and all nodes are up then there may be some connectivity
     issue between nodes in the cluster.
 
+ - `gauge.cassandra.ClientRequest.CASRead.Latency.50thPercentile` (*gauge*)<br>    50th percentile (median) of Cassandra transactional read latency.
+
+ - `gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile` (*gauge*)<br>    99th percentile of Cassandra transactional read latency.
+
+ - `gauge.cassandra.ClientRequest.CASRead.Latency.Max` (*gauge*)<br>    Maximum Cassandra transactional read latency.
+ - `gauge.cassandra.ClientRequest.CASWrite.Latency.50thPercentile` (*gauge*)<br>    50th percentile (median) of Cassandra transactional write latency.
+
+ - `gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile` (*gauge*)<br>    99th percentile of Cassandra transactional write latency.
+
+ - `gauge.cassandra.ClientRequest.CASWrite.Latency.Max` (*gauge*)<br>    Maximum Cassandra transactional write latency.
  - `gauge.cassandra.ClientRequest.RangeSlice.Latency.50thPercentile` (*gauge*)<br>    50th percentile (median) of Cassandra range slice latency. This value
     should be similar across all nodes in the cluster. If some nodes have higher
     values than the rest of the cluster then they may have more connected clients
@@ -179,7 +212,7 @@ This monitor will also emit by default any metrics that are not listed below.
     the rest of the cluster then they may have more connected clients or may be
     experiencing heavier than usual compaction load.
 
- - `gauge.cassandra.ClientRequest.RangeSlice.Latency.Max` (*gauge*)<br>    Maximum Cassandra range slice latency
+ - `gauge.cassandra.ClientRequest.RangeSlice.Latency.Max` (*gauge*)<br>    Maximum Cassandra range slice latency.
  - ***`gauge.cassandra.ClientRequest.Read.Latency.50thPercentile`*** (*gauge*)<br>    50th percentile (median) of Cassandra read latency. This value should
     be similar across all nodes in the cluster. If some nodes have higher
     values than the rest of the cluster then they may have more connected
@@ -190,7 +223,7 @@ This monitor will also emit by default any metrics that are not listed below.
     the rest of the cluster then they may have more connected clients or
     may be experiencing heavier than usual compaction load.
 
- - ***`gauge.cassandra.ClientRequest.Read.Latency.Max`*** (*gauge*)<br>    Maximum Cassandra read latency
+ - ***`gauge.cassandra.ClientRequest.Read.Latency.Max`*** (*gauge*)<br>    Maximum Cassandra read latency.
  - ***`gauge.cassandra.ClientRequest.Write.Latency.50thPercentile`*** (*gauge*)<br>    50th percentile (median) of Cassandra write latency. This value should
     be similar across all nodes in the cluster. If some nodes have higher
     values than the rest of the cluster then they may have more connected

--- a/pkg/monitors/collectd/cassandra/genmetadata.go
+++ b/pkg/monitors/collectd/cassandra/genmetadata.go
@@ -18,20 +18,33 @@ var groupSet = map[string]bool{
 }
 
 const (
+	counterCassandraClientRequestCASReadLatencyCount           = "counter.cassandra.ClientRequest.CASRead.Latency.Count"
+	counterCassandraClientRequestCASReadTotalLatencyCount      = "counter.cassandra.ClientRequest.CASRead.TotalLatency.Count"
+	counterCassandraClientRequestCASWriteLatencyCount          = "counter.cassandra.ClientRequest.CASWrite.Latency.Count"
+	counterCassandraClientRequestCASWriteTotalLatencyCount     = "counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count"
 	counterCassandraClientRequestRangeSliceLatencyCount        = "counter.cassandra.ClientRequest.RangeSlice.Latency.Count"
 	counterCassandraClientRequestRangeSliceTimeoutsCount       = "counter.cassandra.ClientRequest.RangeSlice.Timeouts.Count"
+	counterCassandraClientRequestRangeSliceTotalLatencyCount   = "counter.cassandra.ClientRequest.RangeSlice.TotalLatency.Count"
 	counterCassandraClientRequestRangeSliceUnavailablesCount   = "counter.cassandra.ClientRequest.RangeSlice.Unavailables.Count"
 	counterCassandraClientRequestReadLatencyCount              = "counter.cassandra.ClientRequest.Read.Latency.Count"
 	counterCassandraClientRequestReadTimeoutsCount             = "counter.cassandra.ClientRequest.Read.Timeouts.Count"
+	counterCassandraClientRequestReadTotalLatencyCount         = "counter.cassandra.ClientRequest.Read.TotalLatency.Count"
 	counterCassandraClientRequestReadUnavailablesCount         = "counter.cassandra.ClientRequest.Read.Unavailables.Count"
 	counterCassandraClientRequestWriteLatencyCount             = "counter.cassandra.ClientRequest.Write.Latency.Count"
 	counterCassandraClientRequestWriteTimeoutsCount            = "counter.cassandra.ClientRequest.Write.Timeouts.Count"
+	counterCassandraClientRequestWriteTotalLatencyCount        = "counter.cassandra.ClientRequest.Write.TotalLatency.Count"
 	counterCassandraClientRequestWriteUnavailablesCount        = "counter.cassandra.ClientRequest.Write.Unavailables.Count"
 	counterCassandraCompactionTotalCompactionsCompletedCount   = "counter.cassandra.Compaction.TotalCompactionsCompleted.Count"
 	counterCassandraStorageExceptionsCount                     = "counter.cassandra.Storage.Exceptions.Count"
 	counterCassandraStorageLoadCount                           = "counter.cassandra.Storage.Load.Count"
 	counterCassandraStorageTotalHintsCount                     = "counter.cassandra.Storage.TotalHints.Count"
 	counterCassandraStorageTotalHintsInProgressCount           = "counter.cassandra.Storage.TotalHintsInProgress.Count"
+	gaugeCassandraClientRequestCASReadLatency50thPercentile    = "gauge.cassandra.ClientRequest.CASRead.Latency.50thPercentile"
+	gaugeCassandraClientRequestCASReadLatency99thPercentile    = "gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile"
+	gaugeCassandraClientRequestCASReadLatencyMax               = "gauge.cassandra.ClientRequest.CASRead.Latency.Max"
+	gaugeCassandraClientRequestCASWriteLatency50thPercentile   = "gauge.cassandra.ClientRequest.CASWrite.Latency.50thPercentile"
+	gaugeCassandraClientRequestCASWriteLatency99thPercentile   = "gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile"
+	gaugeCassandraClientRequestCASWriteLatencyMax              = "gauge.cassandra.ClientRequest.CASWrite.Latency.Max"
 	gaugeCassandraClientRequestRangeSliceLatency50thPercentile = "gauge.cassandra.ClientRequest.RangeSlice.Latency.50thPercentile"
 	gaugeCassandraClientRequestRangeSliceLatency99thPercentile = "gauge.cassandra.ClientRequest.RangeSlice.Latency.99thPercentile"
 	gaugeCassandraClientRequestRangeSliceLatencyMax            = "gauge.cassandra.ClientRequest.RangeSlice.Latency.Max"
@@ -53,20 +66,33 @@ const (
 )
 
 var metricSet = map[string]monitors.MetricInfo{
+	counterCassandraClientRequestCASReadLatencyCount:           {Type: datapoint.Counter},
+	counterCassandraClientRequestCASReadTotalLatencyCount:      {Type: datapoint.Counter},
+	counterCassandraClientRequestCASWriteLatencyCount:          {Type: datapoint.Counter},
+	counterCassandraClientRequestCASWriteTotalLatencyCount:     {Type: datapoint.Counter},
 	counterCassandraClientRequestRangeSliceLatencyCount:        {Type: datapoint.Counter},
 	counterCassandraClientRequestRangeSliceTimeoutsCount:       {Type: datapoint.Counter},
+	counterCassandraClientRequestRangeSliceTotalLatencyCount:   {Type: datapoint.Counter},
 	counterCassandraClientRequestRangeSliceUnavailablesCount:   {Type: datapoint.Counter},
 	counterCassandraClientRequestReadLatencyCount:              {Type: datapoint.Counter},
 	counterCassandraClientRequestReadTimeoutsCount:             {Type: datapoint.Counter},
+	counterCassandraClientRequestReadTotalLatencyCount:         {Type: datapoint.Counter},
 	counterCassandraClientRequestReadUnavailablesCount:         {Type: datapoint.Counter},
 	counterCassandraClientRequestWriteLatencyCount:             {Type: datapoint.Counter},
 	counterCassandraClientRequestWriteTimeoutsCount:            {Type: datapoint.Counter},
+	counterCassandraClientRequestWriteTotalLatencyCount:        {Type: datapoint.Counter},
 	counterCassandraClientRequestWriteUnavailablesCount:        {Type: datapoint.Counter},
 	counterCassandraCompactionTotalCompactionsCompletedCount:   {Type: datapoint.Counter},
 	counterCassandraStorageExceptionsCount:                     {Type: datapoint.Counter},
 	counterCassandraStorageLoadCount:                           {Type: datapoint.Counter},
 	counterCassandraStorageTotalHintsCount:                     {Type: datapoint.Counter},
 	counterCassandraStorageTotalHintsInProgressCount:           {Type: datapoint.Counter},
+	gaugeCassandraClientRequestCASReadLatency50thPercentile:    {Type: datapoint.Gauge},
+	gaugeCassandraClientRequestCASReadLatency99thPercentile:    {Type: datapoint.Gauge},
+	gaugeCassandraClientRequestCASReadLatencyMax:               {Type: datapoint.Gauge},
+	gaugeCassandraClientRequestCASWriteLatency50thPercentile:   {Type: datapoint.Gauge},
+	gaugeCassandraClientRequestCASWriteLatency99thPercentile:   {Type: datapoint.Gauge},
+	gaugeCassandraClientRequestCASWriteLatencyMax:              {Type: datapoint.Gauge},
 	gaugeCassandraClientRequestRangeSliceLatency50thPercentile: {Type: datapoint.Gauge},
 	gaugeCassandraClientRequestRangeSliceLatency99thPercentile: {Type: datapoint.Gauge},
 	gaugeCassandraClientRequestRangeSliceLatencyMax:            {Type: datapoint.Gauge},

--- a/pkg/monitors/collectd/cassandra/mbeans.go
+++ b/pkg/monitors/collectd/cassandra/mbeans.go
@@ -20,6 +20,39 @@ cassandra-client-read-latency:
     attribute: Count
 
 
+cassandra-client-read-totallatency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=TotalLatency
+  values:
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.Read.TotalLatency.Count
+    attribute: Count
+
+
+cassandra-client-casread-latency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=CASRead,name=Latency
+  values:
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASRead.Latency.50thPercentile
+    attribute: 50thPercentile
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASRead.Latency.Max
+    attribute: Max
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASRead.Latency.99thPercentile
+    attribute: 99thPercentile
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.CASRead.Latency.Count
+    attribute: Count
+
+
+cassandra-client-casread-totallatency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=CASRead,name=TotalLatency
+  values:
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.CASRead.TotalLatency.Count
+    attribute: Count
+
+
 cassandra-client-read-timeouts:
   objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=Read,name=Timeouts
   values:
@@ -53,6 +86,14 @@ cassandra-client-rangeslice-latency:
     attribute: Count
 
 
+cassandra-client-rangeslice-totallatency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=RangeSlice,name=TotalLatency
+  values:
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.RangeSlice.TotalLatency.Count
+    attribute: Count
+
+
 cassandra-client-rangeslice-timeouts:
   objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=RangeSlice,name=Timeouts
   values:
@@ -83,6 +124,39 @@ cassandra-client-write-latency:
     attribute: 99thPercentile
   - type: counter
     instancePrefix: cassandra.ClientRequest.Write.Latency.Count
+    attribute: Count
+
+
+cassandra-client-write-totallatency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=Write,name=TotalLatency
+  values:
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.Write.TotalLatency.Count
+    attribute: Count
+
+
+cassandra-client-caswrite-latency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=CASWrite,name=Latency
+  values:
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASWrite.Latency.50thPercentile
+    attribute: 50thPercentile
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASWrite.Latency.Max
+    attribute: Max
+  - type: gauge
+    instancePrefix: cassandra.ClientRequest.CASWrite.Latency.99thPercentile
+    attribute: 99thPercentile
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.CASWrite.Latency.Count
+    attribute: Count
+
+
+cassandra-client-caswrite-totallatency:
+  objectName: org.apache.cassandra.metrics:type=ClientRequest,scope=CASWrite,name=TotalLatency
+  values:
+  - type: counter
+    instancePrefix: cassandra.ClientRequest.CASWrite.TotalLatency.Count
     attribute: Count
 
 

--- a/pkg/monitors/collectd/cassandra/metadata.yaml
+++ b/pkg/monitors/collectd/cassandra/metadata.yaml
@@ -74,6 +74,10 @@ monitors:
         - the server is experiencing hardware or software issues and may require maintenance.
       default: true
       type: cumulative
+    counter.cassandra.ClientRequest.RangeSlice.TotalLatency.Count:
+      description: The total number of microseconds elapsed in servicing range slice requests.
+      default: false
+      type: cumulative
     counter.cassandra.ClientRequest.RangeSlice.Timeouts.Count:
       description: |
         Count of range slice timeouts since server start. This typically indicates a server overload condition.
@@ -96,8 +100,28 @@ monitors:
       default: true
       type: cumulative
     counter.cassandra.ClientRequest.Read.Latency.Count:
-      description: Count of read operations since server start
+      description: Count of read operations since server start.
       default: true
+      type: cumulative
+    counter.cassandra.ClientRequest.Read.TotalLatency.Count:
+      description: |
+        The total number of microseconds elapsed in servicing client read requests.
+
+        It can be devided by `counter.cassandra.ClientRequest.Read.Latency.Count`
+        to find the real time read latency.
+      default: false
+      type: cumulative
+    counter.cassandra.ClientRequest.CASRead.Latency.Count:
+      description: Count of transactional read operations since server start.
+      default: false
+      type: cumulative
+    counter.cassandra.ClientRequest.CASRead.TotalLatency.Count:
+      description: |
+        The total number of microseconds elapsed in servicing client transactional read requests.
+
+        It can be devided by `counter.cassandra.ClientRequest.CASRead.Latency.Count`
+        to find the real time transactional read latency.
+      default: false
       type: cumulative
     counter.cassandra.ClientRequest.Read.Timeouts.Count:
       description: |
@@ -122,6 +146,26 @@ monitors:
     counter.cassandra.ClientRequest.Write.Latency.Count:
       description: Count of write operations since server start.
       default: true
+      type: cumulative
+    counter.cassandra.ClientRequest.Write.TotalLatency.Count:
+      description: |
+        The total number of microseconds elapsed in servicing client write requests.
+
+        It can be devided by `counter.cassandra.ClientRequest.Write.Latency.Count`
+        to find the real time write latency.
+      default: false
+      type: cumulative
+    counter.cassandra.ClientRequest.CASWrite.Latency.Count:
+      description: Count of transactional write operations since server start.
+      default: false
+      type: cumulative
+    counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count:
+      description: |
+        The total number of microseconds elapsed in servicing client transactional write requests.
+
+        It can be devided by `counter.cassandra.ClientRequest.CASWrite.Latency.Count`
+        to find the real time transactional write latency.
+      default: false
       type: cumulative
     counter.cassandra.ClientRequest.Write.Timeouts.Count:
       description: |
@@ -169,7 +213,7 @@ monitors:
       default: true
       type: gauge
     gauge.cassandra.ClientRequest.RangeSlice.Latency.Max:
-      description: Maximum Cassandra range slice latency
+      description: Maximum Cassandra range slice latency.
       default: false
       type: gauge
     gauge.cassandra.ClientRequest.Read.Latency.50thPercentile:
@@ -189,8 +233,22 @@ monitors:
       default: true
       type: gauge
     gauge.cassandra.ClientRequest.Read.Latency.Max:
-      description: Maximum Cassandra read latency
+      description: Maximum Cassandra read latency.
       default: true
+      type: gauge
+    gauge.cassandra.ClientRequest.CASRead.Latency.50thPercentile:
+      description: |
+        50th percentile (median) of Cassandra transactional read latency.
+      default: false
+      type: gauge
+    gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile:
+      description: |
+        99th percentile of Cassandra transactional read latency.
+      default: false
+      type: gauge
+    gauge.cassandra.ClientRequest.CASRead.Latency.Max:
+      description: Maximum Cassandra transactional read latency.
+      default: false
       type: gauge
     gauge.cassandra.ClientRequest.Write.Latency.50thPercentile:
       description: |
@@ -211,6 +269,20 @@ monitors:
     gauge.cassandra.ClientRequest.Write.Latency.Max:
       description: Maximum Cassandra write latency
       default: true
+      type: gauge
+    gauge.cassandra.ClientRequest.CASWrite.Latency.50thPercentile:
+      description: |
+        50th percentile (median) of Cassandra transactional write latency.
+      default: false
+      type: gauge
+    gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile:
+      description: |
+        99th percentile of Cassandra transactional write latency.
+      default: false
+      type: gauge
+    gauge.cassandra.ClientRequest.CASWrite.Latency.Max:
+      description: Maximum Cassandra transactional write latency.
+      default: false
       type: gauge
     gauge.cassandra.Compaction.PendingTasks.Value:
       description: |

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -4903,20 +4903,33 @@
         "": {
           "description": "",
           "metrics": [
+            "counter.cassandra.ClientRequest.CASRead.Latency.Count",
+            "counter.cassandra.ClientRequest.CASRead.TotalLatency.Count",
+            "counter.cassandra.ClientRequest.CASWrite.Latency.Count",
+            "counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count",
             "counter.cassandra.ClientRequest.RangeSlice.Latency.Count",
             "counter.cassandra.ClientRequest.RangeSlice.Timeouts.Count",
+            "counter.cassandra.ClientRequest.RangeSlice.TotalLatency.Count",
             "counter.cassandra.ClientRequest.RangeSlice.Unavailables.Count",
             "counter.cassandra.ClientRequest.Read.Latency.Count",
             "counter.cassandra.ClientRequest.Read.Timeouts.Count",
+            "counter.cassandra.ClientRequest.Read.TotalLatency.Count",
             "counter.cassandra.ClientRequest.Read.Unavailables.Count",
             "counter.cassandra.ClientRequest.Write.Latency.Count",
             "counter.cassandra.ClientRequest.Write.Timeouts.Count",
+            "counter.cassandra.ClientRequest.Write.TotalLatency.Count",
             "counter.cassandra.ClientRequest.Write.Unavailables.Count",
             "counter.cassandra.Compaction.TotalCompactionsCompleted.Count",
             "counter.cassandra.Storage.Exceptions.Count",
             "counter.cassandra.Storage.Load.Count",
             "counter.cassandra.Storage.TotalHints.Count",
             "counter.cassandra.Storage.TotalHintsInProgress.Count",
+            "gauge.cassandra.ClientRequest.CASRead.Latency.50thPercentile",
+            "gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile",
+            "gauge.cassandra.ClientRequest.CASRead.Latency.Max",
+            "gauge.cassandra.ClientRequest.CASWrite.Latency.50thPercentile",
+            "gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile",
+            "gauge.cassandra.ClientRequest.CASWrite.Latency.Max",
             "gauge.cassandra.ClientRequest.RangeSlice.Latency.50thPercentile",
             "gauge.cassandra.ClientRequest.RangeSlice.Latency.99thPercentile",
             "gauge.cassandra.ClientRequest.RangeSlice.Latency.Max",
@@ -4944,6 +4957,30 @@
         }
       },
       "metrics": {
+        "counter.cassandra.ClientRequest.CASRead.Latency.Count": {
+          "type": "cumulative",
+          "description": "Count of transactional read operations since server start.",
+          "group": null,
+          "default": false
+        },
+        "counter.cassandra.ClientRequest.CASRead.TotalLatency.Count": {
+          "type": "cumulative",
+          "description": "The total number of microseconds elapsed in servicing client transactional read requests.\n\nIt can be devided by `counter.cassandra.ClientRequest.CASRead.Latency.Count`\nto find the real time transactional read latency.\n",
+          "group": null,
+          "default": false
+        },
+        "counter.cassandra.ClientRequest.CASWrite.Latency.Count": {
+          "type": "cumulative",
+          "description": "Count of transactional write operations since server start.",
+          "group": null,
+          "default": false
+        },
+        "counter.cassandra.ClientRequest.CASWrite.TotalLatency.Count": {
+          "type": "cumulative",
+          "description": "The total number of microseconds elapsed in servicing client transactional write requests.\n\nIt can be devided by `counter.cassandra.ClientRequest.CASWrite.Latency.Count`\nto find the real time transactional write latency.\n",
+          "group": null,
+          "default": false
+        },
         "counter.cassandra.ClientRequest.RangeSlice.Latency.Count": {
           "type": "cumulative",
           "description": "Count of range slice operations since server start. This typically indicates a server overload condition.\n\nIf this value is increasing across the cluster then the cluster is too small for the application range slice load.\n\nIf this value is increasing for a single server in a cluster, then one of the following conditions may be true:\n\n- one or more clients are directing more load to this server than the others\n- the server is experiencing hardware or software issues and may require maintenance.\n",
@@ -4956,6 +4993,12 @@
           "group": null,
           "default": true
         },
+        "counter.cassandra.ClientRequest.RangeSlice.TotalLatency.Count": {
+          "type": "cumulative",
+          "description": "The total number of microseconds elapsed in servicing range slice requests.",
+          "group": null,
+          "default": false
+        },
         "counter.cassandra.ClientRequest.RangeSlice.Unavailables.Count": {
           "type": "cumulative",
           "description": "Count of range slice unavailables since server start. A non-zero value\nmeans that insufficient replicas were available to fulfil a range slice\nrequest at the requested consistency level.\n\nThis typically means that one or more nodes are down. To fix this condition,\nany down nodes must be restarted, or removed from the cluster.\n",
@@ -4964,7 +5007,7 @@
         },
         "counter.cassandra.ClientRequest.Read.Latency.Count": {
           "type": "cumulative",
-          "description": "Count of read operations since server start",
+          "description": "Count of read operations since server start.",
           "group": null,
           "default": true
         },
@@ -4973,6 +5016,12 @@
           "description": "Count of read timeouts since server start. This typically indicates a server overload condition.\n\nIf this value is increasing across the cluster then the cluster is too small for the application read load.\n\nIf this value is increasing for a single server in a cluster, then one of the following conditions may be true:\n- one or more clients are directing more load to this server than the others\n- the server is experiencing hardware or software issues and may require maintenance.\n",
           "group": null,
           "default": true
+        },
+        "counter.cassandra.ClientRequest.Read.TotalLatency.Count": {
+          "type": "cumulative",
+          "description": "The total number of microseconds elapsed in servicing client read requests.\n\nIt can be devided by `counter.cassandra.ClientRequest.Read.Latency.Count`\nto find the real time read latency.\n",
+          "group": null,
+          "default": false
         },
         "counter.cassandra.ClientRequest.Read.Unavailables.Count": {
           "type": "cumulative",
@@ -4991,6 +5040,12 @@
           "description": "Count of write timeouts since server start. This typically indicates a server overload condition.\n\nIf this value is increasing across the cluster then the cluster is too small for the application write load.\n\nIf this value is increasing for a single server in a cluster, then one of the following conditions may be true:\n- one or more clients are directing more load to this server than the others\n- the server is experiencing hardware or software issues and may require maintenance.\n",
           "group": null,
           "default": true
+        },
+        "counter.cassandra.ClientRequest.Write.TotalLatency.Count": {
+          "type": "cumulative",
+          "description": "The total number of microseconds elapsed in servicing client write requests.\n\nIt can be devided by `counter.cassandra.ClientRequest.Write.Latency.Count`\nto find the real time write latency.\n",
+          "group": null,
+          "default": false
         },
         "counter.cassandra.ClientRequest.Write.Unavailables.Count": {
           "type": "cumulative",
@@ -5028,6 +5083,42 @@
           "group": null,
           "default": true
         },
+        "gauge.cassandra.ClientRequest.CASRead.Latency.50thPercentile": {
+          "type": "gauge",
+          "description": "50th percentile (median) of Cassandra transactional read latency.\n",
+          "group": null,
+          "default": false
+        },
+        "gauge.cassandra.ClientRequest.CASRead.Latency.99thPercentile": {
+          "type": "gauge",
+          "description": "99th percentile of Cassandra transactional read latency.\n",
+          "group": null,
+          "default": false
+        },
+        "gauge.cassandra.ClientRequest.CASRead.Latency.Max": {
+          "type": "gauge",
+          "description": "Maximum Cassandra transactional read latency.",
+          "group": null,
+          "default": false
+        },
+        "gauge.cassandra.ClientRequest.CASWrite.Latency.50thPercentile": {
+          "type": "gauge",
+          "description": "50th percentile (median) of Cassandra transactional write latency.\n",
+          "group": null,
+          "default": false
+        },
+        "gauge.cassandra.ClientRequest.CASWrite.Latency.99thPercentile": {
+          "type": "gauge",
+          "description": "99th percentile of Cassandra transactional write latency.\n",
+          "group": null,
+          "default": false
+        },
+        "gauge.cassandra.ClientRequest.CASWrite.Latency.Max": {
+          "type": "gauge",
+          "description": "Maximum Cassandra transactional write latency.",
+          "group": null,
+          "default": false
+        },
         "gauge.cassandra.ClientRequest.RangeSlice.Latency.50thPercentile": {
           "type": "gauge",
           "description": "50th percentile (median) of Cassandra range slice latency. This value\nshould be similar across all nodes in the cluster. If some nodes have higher\nvalues than the rest of the cluster then they may have more connected clients\nor may be experiencing heavier than usual compaction load.\n",
@@ -5042,7 +5133,7 @@
         },
         "gauge.cassandra.ClientRequest.RangeSlice.Latency.Max": {
           "type": "gauge",
-          "description": "Maximum Cassandra range slice latency",
+          "description": "Maximum Cassandra range slice latency.",
           "group": null,
           "default": false
         },
@@ -5060,7 +5151,7 @@
         },
         "gauge.cassandra.ClientRequest.Read.Latency.Max": {
           "type": "gauge",
-          "description": "Maximum Cassandra read latency",
+          "description": "Maximum Cassandra read latency.",
           "group": null,
           "default": true
         },


### PR DESCRIPTION
hello,

after https://github.com/signalfx/signalfx-agent/pull/1496 this one is focus on latencies.

especially it add CASWrite and CASRead latencies (fully similar as existing) which is very crucial to monitor (I already had real production use case where read/write are not enough to see problem)

also it add the total latency (in microseconds) which will allow to calculate the real time latency which seems to be a good info for alerting.