### PR TITLE
Change version compatibility for collectd/redis monitor in documentation

### DIFF
--- a/docs/monitors/collectd-redis.md
+++ b/docs/monitors/collectd-redis.md
@@ -12,7 +12,7 @@ Monitor Type: `collectd/redis` ([Source](https://github.com/signalfx/signalfx-ag
 
 Monitors a redis instance using the [collectd Python Redis
 plugin](https://github.com/signalfx/redis-collectd-plugin).  Supports Redis
-2.8 and later.
+3.2 and later.
 
 You can capture any kind of Redis metrics like:
 


### PR DESCRIPTION
The collectd/redis monitor seems to only be compatible with redis 3.2 and higher.
It seems this was introduced by this PR : https://github.com/signalfx/signalfx-agent/pull/1420

For exemple the `total_system_memory` was introduced in redis 3.2 : https://github.com/redis/redis/commit/ec5a0c548b0afbb1bd584b5761bf740460fd20a2

On my system I get the following errors : 

```
root@sys:~# awk -F"\"" '{print $4}' /var/log/signalfx-agent.log | sort -n | uniq -c | grep Metric
     ...
     92 Metric total_system_memory not found in Redis INFO output
root@sys:~# redis-cli info | grep -i vers
redis_version:2.8.17
```

