### PR TITLE
Docker Monitor: Upgrade minimum version to 1.24

### DIFF
--- a/pkg/monitors/docker/docker.go
+++ b/pkg/monitors/docker/docker.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const dockerAPIVersion = "v1.22"
+const dockerAPIVersion = "v1.24"
 
 func init() {
 	monitors.Register(&monitorMetadata, func() interface{} { return &Monitor{} }, &Config{})


### PR DESCRIPTION
This will allow the monitor to work on newer Docker Enterprise versions without
sacrificing backwards compatibility too much.

Fixes #1529 