### PR TITLE
Update traceEndpointUrl docs for new uAPM value

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -25,7 +25,7 @@ you can set them individually like so:
 ```
 ingestUrl: "https://ingest.YOUR_SIGNALFX_REALM.signalfx.com"
 apiUrl: "https://api.YOUR_SIGNALFX_REALM.signalfx.com"
-traceEndpointUrl: "https://ingest.YOUR_SIGNALFX_REALM.signalfx.com/v1/trace"
+traceEndpointUrl: "https://ingest.YOUR_SIGNALFX_REALM.signalfx.com/v2/trace" // Use /v1/trace for APM PG
 ```
 
 They will default to the endpoints for the realm configured in `signalFxRealm`


### PR DESCRIPTION
Update docs to reference uAPM's new trace endpoint /v2/trace and add a comment for /v1/trace for APM PG