### PR TITLE
Add expr filter config option to limit inventory collection

### DIFF
--- a/docs/monitors/vsphere.md
+++ b/docs/monitors/vsphere.md
@@ -65,6 +65,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `insecureSkipVerify` | no | `bool` | Whether we verify the server's certificate chain and host name (**default:** `false`) |
 | `inventoryRefreshInterval` | no | `int64` | How often to reload the inventory and inventory metrics (**default:** `60s`) |
 | `perfBatchSize` | no | `integer` | Maximum number of inventory objects to be queried for performance data per request. Set this value to zero (0) to request performance data for all inventory objects at a time. (**default:** `10`) |
+| `filter` | no | `string` | An 'expr' expression to limit the inventory traversed by the monitor. Leave blank or omit to traverse and get metrics for the entire vSphere inventory. Otherwise, this expression is evaluated per cluster. If the expression evaluates to true, metrics are collected for the objects in the cluster, otherwise it is skipped. Made available to the expr expression environment are the variables: `Datacenter` and `Cluster`. For example: filter: "Datacenter == 'MyDatacenter' && Cluster == 'MyCluster'" The above expr value will cause metrics collection for only the given datacenter + cluster. See https://github.com/antonmedv/expr for more advanced syntax. |
 | `tlsCACertPath` | no | `string` | Path to the ca file |
 | `tlsClientCertificatePath` | no | `string` | Configure client certs. Both tlsClientKeyPath and tlsClientCertificatePath must be present. The files must contain PEM encoded data. Path to the client certificate |
 | `tlsClientKeyPath` | no | `string` | Path to the keyfile |

--- a/pkg/monitors/vsphere/model/model.go
+++ b/pkg/monitors/vsphere/model/model.go
@@ -36,6 +36,16 @@ type Config struct {
 	// all inventory objects at a time.
 	PerfBatchSize int `yaml:"perfBatchSize" default:"10"`
 
+	// An 'expr' expression to limit the inventory traversed by the monitor. Leave blank or omit
+	// to traverse and get metrics for the entire vSphere inventory. Otherwise, this expression
+	// is evaluated per cluster. If the expression evaluates to true, metrics are collected for
+	// the objects in the cluster, otherwise it is skipped. Made available to the expr expression
+	// environment are the variables: `Datacenter` and `Cluster`. For example:
+	// filter: "Datacenter == 'MyDatacenter' && Cluster == 'MyCluster'"
+	// The above expr value will cause metrics collection for only the given datacenter + cluster.
+	// See https://github.com/antonmedv/expr for more advanced syntax.
+	Filter string `yaml:"filter"`
+
 	// Path to the ca file
 	TLSCACertPath string `yaml:"tlsCACertPath"`
 

--- a/pkg/monitors/vsphere/service/inv_filter.go
+++ b/pkg/monitors/vsphere/service/inv_filter.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"github.com/antonmedv/expr"
+	"github.com/antonmedv/expr/vm"
+)
+
+type InvFilter interface {
+	shouldFollowCluster(dims pairs) (bool, error)
+}
+
+func NewFilter(expression string) (InvFilter, error) {
+	if expression == "" {
+		return nopFilter{}, nil
+	}
+	f := filter{v: vm.VM{}}
+	var err error
+	f.program, err = expr.Compile(expression)
+	if err != nil {
+		return nopFilter{}, err
+	}
+	return f, nil
+}
+
+type nopFilter struct{}
+
+func (n nopFilter) shouldFollowCluster(pairs) (bool, error) {
+	return true, nil
+}
+
+type filter struct {
+	program *vm.Program
+	v       vm.VM
+}
+
+type env struct {
+	Datacenter string
+	Cluster    string
+}
+
+func (f filter) shouldFollowCluster(dims pairs) (bool, error) {
+	e := env{}
+	for _, dim := range dims {
+		if dim[0] == dimDatacenter {
+			e.Datacenter = dim[1]
+		} else if dim[0] == dimCluster {
+			e.Cluster = dim[1]
+		}
+	}
+	result, err := f.v.Run(f.program, e)
+	if err != nil {
+		// default to follow if there's a failure
+		return true, err
+	}
+	return result.(bool), nil
+}

--- a/pkg/monitors/vsphere/service/inv_filter_test.go
+++ b/pkg/monitors/vsphere/service/inv_filter_test.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvFilterMatch(t *testing.T) {
+	f, err := NewFilter("Datacenter == 'dc0' && Cluster == 'cluster0'")
+	require.NoError(t, err)
+	dims := pairs{
+		pair{dimDatacenter, "dc0"},
+		pair{dimCluster, "cluster0"},
+	}
+	follow, err := f.shouldFollowCluster(dims)
+	require.NoError(t, err)
+	require.True(t, follow)
+}
+
+func TestInvFilterNoMatch(t *testing.T) {
+	f, err := NewFilter("Datacenter == 'dc0' && Cluster == 'xyz'")
+	require.NoError(t, err)
+	dims := pairs{
+		pair{dimDatacenter, "dc0"},
+		pair{dimCluster, "cluster0"},
+	}
+	follow, err := f.shouldFollowCluster(dims)
+	require.NoError(t, err)
+	require.False(t, follow)
+}
+
+func TestInvFilterDCMatch(t *testing.T) {
+	f, err := NewFilter("Datacenter == 'dc0'")
+	require.NoError(t, err)
+	dims := pairs{
+		pair{dimDatacenter, "dc0"},
+		pair{dimCluster, "cluster0"},
+	}
+	follow, err := f.shouldFollowCluster(dims)
+	require.NoError(t, err)
+	require.True(t, follow)
+}
+
+func TestInvFilterClusterMatch(t *testing.T) {
+	f, err := NewFilter("Cluster == 'cluster0'")
+	require.NoError(t, err)
+	dims := pairs{
+		pair{dimDatacenter, "dc0"},
+		pair{dimCluster, "cluster0"},
+	}
+	follow, err := f.shouldFollowCluster(dims)
+	require.NoError(t, err)
+	require.True(t, follow)
+}

--- a/pkg/monitors/vsphere/service/inventory_test.go
+++ b/pkg/monitors/vsphere/service/inventory_test.go
@@ -3,13 +3,55 @@ package service
 import (
 	"testing"
 
-	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
+
+func TestExprFilterOutAllInventory(t *testing.T) {
+	gateway := newFakeGateway(1)
+	f, err := NewFilter("Datacenter == 'X'")
+	require.NoError(t, err)
+	svc := NewInventorySvc(gateway, testLog, f)
+	inv, err := svc.RetrieveInventory()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(inv.Objects))
+}
+
+func TestExprFilterInAllInventory(t *testing.T) {
+	gateway := newFakeGateway(1)
+	f, err := NewFilter("Datacenter == 'foo dc' && Cluster == 'foo cluster'")
+	require.NoError(t, err)
+	svc := NewInventorySvc(gateway, testLog, f)
+	inv, err := svc.RetrieveInventory()
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(inv.Objects))
+}
+
+func TestFilterInInventory(t *testing.T) {
+	gateway := newFakeGateway(1)
+	f, err := NewFilter("")
+	require.NoError(t, err)
+	svc := NewInventorySvc(gateway, testLog, f)
+	inv, err := svc.RetrieveInventory()
+	assert.NoError(t, err)
+	assert.True(t, len(inv.Objects) > 0)
+}
+
+func TestFilterEmptyDC(t *testing.T) {
+	gateway := newFakeGateway(1)
+	f, err := NewFilter("")
+	require.NoError(t, err)
+	svc := NewInventorySvc(gateway, testLog, f)
+	inv, err := svc.RetrieveInventory()
+	assert.NoError(t, err)
+	assert.True(t, len(inv.Objects) > 0)
+}
 
 func TestRetrieveInventory(t *testing.T) {
 	gateway := newFakeGateway(1)
-	svc := NewInventorySvc(gateway, testLog)
+	svc := NewInventorySvc(gateway, testLog, nopFilter{})
 	inv, _ := svc.RetrieveInventory()
 	requireClusterHost(t, inv, 0)
 	requireClusterVM(t, inv, 1)

--- a/pkg/monitors/vsphere/service/metrics_test.go
+++ b/pkg/monitors/vsphere/service/metrics_test.go
@@ -9,7 +9,7 @@ import (
 func TestPopulateInvMetrics(t *testing.T) {
 	gateway := newFakeGateway(1)
 	metricsSvc := NewMetricsService(gateway, testLog)
-	inventorySvc := NewInventorySvc(gateway, testLog)
+	inventorySvc := NewInventorySvc(gateway, testLog, nopFilter{})
 	inv, _ := inventorySvc.RetrieveInventory()
 	metricsSvc.PopulateInvMetrics(inv)
 	invObj := inv.Objects[0]

--- a/pkg/monitors/vsphere/service/points_test.go
+++ b/pkg/monitors/vsphere/service/points_test.go
@@ -12,7 +12,7 @@ var testLog = logrus.WithField("monitorType", "vsphere-test")
 
 func TestRetrievePoints(t *testing.T) {
 	gateway := newFakeGateway(1)
-	inventorySvc := NewInventorySvc(gateway, testLog)
+	inventorySvc := NewInventorySvc(gateway, testLog, nopFilter{})
 	metricsSvc := NewMetricsService(gateway, testLog)
 	infoSvc := NewVSphereInfoService(inventorySvc, metricsSvc)
 	vsphereInfo, _ := infoSvc.RetrieveVSphereInfo()

--- a/pkg/monitors/vsphere/vsphere_monitor.go
+++ b/pkg/monitors/vsphere/vsphere_monitor.go
@@ -70,7 +70,12 @@ func (vsm *vSphereMonitor) firstTimeSetup(ctx context.Context) error {
 func (vsm *vSphereMonitor) wireUpServices(ctx context.Context, client *govmomi.Client) {
 	gateway := service.NewGateway(ctx, client, vsm.log)
 	vsm.ptsSvc = service.NewPointsSvc(gateway, vsm.log, vsm.conf.PerfBatchSize, vsm.ptConsumer)
-	vsm.invSvc = service.NewInventorySvc(gateway, vsm.log)
+	f, err := service.NewFilter(vsm.conf.Filter)
+	if err != nil {
+		vsm.log.WithError(err).Error("Failed to create filter")
+		// can keep going, f == nopFilter
+	}
+	vsm.invSvc = service.NewInventorySvc(gateway, vsm.log, f)
 	vsm.metricSvc = service.NewMetricsService(gateway, vsm.log)
 	vsm.timeSvc = service.NewTimeSvc(gateway)
 	vsm.vsInfoSvc = service.NewVSphereInfoService(vsm.invSvc, vsm.metricSvc)

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -55253,6 +55253,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "filter",
+            "doc": "An 'expr' expression to limit the inventory traversed by the monitor. Leave blank or omit to traverse and get metrics for the entire vSphere inventory. Otherwise, this expression is evaluated per cluster. If the expression evaluates to true, metrics are collected for the objects in the cluster, otherwise it is skipped. Made available to the expr expression environment are the variables: `Datacenter` and `Cluster`. For example: filter: \"Datacenter == 'MyDatacenter' \u0026\u0026 Cluster == 'MyCluster'\" The above expr value will cause metrics collection for only the given datacenter + cluster. See https://github.com/antonmedv/expr for more advanced syntax.",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "tlsCACertPath",
             "doc": "Path to the ca file",
             "default": "",


### PR DESCRIPTION
This change lets users supply an optional "expr" filter expression which gets
evaluated per cluster. If the expression evaluates to true, metrics are collected
for all objects in that cluster, otherwise, it is skipped.