### PR TITLE
Improve windows performance by fetching all processes name in one call

### DIFF
--- a/pkg/observers/host/host_others.go
+++ b/pkg/observers/host/host_others.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package host
+
+import (
+	"github.com/shirou/gopsutil/process"
+)
+
+func (p *processName) getName(proc *process.Process) (string, error) {
+	return proc.Name()
+}
+
+func (p *processName) setPidNameMap() error {
+	return nil
+}

--- a/pkg/observers/host/host_windows.go
+++ b/pkg/observers/host/host_windows.go
@@ -1,0 +1,44 @@
+// +build windows
+
+package host
+
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/shirou/gopsutil/process"
+	"golang.org/x/sys/windows"
+)
+
+func (p *processName) getName(proc *process.Process) (string, error) {
+	name, ok := p.pidNameMap[proc.Pid]
+	if !ok {
+		return "", fmt.Errorf("could not find name for PID %v", proc.Pid)
+	}
+	return name, nil
+}
+
+// setPidNameMap fills up the pidNameMap with all processes running on
+// the system by iterating through the windows process snapshot
+func (p *processName) setPidNameMap() error {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = windows.CloseHandle(snapshot)
+	}()
+	var pe32 windows.ProcessEntry32
+	pe32.Size = uint32(unsafe.Sizeof(pe32))
+	if err = windows.Process32First(snapshot, &pe32); err != nil {
+		return err
+	}
+	for {
+		p.pidNameMap[int32(pe32.ProcessID)] = windows.UTF16ToString(pe32.ExeFile[:])
+		if err = windows.Process32Next(snapshot, &pe32); err != nil {
+			// ERROR_NO_MORE_FILES we reached the end of the snapshot
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
The host observer usage of the `gopsutil -> process` method `Name()`, for windows, is not efficient as the latter is a super expensive call.
The host observer gets the list of Processes IDs on the system, iterates through the list and calls `Name()` for every PID that is listening on a port.

[Host observer ](https://github.com/signalfx/signalfx-agent/blob/master/pkg/observers/host/host.go#L122-L133)

The [Name() ](https://github.com/shirou/gopsutil/blob/master/process/process_windows.go#L638) method creates a snapshot of all the running processes and iterates through the list to find a PID that matches the caller’s PID and returns the process name.
`CreateToolhelp32Snapshot` and `Process32Next` are the main resource intensive methods; 
the caller invokes this method for every PID on the system!

As a solution, our code does not need to make the call for each PID, instead, we should use a method that iterates through the windows processes snapshot, builds and returns a PID->ProcessName map of all the processes on the system.

Note: Telegraf/procstat monitor suffer from the same issue.
https://github.com/signalfx/telegraf/blob/signalfx-integration/plugins/inputs/procstat/native_finder_windows.go#L35-L46

cc: @jrcamp @keitwb 
Signed-off-by: Dani Louca <dlouca@splunk.com>