### PR TITLE
cpu: if cpu.utilzation > 100, round down to 100

### DIFF
--- a/pkg/monitors/cpu/cpu.go
+++ b/pkg/monitors/cpu/cpu.go
@@ -188,7 +188,7 @@ func getUtilization(prev *totalUsed, current *totalUsed) (utilization float64, e
 			err = fmt.Errorf("percent %v < 0 total: %v used: %v", utilization, totalDiff, usedDiff)
 		}
 		if utilization > 100.0 {
-			err = fmt.Errorf("percent %v > 100 total: %v used: %v ", utilization, totalDiff, usedDiff)
+			utilization = 100
 		}
 	}
 


### PR DESCRIPTION
I'm not sure if this is the best solution, but this seems slightly more favorable in cases of rounding errors where CPU is something like 100.000003 but we don't send a datapoint. 
In the case of some ridiculous value, 100 would still be enough to trigger detectors and show the CPU pegged, with the logs showing the true value.
