### PR TITLE
Add inline yaml struct tags for all monitor configs

### DIFF
--- a/pkg/monitors/aspdotnet/aspdotnet.go
+++ b/pkg/monitors/aspdotnet/aspdotnet.go
@@ -13,7 +13,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`

--- a/pkg/monitors/cadvisor/cadvisor.go
+++ b/pkg/monitors/cadvisor/cadvisor.go
@@ -18,7 +18,7 @@ func init() {
 
 // CHTTPConfig is the monitor-specific config for cAdvisor
 type CHTTPConfig struct {
-	config.MonitorConfig
+	config.MonitorConfig `yaml:",inline"`
 	// Where to find cAdvisor
 	CAdvisorURL string `yaml:"cadvisorURL" default:"http://localhost:4194"`
 }

--- a/pkg/monitors/cgroups/monitor.go
+++ b/pkg/monitors/cgroups/monitor.go
@@ -19,7 +19,7 @@ import (
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 
 	// The cgroup names to include/exclude, based on the full hierarchy path.
 	// This is an [overridable

--- a/pkg/monitors/cloudfoundry/monitor.go
+++ b/pkg/monitors/cloudfoundry/monitor.go
@@ -18,7 +18,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 
 	// The base URL to the RLP Gateway server. This is quite often of the form
 	// https://log-stream.<CLOUD CONTROLLER SYSTEM DOMAIN> if using PCF 2.4+.

--- a/pkg/monitors/collectd/cpu/cpu.go
+++ b/pkg/monitors/collectd/cpu/cpu.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/cpufreq/cpufreq.go
+++ b/pkg/monitors/collectd/cpufreq/cpufreq.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/df/df.go
+++ b/pkg/monitors/collectd/df/df.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 	// Path to the root of the host filesystem.  Useful when running in a
 	// container and the host filesystem is mounted in some subdirectory under
 	// /.

--- a/pkg/monitors/collectd/disk/disk.go
+++ b/pkg/monitors/collectd/disk/disk.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 
 	// Which devices to include/exclude
 	Disks []string `yaml:"disks" default:"[\"/^loop[0-9]+$/\", \"/^dm-[0-9]+$/\"]"`

--- a/pkg/monitors/collectd/load/load.go
+++ b/pkg/monitors/collectd/load/load.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/memory/memory.go
+++ b/pkg/monitors/collectd/memory/memory.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/metadata/metadata.go
+++ b/pkg/monitors/collectd/metadata/metadata.go
@@ -26,7 +26,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 	WriteServerURL       string `yaml:"writeServerURL"`
 	// (Deprecated) Please set the agent configuration `procPath` instead of
 	// this monitor configuration option.

--- a/pkg/monitors/collectd/netinterface/interface.go
+++ b/pkg/monitors/collectd/netinterface/interface.go
@@ -23,7 +23,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 	// List of interface names to exclude from monitoring
 	ExcludedInterfaces []string `yaml:"excludedInterfaces" default:"[\"/^lo\\\\d*$/\", \"/^docker.*/\", \"/^t(un|ap)\\\\d*$/\", \"/^veth.*$/\"]"`
 	// List of all the interfaces you want to monitor, all others will be

--- a/pkg/monitors/collectd/processes/processes.go
+++ b/pkg/monitors/collectd/processes/processes.go
@@ -24,7 +24,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 	// A list of process names to match
 	Processes []string `yaml:"processes"`
 	// A map with keys specifying the `plugin_instance` value to be sent for

--- a/pkg/monitors/collectd/protocols/protocols.go
+++ b/pkg/monitors/collectd/protocols/protocols.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/statsd/statsd.go
+++ b/pkg/monitors/collectd/statsd/statsd.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 
 	// The host/address on which to bind the UDP listener that accepts statsd
 	// datagrams

--- a/pkg/monitors/collectd/uptime/uptime.go
+++ b/pkg/monitors/collectd/uptime/uptime.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/collectd/vmem/vmem.go
+++ b/pkg/monitors/collectd/vmem/vmem.go
@@ -20,7 +20,7 @@ func init() {
 
 // Config is the monitor-specific config with the generic config embedded
 type Config struct {
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 }
 
 // Monitor is the main type that represents the monitor

--- a/pkg/monitors/conviva/conviva.go
+++ b/pkg/monitors/conviva/conviva.go
@@ -27,7 +27,7 @@ const (
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig
+	config.MonitorConfig `yaml:",inline"`
 	// Conviva Pulse username required with each API request.
 	Username string `yaml:"pulseUsername" validate:"required"`
 	// Conviva Pulse password required with each API request.

--- a/pkg/monitors/cpu/cpu.go
+++ b/pkg/monitors/cpu/cpu.go
@@ -29,7 +29,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// If `true`, stats will be generated for the system as a whole _as well
 	// as_ for each individual CPU/core in the system and will be distinguished
 	// by the `cpu` dimension.  If `false`, stats will only be generated for

--- a/pkg/monitors/diskio/diskio.go
+++ b/pkg/monitors/diskio/diskio.go
@@ -15,7 +15,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 	// The devices to include/exclude. This is an [overridable
 	// set](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html#overridable-filters).
 	Disks []string `yaml:"disks" default:"[\"*\", \"!/^loop[0-9]+$/\", \"!/^dm-[0-9]+$/\"]"`

--- a/pkg/monitors/docker/docker.go
+++ b/pkg/monitors/docker/docker.go
@@ -42,7 +42,7 @@ type EnhancedMetricsConfig struct {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig  `acceptsEndpoints:"false"`
+	config.MonitorConfig  `yaml:",inline" acceptsEndpoints:"false"`
 	EnhancedMetricsConfig `yaml:",inline"`
 
 	// The URL of the docker server

--- a/pkg/monitors/dotnet/dotnet.go
+++ b/pkg/monitors/dotnet/dotnet.go
@@ -13,7 +13,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`

--- a/pkg/monitors/ecs/ecs.go
+++ b/pkg/monitors/ecs/ecs.go
@@ -34,7 +34,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig           `acceptsEndpoints:"false"`
+	config.MonitorConfig           `yaml:",inline" acceptsEndpoints:"false"`
 	dmonitor.EnhancedMetricsConfig `yaml:",inline"`
 
 	// The URL of the ECS task metadata. Default is http://169.254.170.2/v2/metadata, which is hardcoded by AWS for version 2.

--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -25,7 +25,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 
 	// Path to the root of the host filesystem.  Useful when running in a
 	// container and the host filesystem is mounted in some subdirectory under

--- a/pkg/monitors/kubernetes/cluster/monitor.go
+++ b/pkg/monitors/kubernetes/cluster/monitor.go
@@ -46,7 +46,7 @@ var distributionToMonitorType = map[KubernetesDistribution]string{
 
 // Config for the K8s monitor
 type Config struct {
-	config.MonitorConfig
+	config.MonitorConfig `yaml:",inline"`
 	// If `true`, leader election is skipped and metrics are always reported.
 	AlwaysClusterReporter bool `yaml:"alwaysClusterReporter"`
 	// If specified, only resources within the given namespace will be

--- a/pkg/monitors/kubernetes/events/events.go
+++ b/pkg/monitors/kubernetes/events/events.go
@@ -34,7 +34,7 @@ type EventInclusionSpec struct {
 
 // Config for the K8s event monitor
 type Config struct {
-	config.MonitorConfig
+	config.MonitorConfig `yaml:",inline"`
 	// Configuration of the Kubernetes API client
 	KubernetesAPI *kubernetes.APIConfig `yaml:"kubernetesAPI" default:"{}"`
 	// A list of event types to send events for.  Only events matching these

--- a/pkg/monitors/kubernetes/volumes/volumes.go
+++ b/pkg/monitors/kubernetes/volumes/volumes.go
@@ -26,7 +26,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig
+	config.MonitorConfig `yaml:",inline"`
 	// Kubelet kubeletClient configuration
 	KubeletAPI kubelet.APIConfig `yaml:"kubeletAPI" default:""`
 	// Configuration of the Kubernetes API kubeletClient

--- a/pkg/monitors/load/load.go
+++ b/pkg/monitors/load/load.go
@@ -23,7 +23,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	PerCPU               bool `yaml:"perCPU" default:"false"`
 }
 

--- a/pkg/monitors/memory/memory.go
+++ b/pkg/monitors/memory/memory.go
@@ -19,7 +19,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 }
 
 // Monitor for Utilization

--- a/pkg/monitors/metadata/hostmetadata/hostmetadata.go
+++ b/pkg/monitors/metadata/hostmetadata/hostmetadata.go
@@ -31,7 +31,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 }
 
 // Monitor for host-metadata

--- a/pkg/monitors/nagios/nagios.go
+++ b/pkg/monitors/nagios/nagios.go
@@ -28,7 +28,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 	// The command to exec with any arguments like:
 	// `"LC_ALL=\"en_US.utf8\" /usr/lib/nagios/plugins/check_ntp_time -H pool.ntp.typhon.net -w 0.5 -c 1"`
 	Command string `yaml:"command" validate:"required"`

--- a/pkg/monitors/netio/netio.go
+++ b/pkg/monitors/netio/netio.go
@@ -25,7 +25,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 	// The network interfaces to send metrics about. This is an [overridable
 	// set](https://docs.signalfx.com/en/latest/integrations/agent/filtering.html#overridable-filters).
 	Interfaces []string `yaml:"interfaces" default:"[\"*\", \"!/^lo\\\\d*$/\", \"!/^docker.*/\", \"!/^t(un|ap)\\\\d*$/\", \"!/^veth.*$/\", \"!/^Loopback*/\"]"`

--- a/pkg/monitors/ntp/ntp.go
+++ b/pkg/monitors/ntp/ntp.go
@@ -23,7 +23,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 	// The host/ip address of the NTP server (i.e. `pool.ntp.org`).
 	Host string `yaml:"host" validate:"required"`
 	// The port of the NTP server.

--- a/pkg/monitors/process/process.go
+++ b/pkg/monitors/process/process.go
@@ -23,7 +23,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 
 	// A list of process command names to match and send metrics about.  This
 	// is the name contained in /proc/<pid>/comm and is limited to just 15

--- a/pkg/monitors/processlist/processlist.go
+++ b/pkg/monitors/processlist/processlist.go
@@ -30,7 +30,7 @@ var now = time.Now
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 }
 
 func init() {

--- a/pkg/monitors/supervisor/supervisor.go
+++ b/pkg/monitors/supervisor/supervisor.go
@@ -21,7 +21,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"false" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"false" acceptsEndpoints:"false"`
 	// The host/ip address of the Supervisor XML-RPC API. This is used to construct
 	// the `url` option if not provided.
 	Host string `yaml:"host"`

--- a/pkg/monitors/telegraf/monitors/exec/exec.go
+++ b/pkg/monitors/telegraf/monitors/exec/exec.go
@@ -28,7 +28,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	Commands             []string          `yaml:"commands"`
 	Command              string            `yaml:"command"`
 	Timeout              timeutil.Duration `yaml:"timeout"`

--- a/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
+++ b/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
@@ -28,7 +28,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"true"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
 	Host                 string `yaml:"host" validate:"required" default:"."`
 	Port                 uint16 `yaml:"port" validate:"required" default:"1433"`
 	// UserID used to access the SQL Server instance.

--- a/pkg/monitors/telegraf/monitors/procstat/procstat.go
+++ b/pkg/monitors/telegraf/monitors/procstat/procstat.go
@@ -29,7 +29,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// The name of an executable to monitor.  (ie: `exe: "signalfx-agent*"`)
 	Exe string `yaml:"exe"`
 	// Pattern to match against.  On Windows the pattern should be in the form of a WMI query.

--- a/pkg/monitors/telegraf/monitors/tail/tail.go
+++ b/pkg/monitors/telegraf/monitors/tail/tail.go
@@ -27,7 +27,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// Paths to files to be tailed
 	Files []string `yaml:"files" validate:"required"`
 	// Method for watching changes to files ("ionotify" or "poll")

--- a/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
+++ b/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
@@ -25,7 +25,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// Paths to files to be tailed
 	Files []string `yaml:"files" validate:"required"`
 	// Method for watching changes to files ("ionotify" or "poll")

--- a/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
+++ b/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
@@ -58,7 +58,7 @@ type Table struct {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"true"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"true"`
 	// Host and port will be concatenated and appended to the list of SNMP agents to connect to.
 	Host string `yaml:"host"`
 	// Port and Host will be concatenated and appended to the list of SNMP agents to connect to.

--- a/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
+++ b/pkg/monitors/telegraf/monitors/telegrafstatsd/statsd.go
@@ -25,7 +25,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// Protocol to use with the listener: `tcp`, `udp4`, `udp6`, or `udp`.
 	Protocol string `yaml:"protocol" default:"udp"`
 	// The address and port to serve from

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
@@ -54,7 +54,7 @@ type PerfCounterObj struct {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false" deepcopier:"skip"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false" deepcopier:"skip"`
 	Object               []PerfCounterObj `yaml:"objects" default:"[]"`
 	// The frequency that counter paths should be expanded
 	// and how often to refresh counters from configuration.

--- a/pkg/monitors/telegraf/monitors/winservices/winservices.go
+++ b/pkg/monitors/telegraf/monitors/winservices/winservices.go
@@ -14,7 +14,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// Names of services to monitor.  All services will be monitored if none are specified.
 	ServiceNames []string `yaml:"serviceNames"`
 }

--- a/pkg/monitors/vmem/vmem.go
+++ b/pkg/monitors/vmem/vmem.go
@@ -14,7 +14,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) The frequency that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	// This is expressed as a duration.

--- a/pkg/monitors/windowsiis/windowsiis.go
+++ b/pkg/monitors/windowsiis/windowsiis.go
@@ -14,7 +14,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`

--- a/pkg/monitors/windowslegacy/windowslegacy.go
+++ b/pkg/monitors/windowslegacy/windowslegacy.go
@@ -13,7 +13,7 @@ func init() {
 
 // Config for this monitor
 type Config struct {
-	config.MonitorConfig `singleInstance:"true" acceptsEndpoints:"false"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true" acceptsEndpoints:"false"`
 	// (Windows Only) Number of seconds that wildcards in counter paths should
 	// be expanded and how often to refresh counters from configuration.
 	CountersRefreshInterval timeutil.Duration `yaml:"counterRefreshInterval" default:"60s"`


### PR DESCRIPTION
These changes allow each monitor config to be unmarshalled directly from yaml instead of requiring the current two pass system using the catch-all extra config.  They are effectively noops regarding current unmarshalling behavior and are being added for better compatibility for agent module* consumers.