### PR TITLE
add path parameter to jenkins monitor

### DIFF
--- a/collectd-plugins.yaml
+++ b/collectd-plugins.yaml
@@ -26,7 +26,7 @@
   repo: signalfx/collectd-health_checker
 
 - name: jenkins
-  version: v2.1.0
+  version: v2.2.0
   repo: signalfx/collectd-jenkins
 
 - name: kong

--- a/docs/monitors/collectd-jenkins.md
+++ b/docs/monitors/collectd-jenkins.md
@@ -85,6 +85,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `pythonBinary` | no | `string` | Path to a python binary that should be used to execute the Python code. If not set, a built-in runtime will be used.  Can include arguments to the binary as well. |
 | `host` | **yes** | `string` |  |
 | `port` | **yes** | `integer` |  |
+| `path` | no | `string` |  |
 | `metricsKey` | **yes** | `string` | Key required for collecting metrics.  The access key located at `Manage Jenkins > Configure System > Metrics > ADD.` If empty, click `Generate`. |
 | `enhancedMetrics` | no | `bool` | Whether to enable enhanced metrics (**default:** `false`) |
 | `includeMetrics` | no | `list of strings` | Used to enable individual enhanced metrics when `enhancedMetrics` is false |

--- a/pkg/monitors/collectd/jenkins/jenkins.go
+++ b/pkg/monitors/collectd/jenkins/jenkins.go
@@ -29,6 +29,7 @@ type Config struct {
 	pyConf               *python.Config
 	Host                 string `yaml:"host" validate:"required"`
 	Port                 uint16 `yaml:"port" validate:"required"`
+	Path                 string `yaml:"path"`
 	// Key required for collecting metrics.  The access key located at
 	// `Manage Jenkins > Configure System > Metrics > ADD.`
 	// If empty, click `Generate`.
@@ -77,6 +78,7 @@ func (m *Monitor) Configure(conf *Config) error {
 		PluginConfig: map[string]interface{}{
 			"Host":                conf.Host,
 			"Port":                conf.Port,
+			"Path":                conf.Path,
 			"Interval":            conf.IntervalSeconds,
 			"MetricsKey":          conf.MetricsKey,
 			"EnhancedMetrics":     conf.EnhancedMetrics,

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -12590,6 +12590,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "path",
+            "doc": "",
+            "default": "",
+            "required": false,
+            "type": "string",
+            "elementKind": ""
+          },
+          {
             "yamlName": "metricsKey",
             "doc": "Key required for collecting metrics.  The access key located at `Manage Jenkins \u003e Configure System \u003e Metrics \u003e ADD.` If empty, click `Generate`.",
             "default": null,


### PR DESCRIPTION
Hello,

as explained here : https://github.com/signalfx/collectd-jenkins/issues/20

Sometimes we need to customize the path of jenkins (i.e. when deployed into kubernetes).

Note: this change has been fully tested (with dev agent using the python collectd script updated) and it works fine in our environment.