### PR TITLE
Add windows registry facts for puppet

### DIFF
--- a/deployments/puppet/.fixtures.yml
+++ b/deployments/puppet/.fixtures.yml
@@ -12,4 +12,7 @@ fixtures:
     powershell:
       repo: "puppetlabs/powershell"
       ref: "2.3.0"
+    registry:
+      repo: "puppetlabs/registry"
+      ref: "3.2.0"
 

--- a/deployments/puppet/README.md
+++ b/deployments/puppet/README.md
@@ -85,6 +85,8 @@ On Windows-based systems SignalFx Agent Puppet module has the following dependen
 
 - [puppetlabs/powershell](https://forge.puppet.com/puppetlabs/powershell)
 
+- [puppetlabs/registry](https://forge.puppet.com/modules/puppetlabs/registry)
+
 ## Development
 
 To work on the module in development, you can use the provided dev image to

--- a/deployments/puppet/lib/facter/signalfx_agent_config_path.rb
+++ b/deployments/puppet/lib/facter/signalfx_agent_config_path.rb
@@ -1,0 +1,20 @@
+# This custom fact checks for the agent config path on windows.
+# Returns empty string if the key or the path does not exist.
+
+Facter.add(:signalfx_agent_config_path) do
+  confine :osfamily => :windows
+  setcode do
+    begin
+      value = ''
+      Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\CurrentControlSet\Services\signalfx-agent') do |regkey|
+        value = regkey['ConfigPath']
+      end
+      if value and !File.exists?(value)
+        value = ''
+      end
+      value
+    rescue
+      ''
+    end
+  end
+end

--- a/deployments/puppet/lib/facter/signalfx_agent_exe_path.rb
+++ b/deployments/puppet/lib/facter/signalfx_agent_exe_path.rb
@@ -1,0 +1,20 @@
+# This custom fact checks for the installed agent path on windows.
+# Returns empty string if the key or the path does not exist.
+
+Facter.add(:signalfx_agent_exe_path) do
+  confine :osfamily => :windows
+  setcode do
+    begin
+      value = ''
+      Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\CurrentControlSet\Services\signalfx-agent') do |regkey|
+        value = regkey['ExePath']
+      end
+      if value and !File.exists?(value)
+        value = ''
+      end
+      value
+    rescue
+      ''
+    end
+  end
+end

--- a/deployments/puppet/lib/facter/signalfx_agent_version.rb
+++ b/deployments/puppet/lib/facter/signalfx_agent_version.rb
@@ -1,0 +1,17 @@
+# This custom fact checks for the installed agent version on windows.
+# Returns empty string if the key does not exist.
+
+Facter.add(:signalfx_agent_version) do
+  confine :osfamily => :windows
+  setcode do
+    begin
+      value = ''
+      Win32::Registry::HKEY_LOCAL_MACHINE.open('SYSTEM\CurrentControlSet\Services\signalfx-agent') do |regkey|
+        value = regkey['CurrentVersion']
+      end
+      value
+    rescue
+      ''
+    end
+  end
+end

--- a/deployments/puppet/manifests/win_repo.pp
+++ b/deployments/puppet/manifests/win_repo.pp
@@ -5,32 +5,40 @@ class signalfx_agent::win_repo (
   $version,
   $installation_directory,
   $service_name,
+  $config_file_path,
 ) {
 
   $zipfile_name = "SignalFxAgent-${version}-win64.zip"
   $url = "https://${repo_base}/windows/${package_stage}/zip/${zipfile_name}"
   $zipfile_location = "${installation_directory}\\${zipfile_name}"
-  $version_file = "${installation_directory}\\version.txt"
+  $exe_path = "${installation_directory}\\SignalFxAgent\\bin\\signalfx-agent.exe"
+  $registry_key = 'HKLM\SYSTEM\CurrentControlSet\Services\signalfx-agent'
 
-  file { $installation_directory:
-    ensure => 'directory',
-  }
+  if $::signalfx_agent_exe_path != $exe_path or $::signalfx_agent_version != $version {
+    # download and install if the agent is not already installed or the version changed
 
-  if find_file($version_file) {
-    $installed_version = file($version_file)
-  }
-  else {
-    $installed_version = ''
-  }
+    file { $installation_directory:
+      ensure => 'directory',
+    }
 
-  if $url != $installed_version {
     exec { 'Stop SignalFx Agent':
       command  => "Stop-Service -Name \'${service_name}\'",
       onlyif   => "((Get-CimInstance -ClassName win32_service -Filter 'Name = \'${service_name}\'' | Select Name, State).Name)",
       provider => 'powershell',
     }
 
-    -> archive { $zipfile_name:
+    # uninstall the existing service
+    if $::signalfx_agent_exe_path != '' {
+      exec { 'Uninstall service':
+        command  => "& \"${::signalfx_agent_exe_path}\" -service \"uninstall\"",
+        onlyif   => "((Get-CimInstance -ClassName win32_service -Filter 'Name = \'${service_name}\'' | Select Name, State).Name)",
+        provider => 'powershell',
+        require  => Exec['Stop SignalFx Agent'],
+        before   => Archive[$zipfile_name],
+      }
+    }
+
+    archive { $zipfile_name:
       source       => $url,
       path         => $zipfile_location,
       extract_path => $installation_directory,
@@ -38,11 +46,7 @@ class signalfx_agent::win_repo (
       user         => 'Administrator',
       extract      => true,
       cleanup      => true,
-      require      => File[$installation_directory],
-    }
-
-    -> file { $version_file:
-      content => $url,
+      require      => [File[$installation_directory], Exec['Stop SignalFx Agent']],
     }
 
     # ensure zip file is always deleted
@@ -50,5 +54,56 @@ class signalfx_agent::win_repo (
       ensure => 'absent',
       path   => $zipfile_location,
     }
+
+    -> exec { 'Install service':
+      command  => "& \"${exe_path}\" -service \"install\" -logEvents -config \"${config_file_path}\"",
+      provider => 'powershell',
+    }
+  } elsif $::signalfx_agent_config_path != $config_file_path {
+    # re-install the agent service if only the config path changed
+
+    exec { 'Stop SignalFx Agent':
+      command  => "Stop-Service -Name \'${service_name}\'",
+      onlyif   => "((Get-CimInstance -ClassName win32_service -Filter 'Name = \'${service_name}\'' | Select Name, State).Name)",
+      provider => 'powershell',
+    }
+
+    -> exec { 'Uninstall service':
+      command  => "& \"${exe_path}\" -service \"uninstall\"",
+      onlyif   => "((Get-CimInstance -ClassName win32_service -Filter 'Name = \'${service_name}\'' | Select Name, State).Name)",
+      provider => 'powershell',
+    }
+
+    -> exec { 'Install service':
+      command  => "& \"${exe_path}\" -service \"install\" -logEvents -config \"${config_file_path}\"",
+      provider => 'powershell',
+    }
+  }
+
+  # ensure that the registry is always up-to-date
+
+  registry_key { $registry_key:
+    ensure => 'present',
+  }
+
+  registry_value { "${registry_key}\\CurrentVersion":
+    ensure  => 'present',
+    type    => 'string',
+    data    => $version,
+    require => Registry_key[$registry_key],
+  }
+
+  registry_value { "${registry_key}\\ExePath":
+    ensure  => 'present',
+    type    => 'string',
+    data    => $exe_path,
+    require => Registry_key[$registry_key],
+  }
+
+  registry_value { "${registry_key}\\ConfigPath":
+    ensure  => 'present',
+    type    => 'string',
+    data    => $config_file_path,
+    require => Registry_key[$registry_key],
   }
 }

--- a/deployments/puppet/metadata.json
+++ b/deployments/puppet/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "signalfx-signalfx_agent",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "author": "SignalFx, Inc.",
   "summary": "This module installs the SignalFx SmartAgent via distro packages and configures it.",
   "license": "Apache-2.0",
@@ -17,6 +17,10 @@
     {
       "name": "puppetlabs/powershell",
       "version_requirement": "<= 2.3.0"
+    },
+    {
+      "name": "puppetlabs/registry",
+      "version_requirement": "<= 3.2.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
For #1584 and #1588 
- Requires the `puppetlabs/registry` module to access/update the agent service registry key
- Remove `package` resource for windows; install agent service with `exec`