### PR TITLE
Add a shutdown hook to processlist monitor

### DIFF
--- a/pkg/monitors/processlist/processlist.go
+++ b/pkg/monitors/processlist/processlist.go
@@ -206,3 +206,10 @@ func toTime(secs float64) string {
 	dec := math.Mod(seconds, 1.0) * 100
 	return fmt.Sprintf("%02d:%02.f.%02.f", minutes, seconds, dec)
 }
+
+// Shutdown stops the metric sync
+func (m *Monitor) Shutdown() {
+	if m.cancel != nil {
+		m.cancel()
+	}
+}


### PR DESCRIPTION
While debugging a windows performance issue related to the processlist usage of wmi, I noticed that if I just edit the config to remove `processlist` monitor, the monitor is removed from the internal list but the main function loaded in `RunOnInterval` periodically runs and hits the wmi interface.

The only workaround is to restart the agent.

this bug adds the shutdown hook to processlist monitor

Signed-off-by: Dani Louca <dlouca@splunk.com>