### PR TITLE
memory Monitor: Add Swap Memory Metrics

### DIFF
--- a/docs/monitors/memory.md
+++ b/docs/monitors/memory.md
@@ -53,6 +53,9 @@ Metrics that are categorized as
  - ***`memory.free`*** (*gauge*)<br>    (Linux Only) Bytes of memory available for use.
  - ***`memory.slab_recl`*** (*gauge*)<br>    (Linux Only) Bytes of memory, used for SLAB-allocation of kernel objects, that can be reclaimed.
  - ***`memory.slab_unrecl`*** (*gauge*)<br>    (Linux Only) Bytes of memory, used for SLAB-allocation of kernel objects, that can't be reclaimed.
+ - `memory.swap_free` (*gauge*)<br>    Bytes of swap memory available for use.
+ - `memory.swap_total` (*gauge*)<br>    Total bytes of swap memory on the system
+ - `memory.swap_used` (*gauge*)<br>    Bytes of swap memory in use by the system.
  - ***`memory.total`*** (*gauge*)<br>    Total bytes of system memory on the system.
  - ***`memory.used`*** (*gauge*)<br>    Bytes of memory in use by the system.
  - ***`memory.utilization`*** (*gauge*)<br>    Percent of memory in use on this host.  This does NOT include buffer or cache memory on Linux.

--- a/docs/monitors/memory.md
+++ b/docs/monitors/memory.md
@@ -54,7 +54,7 @@ Metrics that are categorized as
  - ***`memory.slab_recl`*** (*gauge*)<br>    (Linux Only) Bytes of memory, used for SLAB-allocation of kernel objects, that can be reclaimed.
  - ***`memory.slab_unrecl`*** (*gauge*)<br>    (Linux Only) Bytes of memory, used for SLAB-allocation of kernel objects, that can't be reclaimed.
  - `memory.swap_free` (*gauge*)<br>    Bytes of swap memory available for use.
- - `memory.swap_total` (*gauge*)<br>    Total bytes of swap memory on the system
+ - `memory.swap_total` (*gauge*)<br>    Total bytes of swap memory on the system.
  - `memory.swap_used` (*gauge*)<br>    Bytes of swap memory in use by the system.
  - ***`memory.total`*** (*gauge*)<br>    Total bytes of system memory on the system.
  - ***`memory.used`*** (*gauge*)<br>    Bytes of memory in use by the system.

--- a/pkg/monitors/memory/genmetadata.go
+++ b/pkg/monitors/memory/genmetadata.go
@@ -18,6 +18,9 @@ const (
 	memoryFree        = "memory.free"
 	memorySlabRecl    = "memory.slab_recl"
 	memorySlabUnrecl  = "memory.slab_unrecl"
+	memorySwapFree    = "memory.swap_free"
+	memorySwapTotal   = "memory.swap_total"
+	memorySwapUsed    = "memory.swap_used"
 	memoryTotal       = "memory.total"
 	memoryUsed        = "memory.used"
 	memoryUtilization = "memory.utilization"
@@ -30,6 +33,9 @@ var metricSet = map[string]monitors.MetricInfo{
 	memoryFree:        {Type: datapoint.Gauge},
 	memorySlabRecl:    {Type: datapoint.Gauge},
 	memorySlabUnrecl:  {Type: datapoint.Gauge},
+	memorySwapFree:    {Type: datapoint.Gauge},
+	memorySwapTotal:   {Type: datapoint.Gauge},
+	memorySwapUsed:    {Type: datapoint.Gauge},
 	memoryTotal:       {Type: datapoint.Gauge},
 	memoryUsed:        {Type: datapoint.Gauge},
 	memoryUtilization: {Type: datapoint.Gauge},

--- a/pkg/monitors/memory/memory.go
+++ b/pkg/monitors/memory/memory.go
@@ -38,7 +38,13 @@ func (m *Monitor) emitDatapoints() {
 		return
 	}
 
-	dps := m.makeMemoryDatapoints(memInfo, nil)
+	swapInfo, err := mem.SwapMemory()
+	if err != nil {
+		m.logger.WithError(err).Errorf("Unable to collect swap memory stats")
+		return
+	}
+
+	dps := m.makeMemoryDatapoints(memInfo, swapInfo, nil)
 	m.Output.SendDatapoints(dps...)
 }
 

--- a/pkg/monitors/memory/memory_darwin.go
+++ b/pkg/monitors/memory/memory_darwin.go
@@ -7,7 +7,7 @@ import (
 	"github.com/signalfx/golib/v3/datapoint"
 )
 
-func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo *mem.SwapMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
 		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
@@ -16,5 +16,8 @@ func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimension
 		datapoint.New("memory.wired", dimensions, datapoint.NewIntValue(int64(memInfo.Wired)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
 	}
 }

--- a/pkg/monitors/memory/memory_linux.go
+++ b/pkg/monitors/memory/memory_linux.go
@@ -7,7 +7,7 @@ import (
 	"github.com/signalfx/golib/v3/datapoint"
 )
 
-func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo *mem.SwapMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	used := memInfo.Total - memInfo.Free - memInfo.Buffers - (memInfo.Cached - memInfo.SReclaimable) - memInfo.Slab
 
 	return []*datapoint.Datapoint{
@@ -20,5 +20,8 @@ func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimension
 		datapoint.New("memory.slab_unrecl", dimensions, datapoint.NewIntValue(int64(memInfo.Slab-memInfo.SReclaimable)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.free", dimensions, datapoint.NewIntValue(int64(memInfo.Free)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
 	}
 }

--- a/pkg/monitors/memory/memory_windows.go
+++ b/pkg/monitors/memory/memory_windows.go
@@ -7,11 +7,14 @@ import (
 	"github.com/signalfx/golib/v3/datapoint"
 )
 
-func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
+func (m *Monitor) makeMemoryDatapoints(memInfo *mem.VirtualMemoryStat, swapInfo *mem.SwapMemoryStat, dimensions map[string]string) []*datapoint.Datapoint {
 	return []*datapoint.Datapoint{
 		datapoint.New("memory.utilization", dimensions, datapoint.NewFloatValue(memInfo.UsedPercent), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.used", dimensions, datapoint.NewIntValue(int64(memInfo.Used)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.available", dimensions, datapoint.NewIntValue(int64(memInfo.Available)), datapoint.Gauge, time.Time{}),
 		datapoint.New("memory.total", dimensions, datapoint.NewIntValue(int64(memInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_total", dimensions, datapoint.NewIntValue(int64(swapInfo.Total)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_free", dimensions, datapoint.NewIntValue(int64(swapInfo.Free)), datapoint.Gauge, time.Time{}),
+		datapoint.New("memory.swap_used", dimensions, datapoint.NewIntValue(int64(swapInfo.Used)), datapoint.Gauge, time.Time{}),
 	}
 }

--- a/pkg/monitors/memory/metadata.yaml
+++ b/pkg/monitors/memory/metadata.yaml
@@ -29,6 +29,18 @@ monitors:
       description: (Linux Only) Bytes of memory available for use.
       default: true
       type: gauge
+    memory.swap_free:
+      description: Bytes of swap memory available for use.
+      default: false
+      type: gauge
+    memory.swap_total:
+      description: Total bytes of swap memory on the system
+      default: false
+      type: gauge
+    memory.swap_used:
+      description: Bytes of swap memory in use by the system.
+      default: false
+      type: gauge
     memory.slab_recl:
       description: (Linux Only) Bytes of memory, used for SLAB-allocation of kernel
         objects, that can be reclaimed.

--- a/pkg/monitors/memory/metadata.yaml
+++ b/pkg/monitors/memory/metadata.yaml
@@ -34,7 +34,7 @@ monitors:
       default: false
       type: gauge
     memory.swap_total:
-      description: Total bytes of swap memory on the system
+      description: Total bytes of swap memory on the system.
       default: false
       type: gauge
     memory.swap_used:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -41609,7 +41609,7 @@
         },
         "memory.swap_total": {
           "type": "gauge",
-          "description": "Total bytes of swap memory on the system",
+          "description": "Total bytes of swap memory on the system.",
           "group": null,
           "default": false
         },

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -41555,6 +41555,9 @@
             "memory.free",
             "memory.slab_recl",
             "memory.slab_unrecl",
+            "memory.swap_free",
+            "memory.swap_total",
+            "memory.swap_used",
             "memory.total",
             "memory.used",
             "memory.utilization"
@@ -41597,6 +41600,24 @@
           "description": "(Linux Only) Bytes of memory, used for SLAB-allocation of kernel objects, that can't be reclaimed.",
           "group": null,
           "default": true
+        },
+        "memory.swap_free": {
+          "type": "gauge",
+          "description": "Bytes of swap memory available for use.",
+          "group": null,
+          "default": false
+        },
+        "memory.swap_total": {
+          "type": "gauge",
+          "description": "Total bytes of swap memory on the system",
+          "group": null,
+          "default": false
+        },
+        "memory.swap_used": {
+          "type": "gauge",
+          "description": "Bytes of swap memory in use by the system.",
+          "group": null,
+          "default": false
         },
         "memory.total": {
           "type": "gauge",


### PR DESCRIPTION
Adds swap total, used, and free for Windows, Linux, and Mac.

They are all non-default metrics.

Fixes #1594