### PR TITLE
Change apt_key for get_url

### DIFF
--- a/deployments/ansible/roles/signalfx-agent/tasks/debian_repo.yml
+++ b/deployments/ansible/roles/signalfx-agent/tasks/debian_repo.yml
@@ -10,10 +10,10 @@
     state: absent
 
 - name: Add an Apt signing key for Signalfx Agent
-  apt_key:
+  get_url:
     url: "{{ sfx_repo_base_url }}/signalfx-agent-deb/splunk-B3CD4420.gpg"
-    keyring: /etc/apt/trusted.gpg.d/splunk.gpg
-    state: present
+    dest: /etc/apt/trusted.gpg.d/splunk.gpg
+    mode: 0644
 
 - name: Add Signalfx Agent repository into sources list
   apt_repository:


### PR DESCRIPTION
Hi,

`apt_key` do not support proxy environment settings or apt configuration (https://github.com/ansible/ansible/issues/31691), this makes this role unsable when we have to rely on proxies to setup our instances. `apt_key` is also not anymore the recommended to install keys (https://github.com/ansible/ansible/issues/55590).

`get_url` seems to be the easiest way to deal with this problem as it support proxy environment if we set it at task or playbook level (https://docs.ansible.com/ansible/latest/user_guide/playbooks_environment.html). 

Thanks,