### PR TITLE
Allow k8s-api observer's discovery settings to be independently configured via Helm

### DIFF
--- a/deployments/k8s/configmap.yaml
+++ b/deployments/k8s/configmap.yaml
@@ -35,8 +35,6 @@ data:
 
     observers:
     - type: k8s-api
-      discoverAllPods: false
-      discoverNodes: false
 
     monitors:
     - type: cpu

--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -96,8 +96,12 @@ data:
         skipVerify: true
       {{- end }}
       {{- if semverCompare ">=5.2.0" $agentSemver.Original }}
-      discoverAllPods: {{ toYaml .Values.isServerless }}
-      discoverNodes: {{ toYaml .Values.isServerless }}
+      {{- if or (.Values.isServerless) (.Values.discoverAllPods) }}
+      discoverAllPods: true
+      {{- end }}
+      {{- if or (.Values.isServerless) (.Values.discoverNodes) }}
+      discoverNodes: true
+      {{- end }}
       {{- end }}
       {{- if .Values.additionalPortAnnotations }}
       additionalPortAnnotations:

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -121,6 +121,18 @@ runOnMaster: true
 # sufficiently similar.
 isServerless: false
 
+# If this is set to `true`, the k8s-api observer will be configured to discover 
+# all services in the cluster, regardless of node. This is similar to the
+# `isServerless` setting but only configures the k8s-api observer to discover
+# all services in the cluster and does not configure any additional monitors.
+discoverAllPods: false
+
+# If this is set to `true`, the k8s-api observer will be configured to discover 
+# cluster nodes as a special type of endpoint. This is similar to the
+# `isServerless` setting but only configures the k8s-api observer to discover
+# all nodes in the cluster and does not configure any additional monitors.
+discoverNodes: false
+
 # You can specify a node selector (https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector)
 # that limits what nodes the agent will run on.
 nodeSelector: {


### PR DESCRIPTION
When using the Helm chart, it is not currently possible to set the k8s-api observer's `discoverAllPods` or `discoverNodes` parameters except by setting the `isServerless` parameter to true. There are some situations where the observer needs to be configured to discover all pods or nodes in a non-serverless environment, thus this change will set the values to true if the new `discoverAllPods`/`discoverNodes` setting is true or if `isServerless` is set to true.

With the current default values, this does result in a minor change to the ConfigMap - removing `discoverAllPods` and `discoverNodes` if they are not set to true. This does not result in a behavioural change, [as the observer itself will treat these values as false if not explicitly defined](https://docs.signalfx.com/en/latest/integrations/agent/observers/k8s-api.html#configuration).

One such use case for this functionality on a non-serverless cluster is for configuring monitors that target services running on some of the cluster's nodes that are not discoverable via Kubernetes itself. For example, [a similar discovery rule as is used to discover the Kubelet on Fargate clusters](https://github.com/signalfx/signalfx-agent/blob/fc1d6cbdfe042855b1ad3e6f55416cd027f86955/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml#L154) can be used to discover etcd on Rancher clusters. Both rely on the ability to discover the nodes themselves.