### PR TITLE
Eks updates

### DIFF
--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -32,7 +32,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - clustermaps
+  - configmaps
   verbs:
   - get
   - list

--- a/deployments/k8s/clusterrole.yaml
+++ b/deployments/k8s/clusterrole.yaml
@@ -32,6 +32,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - clustermaps
+  verbs:
+  - get
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
   - nodes/stats
   verbs:
   - get

--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -54,6 +54,7 @@ data:
     - type: kubelet-metrics
       kubeletAPI:
         authType: serviceAccount
+        url: https://${MY_NODE_NAME}:10250
       usePodsEndpoint: true
 
 


### PR DESCRIPTION
Ran into a few issues when deploying with AWS EKS.

Error 1:
`time="2020-11-10T19:48:33Z" level=error msg="Could not get summary metrics" error="failed to get pods from Kubelet URL \"ip-192-168-0-32.us-east-2.compute.internal:10250/pods\": Get \"ip-192-168-0-32.us-east-2.compute.internal:10250/pods\": unsupported protocol scheme \"ip-192-168-0-32.us-east-2.compute.internal\"" monitorType=kubelet-metrics`
resolved by specifying the correct url and port for the kubeletAPI

Error 2:
`E1110 19:59:40.404096       1 leaderelection.go:367] Failed to update lock: configmaps "signalfx-agent-leader" is forbidden: User "system:serviceaccount:corda-net:signalfx-agent" cannot update resource "configmaps" in API group "" in the namespace "corda-net"`
resolved by allowing configmaps to be updated