### PR TITLE
cpu monitor: remove unused gopsutil field removed in subsequent gopsutil version

### DIFF
--- a/pkg/monitors/cpu/cpu.go
+++ b/pkg/monitors/cpu/cpu.go
@@ -274,8 +274,7 @@ func cpuTimeStatTototalUsed(t *cpu.TimesStat) *totalUsed {
 		t.Iowait +
 		t.Irq +
 		t.Softirq +
-		t.Steal +
-		t.Stolen
+		t.Steal
 
 	return &totalUsed{
 		Total: total,


### PR DESCRIPTION
In trying to incorporate the agent in the Splunk OTel Collector I need to move our gopsutil version to a more recent one.  These changes remove usage of an unnecessary field that is removed in a future breaking change for a patch version*: https://github.com/shirou/gopsutil/pull/677/commits/cae8efcffa765c9534442328d385bdd883faf5df.

Similarly trying to [update our telegraf fork](https://github.com/signalfx/telegraf/pull/23) to also address this change and will update deps in a later PR.