### PR TITLE
Update telegraf procstat doc - Under telegraf v2.20.5 , Pattern for windows is now a regular expression

### DIFF
--- a/docs/monitors/telegraf-procstat.md
+++ b/docs/monitors/telegraf-procstat.md
@@ -49,7 +49,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
 | `exe` | no | `string` | The name of an executable to monitor.  (ie: `exe: "signalfx-agent*"`) |
-| `pattern` | no | `string` | Pattern to match against.  On Windows the pattern should be in the form of a WMI query. (ie: `pattern: "%signalfx-agent%"`) |
+| `pattern` | no | `string` | Regular expression pattern to match against. |
 | `user` | no | `string` | Username to match against |
 | `pidFile` | no | `string` | Path to Pid file to monitor.  (ie: `pidFile: "/var/run/signalfx-agent.pid"`) |
 | `processName` | no | `string` | Used to override the process name dimension |

--- a/pkg/monitors/telegraf/monitors/procstat/procstat.go
+++ b/pkg/monitors/telegraf/monitors/procstat/procstat.go
@@ -32,8 +32,7 @@ type Config struct {
 	config.MonitorConfig `yaml:",inline" acceptsEndpoints:"false"`
 	// The name of an executable to monitor.  (ie: `exe: "signalfx-agent*"`)
 	Exe string `yaml:"exe"`
-	// Pattern to match against.  On Windows the pattern should be in the form of a WMI query.
-	// (ie: `pattern: "%signalfx-agent%"`)
+	// Regular expression pattern to match against.
 	Pattern string `yaml:"pattern"`
 	// Username to match against
 	User string `yaml:"user"`

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -50969,7 +50969,7 @@
           },
           {
             "yamlName": "pattern",
-            "doc": "Pattern to match against.  On Windows the pattern should be in the form of a WMI query. (ie: `pattern: \"%signalfx-agent%\"`)",
+            "doc": "Regular expression pattern to match against.",
             "default": "",
             "required": false,
             "type": "string",


### PR DESCRIPTION
in SFX agent 5.7.0 we upgraded our telegraf fork to `v2.20.5` 
This version brings a behavior change that impacts our docs; the `procstat` monitor's `Pattern` option is no longer in the form of a WMI query, it's now a regex https://github.com/signalfx/telegraf/blob/signalfx-agent/plugins/inputs/procstat/native_finder.go#L63

Signed-off-by: Dani Louca <dlouca@splunk.com>