### PR TITLE
Add config override to observers in K8S Helm chart

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/configmap.yaml
@@ -90,6 +90,7 @@ data:
       {{- end }}
 
     observers:
+    {{- if .Values.configureStandardObservers }}
     - type: k8s-api
       {{- if .Values.apiServerSkipVerify }}
       kubernetesAPI:
@@ -109,6 +110,10 @@ data:
       - {{ toYaml . | indent 8 | trim }}
       {{- end }}
       {{- end }}
+    {{- end }}
+    {{- with .Values.observers }}
+    {{ toYaml . }}
+    {{- end }}
 
     monitors:
 {{- if .Values.configureStandardMonitors }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -333,3 +333,12 @@ monitorsd:
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}
 
+# If true, a standard set of observers will be added to config
+#   default for helm chart:  config="{k8s-api map[discoverAllPods:true discoverNodes:true]}
+configureStandardObservers: true
+
+# A list of observer configurations to include in the agent config.  These
+# values correspond exactly to what goes under 'observers' in the agent config.
+# Added to configs regardless of the value of `configureStandardObservers`
+observers: []
+


### PR DESCRIPTION
I have a use case where I want to run a monitor only agent in serverless mode with a single k8s pod.

This PR allows ability to override observers config block completely instead of assuming k8s-api discovery is always enabled.