### PR TITLE
Add cmdLineTag dimension option and upgrading telegraf

### DIFF
--- a/docs/monitors/telegraf-procstat.md
+++ b/docs/monitors/telegraf-procstat.md
@@ -55,6 +55,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `processName` | no | `string` | Used to override the process name dimension |
 | `prefix` | no | `string` | Prefix to be added to each dimension |
 | `pidTag` | no | `bool` | Whether to add PID as a dimension instead of part of the metric name (**default:** `false`) |
+| `cmdLineTag` | no | `bool` | When true add the full cmdline as a dimension. (**default:** `false`) |
 | `cGroup` | no | `string` | The name of the cgroup to monitor.  This cgroup name will be appended to the configured `sysPath`.  See the agent config schema for more information about the `sysPath` agent configuration. |
 | `WinService` | no | `string` | The name of a windows service to report procstat information on. |
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110
 
 replace code.cloudfoundry.org/go-loggregator => github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d
 
-replace github.com/influxdata/telegraf => github.com/signalfx/telegraf v0.10.2-0.20200415004250-249b98cac6c7
+replace github.com/influxdata/telegraf => github.com/signalfx/telegraf v0.10.2-0.20201130223629-3a4c14f6fe12
 
 replace github.com/dancannon/gorethink => gopkg.in/gorethink/gorethink.v4 v4.0.0
 

--- a/go.sum
+++ b/go.sum
@@ -950,8 +950,8 @@ github.com/signalfx/signalfx-go-tracing v1.2.0 h1:wEdlZQ69u3QyEZEEIo+prmGaVieKgi
 github.com/signalfx/signalfx-go-tracing v1.2.0/go.mod h1:JoTkkhSBe42ns9/AsvtqX7lLiiS6YwE0Q7J0DZFzt00=
 github.com/signalfx/tdigest v0.0.0-20191031204725-c860c3ff6902 h1:V/uPctkyrXFOwGmWbFFEJP48ntw8ykJN6oxEJBTPARE=
 github.com/signalfx/tdigest v0.0.0-20191031204725-c860c3ff6902/go.mod h1:fbvuJM3o+bwr36+TVjokMUGd4muJVHiCshTmKZ/6eNU=
-github.com/signalfx/telegraf v0.10.2-0.20200415004250-249b98cac6c7 h1:2yl1neQAA7FvggdNsY65PiZnTTzQH/mBQhNEiwUV/fQ=
-github.com/signalfx/telegraf v0.10.2-0.20200415004250-249b98cac6c7/go.mod h1:1gnMOcwGO3lAxfoMq28M8gjooF2MqVwquPVEvgZ1its=
+github.com/signalfx/telegraf v0.10.2-0.20201130223629-3a4c14f6fe12 h1:AGaHKs5V2+Q7+qVeyKZfW2r8duthcCr4qSqRriunuNM=
+github.com/signalfx/telegraf v0.10.2-0.20201130223629-3a4c14f6fe12/go.mod h1:1gnMOcwGO3lAxfoMq28M8gjooF2MqVwquPVEvgZ1its=
 github.com/signalfx/thrift v0.0.0-20181211001559-3838fa316492/go.mod h1:Xv29nl9fxdk0hmeqcUHgAZZwvYrOhduNW+9qk4H+6K0=
 github.com/signalfx/xdgbasedir v0.0.0-20160106035722-cd6a71c07e4e h1:QCYFq7iZwqlBTbP5xcJNIaLnAhozjhcrySGiEegRYus=
 github.com/signalfx/xdgbasedir v0.0.0-20160106035722-cd6a71c07e4e/go.mod h1:RnQhO4a62x0VHvh8eSMsqgTgYRso2hfat7ioM8rD1jc=

--- a/pkg/monitors/telegraf/monitors/procstat/procstat.go
+++ b/pkg/monitors/telegraf/monitors/procstat/procstat.go
@@ -45,6 +45,8 @@ type Config struct {
 	Prefix string `yaml:"prefix"`
 	// Whether to add PID as a dimension instead of part of the metric name
 	PidTag bool `yaml:"pidTag"`
+	// When true add the full cmdline as a dimension.
+	CmdLineTag bool `yaml:"cmdLineTag"`
 	// The name of the cgroup to monitor.  This cgroup name will be appended to
 	// the configured `sysPath`.  See the agent config schema for more information
 	// about the `sysPath` agent configuration.

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -50897,6 +50897,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "cmdLineTag",
+            "doc": "When true add the full cmdline as a dimension.",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
             "yamlName": "cGroup",
             "doc": "The name of the cgroup to monitor.  This cgroup name will be appended to the configured `sysPath`.  See the agent config schema for more information about the `sysPath` agent configuration.",
             "default": "",


### PR DESCRIPTION
Signed-off-by: Dani Louca <dlouca@splunk.com>

With this config, 

```
monitors:
  - type: telegraf/procstat
    exe: "signalfx*"
    cmdLineTag: true
```

we now can send a datapoint that shows the cmdline as a dimension


```
procstat.rlimit_cpu_time_hard: 2147483647 (GAUGE) 
+--------------------------------+-----------+--------------+-------------------+----------------+---------------+------+
|            cmdline             |    exe    |     host     |      plugin       |  process_name  | telegraf_type | user |
+--------------------------------+-----------+--------------+-------------------+----------------+---------------+------+
| ./signalfx-agent --config      | signalfx* | a53e61d32084 | telegraf-procstat | signalfx-agent | untyped       | root |
| local-etc/agent-procstat.yaml  |           |              |                   |                |               |      |
+--------------------------------+-----------+--------------+-------------------+----------------+---------------+------+

```