### PR TITLE
Helm add possibility to specify confimap env vars(#1519)

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/daemonset.yaml
@@ -134,6 +134,12 @@ spec:
       {{- with .Values.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
+      {{- if .Values.envFrom }}
+        envFrom:
+        {{- with .Values.envFrom }}
+          {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      {{- end }}
       volumes:
       - name: config
         configMap:

--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -84,6 +84,12 @@ spec:
       {{- with .Values.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
+      {{- if .Values.envFrom }}
+        envFrom:
+        {{- with .Values.envFrom }}
+          {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+      {{- end }}
       volumes:
       - name: config
         configMap:


### PR DESCRIPTION
For example
```
envFrom:
  - configMapRef:
      name: signalfx-agent.env
```