### PR TITLE
Satisfy race detection in Debounce0

### DIFF
--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -20,14 +20,12 @@ func Debounce0(fn func(), duration time.Duration) (func(), chan<- struct{}) {
 			case <-stop:
 				return
 			case <-timer.C:
+				lock.Lock()
 				if callRequested {
-					lock.Lock()
-
 					fn()
 					callRequested = false
-
-					lock.Unlock()
 				}
+				lock.Unlock()
 			}
 		}
 	}()


### PR DESCRIPTION
The data race detector is flagging the goroutine in `utils.Debounce0` for not having the lock when reading `callDetected`.  These changes move the lock acquisition forward to prevent unrelated test failures in projects using the agent.

```
==================
WARNING: DATA RACE
Read at 0x00c0000b4918 by goroutine 31:
  github.com/signalfx/signalfx-agent/pkg/utils.Debounce0.func1()
      /signalfx-agent/pkg/utils/time.go:23 +0x126

Previous write at 0x00c0000b4918 by goroutine 32:
  github.com/signalfx/signalfx-agent/pkg/utils.Debounce0.func2()
      /signalfx-agent/pkg/utils/time.go:37 +0x5d
  github.com/signalfx/signalfx-agent/pkg/monitors/collectd.(*Manager).manageCollectd.func2()
      /signalfx-agent/pkg/monitors/collectd/collectd.go:272 +0x67

Goroutine 31 (running) created at:
  github.com/signalfx/signalfx-agent/pkg/utils.Debounce0()
      /signalfx-agent/pkg/utils/time.go:17 +0x124
  github.com/signalfx/signalfx-agent/pkg/monitors/collectd.(*Manager).manageCollectd()
      /signalfx-agent/pkg/monitors/collectd/collectd.go:262 +0x121b

Goroutine 32 (running) created at:
  github.com/signalfx/signalfx-agent/pkg/monitors/collectd.(*Manager).manageCollectd()
      /signalfx-agent/pkg/monitors/collectd/collectd.go:268 +0x129d
==================
```