### PR TITLE
Update maven repo to jcenter.bintray.com

### DIFF
--- a/java/jmx/pom.xml
+++ b/java/jmx/pom.xml
@@ -15,9 +15,9 @@
 
     <repositories>
         <repository>
-            <id>Spring Plugins</id>
-            <name>Spring Plugins</name>
-            <url>https://repo.spring.io/plugins-release/</url>
+            <id>JCenter Bintray</id>
+            <name>JCenter Bintray</name>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
`https://repo.spring.io` has been locked down (https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020), causing the jmx monitor build to fail:
```
[ERROR] Failed to execute goal on project agent-jmx-monitor: Could not resolve dependencies for project com.signalfx.public:agent-jmx-monitor:jar:1.0-SNAPSHOT: Failed to collect dependencies at org.terracotta:jmxremote_optional-tc:jar:1.0.5: Failed to read artifact descriptor for org.terracotta:jmxremote_optional-tc:jar:1.0.5: Could not transfer artifact org.terracotta:jmxremote_optional-tc:pom:1.0.5 from/to Spring Plugins (https://repo.spring.io/plugins-release/): Not authorized , ReasonPhrase:Unauthorized. -> [Help 1]
```