### PR TITLE
upgrading redis to v1.2.1

### DIFF
--- a/collectd-plugins.yaml
+++ b/collectd-plugins.yaml
@@ -58,7 +58,7 @@
     - integration-test
 
 - name: redis
-  version: v1.2.0
+  version: v1.2.1
   repo: signalfx/redis-collectd-plugin
 
 - name: signalfx


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>