### PR TITLE
Adding the memory reporting for Windows containers.

### DIFF
--- a/pkg/monitors/docker/conversion.go
+++ b/pkg/monitors/docker/conversion.go
@@ -149,18 +149,13 @@ func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*data
 	// If not present, default value will be 0.
 	bufferCacheUsage := stats.Stats["total_cache"]
 
+	out = append(out, sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)))
 	if stats.PrivateWorkingSet == 0 {
-		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
-			// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
-			sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
-		}...)
+		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
+		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)))
 	} else {
 		// This is used for Windows containers
-		out = append(out, []*datapoint.Datapoint{
-			sfxclient.Gauge("memory.usage.limit", nil, int64(stats.CommitPeak)),
-			sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)),
-		}...)
+		out = append(out, sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)))
 	}
 
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled

--- a/pkg/monitors/docker/conversion.go
+++ b/pkg/monitors/docker/conversion.go
@@ -148,21 +148,21 @@ func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*data
 
 	// If not present, default value will be 0.
 	bufferCacheUsage := stats.Stats["total_cache"]
-    
-    if (stats.PrivateWorkingSet == 0) {
-        out = append(out, []*datapoint.Datapoint{
-    		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
-    		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
-    		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
-    	}...)
-    } else {
-        // This is used for Windows containers
-        out = append(out, []*datapoint.Datapoint{
-        		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.CommitPeak)),
-        		sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)),
-        	}...)
-    }
-	
+
+	if stats.PrivateWorkingSet == 0 {
+		out = append(out, []*datapoint.Datapoint{
+			sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
+			// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
+			sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
+		}...)
+	} else {
+		// This is used for Windows containers
+		out = append(out, []*datapoint.Datapoint{
+			sfxclient.Gauge("memory.usage.limit", nil, int64(stats.CommitPeak)),
+			sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)),
+		}...)
+	}
+
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled
 	if enhancedMetrics {
 		out = append(out, []*datapoint.Datapoint{

--- a/pkg/monitors/docker/conversion.go
+++ b/pkg/monitors/docker/conversion.go
@@ -148,13 +148,21 @@ func convertMemoryStats(stats *dtypes.MemoryStats, enhancedMetrics bool) []*data
 
 	// If not present, default value will be 0.
 	bufferCacheUsage := stats.Stats["total_cache"]
-
-	out = append(out, []*datapoint.Datapoint{
-		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
-		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
-		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
-	}...)
-
+    
+    if (stats.PrivateWorkingSet == 0) {
+        out = append(out, []*datapoint.Datapoint{
+    		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.Limit)),
+    		// See discussion at https://github.com/signalfx/signalfx-agent/issues/1009
+    		sfxclient.Gauge("memory.usage.total", nil, int64(stats.Usage-bufferCacheUsage)),
+    	}...)
+    } else {
+        // This is used for Windows containers
+        out = append(out, []*datapoint.Datapoint{
+        		sfxclient.Gauge("memory.usage.limit", nil, int64(stats.CommitPeak)),
+        		sfxclient.Gauge("memory.usage.total", nil, int64(stats.PrivateWorkingSet)),
+        	}...)
+    }
+	
 	// Except two metrics above, everything else will be added only when enhnacedMetrics is enabled
 	if enhancedMetrics {
 		out = append(out, []*datapoint.Datapoint{


### PR DESCRIPTION
Windows containers don't report the same metrics as Linux containers. 

Tested this code change to report CommitPeak and PrivateWorkingSet. 
See: https://github.com/docker/engine/blob/master/api/types/stats.go

![image](https://user-images.githubusercontent.com/1642196/101070611-6a2e3100-3550-11eb-8e76-f1dbc6f0db27.png)

