### PR TITLE
Updated conditional for sfx_agent_config.signalFxAccessToken

### DIFF
--- a/deployments/ansible/roles/signalfx-agent/tasks/main.yml
+++ b/deployments/ansible/roles/signalfx-agent/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: Confirm SignalFx Access Token is defined
   fail: msg='Please specify a signalFxAccessToken in your sfx_agent_config'
-  when: not (sfx_agent_config.signalFxAccessToken | default('') | trim) or not sfx_agent_config.signalFxAccessToken
+  when: sfx_agent_config.signalFxAccessToken is not defined
 
 - name: Acceptable distribution check
   fail:


### PR DESCRIPTION
Updated conditional for sfx_agent_config.signalFxAccessToken to allow for ansible-vault encrypt_string compatibility. The existing version of this task required that the API token be stored unencrypted, which is insecure. The proper way to store credentials in Ansible is to use Ansible's built-in encryption method, i.e. ansible-vault --ask-vault-pass encrypt_string 'SECRET_VALUE'

This PR resolves the following error that occurs when the value of sfx_agent_config.signalFxAccessToken has been encrypted via ansible-vault encrypt_string:

TASK [../roles/signalfx-agent : Confirm SignalFx Access Token is defined] **************************************************************************************************************
 [WARNING]: There was a vault format error: Vault format unhexlify error: Odd-length string

fatal: [10.202.13.136]: FAILED! => {"msg": "The conditional check 'not (sfx_agent_config.signalFxAccessToken | default('') | trim) or not sfx_agent_config.signalFxAccessToken' failed. The error was: Vault format unhexlify error: Odd-length string\n\nThe error appears to have been in '/home/mmorales/ansible_splunk_zero/roles/signalfx-agent/tasks/main.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Confirm SignalFx Access Token is defined\n  ^ here\n"}
 