### PR TITLE
Allow for additional container image exclusions via Helm values

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -178,6 +178,9 @@ data:
           container_image:
            - '*pause-amd64*'
            - 'k8s.gcr.io/pause*'
+           {{- if .Values.extraExcludedContainerImages }}
+           {{ toYaml .Values.extraExcludedContainerImages | indent 11 | trim }}
+           {{- end }}
         metricNames:
           - '*'
           - '!*network*'
@@ -232,6 +235,9 @@ data:
       excludedImages:
        - '*pause-amd64*'
        - 'k8s.gcr.io/pause*'
+       {{- if .Values.extraExcludedContainerImages }}
+       {{ toYaml .Values.extraExcludedContainerImages | indent 7 | trim }}
+       {{- end }}
       labelsToDimensions:
         io.kubernetes.container.name: container_spec_name
         io.kubernetes.pod.name: kubernetes_pod_name

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -306,6 +306,11 @@ configureStandardMonitors: true
 # Has no effect if `configureStandardMonitors: false`
 loadPerCPU: false
 
+# A list of additional container images to exclude from the kubelet-metrics,
+# kubelet-stats and docker-container-stats monitors. These are typically pause
+# containers that are not covered by the default exclusions.
+extraExcludedContainerImages: []
+
 # A list of monitor configurations to include in the agent config.  These
 # values correspond exactly to what goes under 'monitors' in the agent config.
 monitors:


### PR DESCRIPTION
The kubelet-metrics, kubelet-stats and docker-container-stats monitors exclude some or all metrics from two common 'pause' containers by default. However, some Kubernetes distributions will use different pause container images and thus the list of container images to exclude from these monitors needs to be extensible.

n.b. The indent levels for the included list are set to an odd number in order to match the same indent level as the existing items in the image list. This is also consistent with the excluded image list indentation in the [kubelet-stats documentation](https://github.com/signalfx/signalfx-agent/blob/master/docs/monitors/kubelet-stats.md#L43-L44).