### PR TITLE
(during build) Upgrade pip before installing python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 ARG GO_VERSION=1.14.2
+ARG PIP_VERSION=21.0.1
 
 ###### Agent Build Image ########
 FROM ubuntu:16.04 as agent-builder
@@ -255,7 +256,9 @@ RUN patchelf --add-needed libm-2.23.so /opt/deps/libvarnishapi.so.1.0.4
 ###### Python Plugin Image ######
 FROM collectd as python-plugins
 
-RUN python3 -m pip install yq &&\
+ARG PIP_VERSION
+
+RUN python3 -m pip install --upgrade pip==$PIP_VERSION && python3 -m pip install yq &&\
     wget -O /usr/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 &&\
     chmod +x /usr/bin/jq
 


### PR DESCRIPTION
The `cryptography` crate contains a Rust dependency;
If pip is not up to date it will expect the rust toolchain to be installed on the machine.
Otherwise, if pip is up to date, it will install a binary wheel.

I discovered this while building a DEB package for ARM64