### PR TITLE
Update tracker.go to add pod name as a tag

### DIFF
--- a/pkg/apm/tracetracker/tracker.go
+++ b/pkg/apm/tracetracker/tracker.go
@@ -21,6 +21,7 @@ const spanCorrelationMetricName = "sf.int.service.heartbeat"
 var DefaultDimsToSyncSource = map[string]string{
 	"container_id":       "container_id",
 	"kubernetes_pod_uid": "kubernetes_pod_uid",
+	"kubernetes_pod_name": "kubernetes_pod_name",
 }
 
 // ActiveServiceTracker keeps track of which services are seen in the trace


### PR DESCRIPTION
It is valuable to the customers to track the pod name in the span tag. Did some testing and confirmed that this worked as the kubernetes_pod_name seems to be available in the map of dims that the agent checks against (dims: map[container_id,container_image,container_name,container_spec_name:,kubernetes_namespace, kubernetes_pod_name, kubernetes_pod_uid]
Though there may be other implications that I'm not aware of (the MTS with these dimensions also get updated with properties?)