### PR TITLE
aws instance-identity response; log the body for better debugging

### DIFF
--- a/pkg/core/hostid/aws.go
+++ b/pkg/core/hostid/aws.go
@@ -44,6 +44,7 @@ func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
+			"body":  string(body),
 		}).Debug("Failed to unmarshal AWS instance-identity response")
 		return ""
 	}


### PR DESCRIPTION
This will help debugging errors like this:

```
time="2021-01-21T06:42:31Z" level=debug msg="Failed to unmarshal AWS instance-identity response" error="invalid character '<' looking for beginning of value"
```

Signed-off-by: Dani Louca <dlouca@splunk.com>