### PR TITLE
Use correct Showmax project name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a
-	github.com/ShowMax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4
+	github.com/Showmax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190315122603-6f9e54af456e // indirect
 	github.com/antonmedv/expr v1.8.5

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a h1:KFHLI4QGttB0
 github.com/Sectorbob/mlab-ns2 v0.0.0-20171030222938-d3aa0c295a8a/go.mod h1:D73UAuEPckrDorYZdtlCu2ySOLuPB5W4rhIkmmc/XbI=
 github.com/SermoDigital/jose v0.9.1 h1:atYaHPD3lPICcbK1owly3aPm0iaJGSGPi0WD4vLznv8=
 github.com/SermoDigital/jose v0.9.1/go.mod h1:ARgCUhI1MHQH+ONky/PAtmVHQrP5JlGY0F3poXOp/fA=
-github.com/ShowMax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4 h1:LbMMQr4Ij1Eq5RUNsLBpNmcnhRXuq+BlyInEbI4FTAU=
-github.com/ShowMax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4/go.mod h1:Wbphg/zwBzq1nUotnHP8day9iRhcMOwh7JFW1vkzq6w=
+github.com/Showmax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4 h1:j9c8TWYg+huqRhrHJoaBetAJUhwy80ja/mpB9LHMK+s=
+github.com/Showmax/go-fqdn v0.0.0-20160909083404-2501cdd51ef4/go.mod h1:nxfWvpOWKx1oAU7G3U8UYWL/iY6EKdjjv1w/S8HDsvg=
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=

--- a/pkg/core/hostid/host.go
+++ b/pkg/core/hostid/host.go
@@ -3,7 +3,7 @@ package hostid
 import (
 	"os"
 
-	fqdn "github.com/ShowMax/go-fqdn"
+	fqdn "github.com/Showmax/go-fqdn"
 	log "github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
Using `ShowMax` causes a conflict when externally using agent in a project w/ `Showmax` in module path.