### PR TITLE
nagios: allow to filter stdout and stderr from event comparison

### DIFF
--- a/docs/monitors/nagios.md
+++ b/docs/monitors/nagios.md
@@ -34,7 +34,8 @@ It will also give the ability to create a dashboard similar to what nagios user 
 
 __Note__: the last sent event is cached into memory to avoid sending the same event for each collection 
 interval over and over but already sent event will be send again when you restart the agent erasing its 
-cache.
+cache. If your check always "normally" produces a different output for each run like the uptime check 
+does so you can use the `FilterStdOut: true` parameter to ignore it in comparison.
 
 
 ## Configuration
@@ -57,6 +58,8 @@ Configuration](../monitor-config.md#common-configuration).**
 | `command` | **yes** | `string` | The command to exec with any arguments like: `"LC_ALL=\"en_US.utf8\" /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1"` |
 | `service` | **yes** | `string` | Corresponds to the nagios `service` column and allows to aggregate all instances of the same service (when calling the same check script with different arguments) |
 | `timeout` | no | `integer` | The max execution time allowed in seconds before sending SIGKILL (**default:** `9`) |
+| `filterStdOut` | no | `bool` | If `false` and change is detected on `stdout` compared to the last event it will send a new one (**default:** `false`) |
+| `filterStdErr` | no | `bool` | If `false` and change is detected on `stderr` compared to the last event it will send a new one (**default:** `false`) |
 
 
 ## Metrics

--- a/docs/monitors/nagios.md
+++ b/docs/monitors/nagios.md
@@ -58,8 +58,8 @@ Configuration](../monitor-config.md#common-configuration).**
 | `command` | **yes** | `string` | The command to exec with any arguments like: `"LC_ALL=\"en_US.utf8\" /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1"` |
 | `service` | **yes** | `string` | Corresponds to the nagios `service` column and allows to aggregate all instances of the same service (when calling the same check script with different arguments) |
 | `timeout` | no | `integer` | The max execution time allowed in seconds before sending SIGKILL (**default:** `9`) |
-| `filterStdOut` | no | `bool` | If `false` and change is detected on `stdout` compared to the last event it will send a new one (**default:** `false`) |
-| `filterStdErr` | no | `bool` | If `false` and change is detected on `stderr` compared to the last event it will send a new one (**default:** `false`) |
+| `ignoreStdOut` | no | `bool` | If `false` and change is detected on `stdout` compared to the last event it will send a new one (**default:** `false`) |
+| `ignoreStdErr` | no | `bool` | If `false` and change is detected on `stderr` compared to the last event it will send a new one (**default:** `false`) |
 
 
 ## Metrics

--- a/pkg/monitors/nagios/metadata.yaml
+++ b/pkg/monitors/nagios/metadata.yaml
@@ -24,7 +24,8 @@ monitors:
 
     __Note__: the last sent event is cached into memory to avoid sending the same event for each collection 
     interval over and over but already sent event will be send again when you restart the agent erasing its 
-    cache.
+    cache. If your check always "normally" produces a different output for each run like the uptime check 
+    does so you can use the `FilterStdOut: true` parameter to ignore it in comparison.
 
   dimensions:
     plugin:

--- a/pkg/monitors/nagios/nagios.go
+++ b/pkg/monitors/nagios/nagios.go
@@ -40,10 +40,10 @@ type Config struct {
 	Timeout int `yaml:"timeout" default:"9"`
 	// If `false` and change is detected on `stdout` compared to the last
 	// event it will send a new one
-	FilterStdOut bool `yaml:"filterStdOut" default:"false"`
+	IgnoreStdOut bool `yaml:"ignoreStdOut" default:"false"`
 	// If `false` and change is detected on `stderr` compared to the last
 	// event it will send a new one
-	FilterStdErr bool `yaml:"filterStdErr" default:"false"`
+	IgnoreStdErr bool `yaml:"ignoreStdErr" default:"false"`
 }
 
 // Monitor that collect metrics
@@ -101,9 +101,7 @@ func (m *Monitor) Configure(conf *Config) error {
 		properties := makeProperties(state, err, stdout, stderr)
 		// Some scripts could produce different output (and stderr) for
 		// each interval "normally", so we do not want to compare them
-		m.logger.Warn(conf.FilterStdOut)
-		diffProperties := filterProperties(properties, conf.FilterStdOut, conf.FilterStdErr)
-		m.logger.Warn(diffProperties)
+		diffProperties := filterProperties(properties, conf.IgnoreStdOut, conf.IgnoreStdErr)
 
 		// Compare with previous event if it exists
 		sendEvent := true
@@ -253,13 +251,13 @@ func formatStd(std []byte) string {
 	return rendered
 }
 
-func filterProperties(properties map[string]interface{}, filterStdOut bool, filterStdErr bool) map[string]interface{} {
+func filterProperties(properties map[string]interface{}, ignoreStdOut bool, ignoreStdErr bool) map[string]interface{} {
 	filteredProperties := make(map[string]interface{})
 	for k, v := range properties {
-		if k == "stdout" && filterStdOut {
+		if k == "stdout" && ignoreStdOut {
 			continue
 		}
-		if k == "stderr" && filterStdErr {
+		if k == "stderr" && ignoreStdErr {
 			continue
 		}
 		filteredProperties[k] = v

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42372,7 +42372,7 @@
             "elementKind": ""
           },
           {
-            "yamlName": "filterStdOut",
+            "yamlName": "ignoreStdOut",
             "doc": "If `false` and change is detected on `stdout` compared to the last event it will send a new one",
             "default": false,
             "required": false,
@@ -42380,7 +42380,7 @@
             "elementKind": ""
           },
           {
-            "yamlName": "filterStdErr",
+            "yamlName": "ignoreStdErr",
             "doc": "If `false` and change is detected on `stderr` compared to the last event it will send a new one",
             "default": false,
             "required": false,

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42324,7 +42324,7 @@
           "description": "The configured `service` for this monitor."
         }
       },
-      "doc": "Wrapper to run existing nagios status check scripts through SignalFx agent which will play the \nrole of NRPE or SNMP exec.\n\nIt will run the script set in `command` parameter and send the \n[state](https://nagios-plugins.org/doc/guidelines.html#AEN78) of the check depending on the \nexit code of the command.\n\nIt is very similar to [telegraf/exec](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html) \nmonitor configured with `dataFormat: nagios` but:\n  - it does not retrieve perfdata metrics, only the state of the script for alerting purpose.\n  - it will override the state if exit code == 0 but output string starts with `warn`, `crit` or `unkn` \n  (not case sensitive).\n\nAlso the main advantage and purpose of this monitor is to add more context to this status check state \nthougth SignalFx [events](https://docs.signalfx.com/en/latest/detect-alert/events-intro.html).\nIndeed, in addition to the state metric, it will send an event which includes the output and the error \ncaught from the command execution.\n\nThis should make the troubleshooting more efficient and allow the user to remain in SignalFx without \nto have to connect to the machine in case of anormal state to understand what is happening.\nIt will also give the ability to create a dashboard similar to what nagios user are accustomed to.\n\n__Note__: the last sent event is cached into memory to avoid sending the same event for each collection \ninterval over and over but already sent event will be send again when you restart the agent erasing its \ncache.\n",
+      "doc": "Wrapper to run existing nagios status check scripts through SignalFx agent which will play the \nrole of NRPE or SNMP exec.\n\nIt will run the script set in `command` parameter and send the \n[state](https://nagios-plugins.org/doc/guidelines.html#AEN78) of the check depending on the \nexit code of the command.\n\nIt is very similar to [telegraf/exec](https://docs.signalfx.com/en/latest/integrations/agent/monitors/telegraf-exec.html) \nmonitor configured with `dataFormat: nagios` but:\n  - it does not retrieve perfdata metrics, only the state of the script for alerting purpose.\n  - it will override the state if exit code == 0 but output string starts with `warn`, `crit` or `unkn` \n  (not case sensitive).\n\nAlso the main advantage and purpose of this monitor is to add more context to this status check state \nthougth SignalFx [events](https://docs.signalfx.com/en/latest/detect-alert/events-intro.html).\nIndeed, in addition to the state metric, it will send an event which includes the output and the error \ncaught from the command execution.\n\nThis should make the troubleshooting more efficient and allow the user to remain in SignalFx without \nto have to connect to the machine in case of anormal state to understand what is happening.\nIt will also give the ability to create a dashboard similar to what nagios user are accustomed to.\n\n__Note__: the last sent event is cached into memory to avoid sending the same event for each collection \ninterval over and over but already sent event will be send again when you restart the agent erasing its \ncache. If your check always \"normally\" produces a different output for each run like the uptime check \ndoes so you can use the `FilterStdOut: true` parameter to ignore it in comparison.\n",
       "groups": {
         "": {
           "description": "",
@@ -42369,6 +42369,22 @@
             "default": 9,
             "required": false,
             "type": "int",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "filterStdOut",
+            "doc": "If `false` and change is detected on `stdout` compared to the last event it will send a new one",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
+          },
+          {
+            "yamlName": "filterStdErr",
+            "doc": "If `false` and change is detected on `stderr` compared to the last event it will send a new one",
+            "default": false,
+            "required": false,
+            "type": "bool",
             "elementKind": ""
           }
         ]


### PR DESCRIPTION
Hello 

related to https://github.com/signalfx/signalfx-agent/pull/1553 

it seems users want this to be customizable because there are as much scripts with different and same output from nagios world.

thanks for the quick merge of the previous one it will be enough to unstuck my colleague.