### PR TITLE
Update docker observer min API version

### DIFF
--- a/pkg/observers/docker/docker.go
+++ b/pkg/observers/docker/docker.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	observerType     = "docker"
-	dockerAPIVersion = "v1.22"
+	dockerAPIVersion = "v1.24"
 )
 
 // OBSERVER(docker): Queries the Docker Engine API for running containers.  If


### PR DESCRIPTION
This is analogous to the change in the docker monitor.