### PR TITLE
Change apiserver_request_total metric to be emitted by default

### DIFF
--- a/docs/monitors/kubernetes-apiserver.md
+++ b/docs/monitors/kubernetes-apiserver.md
@@ -177,7 +177,7 @@ monitor config option `extraGroups`:
  - `apiserver_request_latencies_summary` (*cumulative*)<br>    (Deprecated) Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component. (sum)
  - `apiserver_request_latencies_summary_count` (*cumulative*)<br>    (Deprecated) Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component. (count)
  - `apiserver_request_latencies_summary_quantile` (*gauge*)<br>    (Deprecated) Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component. (quantized)
- - `apiserver_request_total` (*cumulative*)<br>    Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, client, and HTTP response contentType and code.
+ - ***`apiserver_request_total`*** (*cumulative*)<br>    Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, client, and HTTP response contentType and code.
 
 #### Group apiserver_response
 All of the following metrics are part of the `apiserver_response` metric group. All of

--- a/pkg/monitors/kubernetes/apiserver/genmetadata.go
+++ b/pkg/monitors/kubernetes/apiserver/genmetadata.go
@@ -580,6 +580,7 @@ var metricSet = map[string]monitors.MetricInfo{
 var defaultMetrics = map[string]bool{
 	admissionQuotaControllerAdds: true,
 	apiserverRequestCount:        true,
+	apiserverRequestTotal:        true,
 	workqueueAddsTotal:           true,
 	workqueueDepth:               true,
 }

--- a/pkg/monitors/kubernetes/apiserver/metadata.yaml
+++ b/pkg/monitors/kubernetes/apiserver/metadata.yaml
@@ -566,7 +566,7 @@ monitors:
       type: gauge
       group: apiserver_request
     apiserver_request_total:
-      default: false
+      default: true
       description: Counter of apiserver requests broken out for each verb, dry run
         value, group, version, resource, scope, component, client, and HTTP response
         contentType and code.

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -37241,7 +37241,7 @@
           "type": "cumulative",
           "description": "Counter of apiserver requests broken out for each verb, dry run value, group, version, resource, scope, component, client, and HTTP response contentType and code.",
           "group": "apiserver_request",
-          "default": false
+          "default": true
         },
         "apiserver_response_sizes": {
           "type": "cumulative",


### PR DESCRIPTION
We emit a metric `apiserver_request_count` by default but we also label it as deprecated.
`apiserver_request_total` is _not_ deprecated and is intended to be as a replacement.