### PR TITLE
vSphere: set `host` dimension to `vm_ip` value when available

### DIFF
--- a/pkg/monitors/vsphere/service/inventory.go
+++ b/pkg/monitors/vsphere/service/inventory.go
@@ -29,6 +29,7 @@ const (
 	dimVM            = "vm_name"
 	dimGuestID       = "guest_id"
 	dimVMip          = "vm_ip"
+	dimHost          = "host"
 	dimGuestFamily   = "guest_family"
 	dimGuestFullname = "guest_fullname"
 )
@@ -193,6 +194,7 @@ func (svc *InventorySvc) followVM(
 		dimVM:            vm.Name,           // e.g. "MyDebian10Host"
 		dimGuestID:       vm.Config.GuestId, // e.g. "debian10_64Guest"
 		dimVMip:          vm.Guest.IpAddress,
+		dimHost:          vm.Guest.IpAddress,
 		dimGuestFamily:   vm.Guest.GuestFamily,   // e.g. "linuxGuest"
 		dimGuestFullname: vm.Guest.GuestFullName, // e.g. "Other 4.x or later Linux (64-bit)"
 	}

--- a/pkg/monitors/vsphere/service/points.go
+++ b/pkg/monitors/vsphere/service/points.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/vim25/types"
 
+	"github.com/signalfx/signalfx-agent/pkg/core/common/dpmeta"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
 
@@ -115,6 +116,9 @@ func (svc *PointsSvc) FetchPoints(vsInfo *model.VsphereInfo, numSamplesReqd int3
 						sfxMetricType,
 						perfEntityMetric.SampleInfo[i].Timestamp,
 					)
+					// make sure the agent doesn't overwrite the `host` dimension with the hostname
+					// the agent is running on
+					dp.Meta[dpmeta.NotHostSpecificMeta] = true
 					svc.ptConsumer(dp)
 				}
 			}


### PR DESCRIPTION
Previously, metrics for VMs in a vSphere cluster all had the same host dimension, the hostname on which the smart agent was running. This change explicitly sets the host dimension to the vm_ip dimension's value, if available.