### PR TITLE
Support postgresql 13

### DIFF
--- a/pkg/monitors/postgresql/monitor.go
+++ b/pkg/monitors/postgresql/monitor.go
@@ -136,7 +136,6 @@ func (m *Monitor) Configure(conf *Config) error {
 
 	m.serverMonitor, err = m.monitorServer()
 	if err != nil {
-		m.database.Close()
 		return fmt.Errorf("could not monitor postgresql server: %v", err)
 	}
 

--- a/pkg/monitors/postgresql/queries.go
+++ b/pkg/monitors/postgresql/queries.go
@@ -1,94 +1,100 @@
 package postgresql
 
-import "github.com/signalfx/signalfx-agent/pkg/monitors/sql"
+import (
+	"fmt"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/sql"
+)
 
 // Queries that get metrics about the entire server instance and do not need to
 // be run on a per-database basis.
-var defaultServerQueries = []sql.Query{
-	{
-		Query: `SELECT COUNT(*) as count, state, datname as database FROM pg_stat_activity WHERE state IS NOT NULL GROUP BY pg_stat_activity.state, pg_stat_activity.datname;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_sessions",
-				ValueColumn:      "count",
-				DimensionColumns: []string{"state", "database"},
+func defaultServerQueries(totalTimeColumn string) []sql.Query {
+	return []sql.Query{
+		{
+			Query: `SELECT COUNT(*) as count, state, datname as database FROM pg_stat_activity WHERE state IS NOT NULL GROUP BY pg_stat_activity.state, pg_stat_activity.datname;`,
+			Metrics: []sql.Metric{
+				{
+					MetricName:       "postgres_sessions",
+					ValueColumn:      "count",
+					DimensionColumns: []string{"state", "database"},
+				},
 			},
 		},
-	},
-	{
-		Query: `SELECT datname as database, (blks_hit*1.0 / GREATEST(blks_read + blks_hit, 1)) as blks_hit_ratio, deadlocks FROM pg_stat_database WHERE blks_read > 0;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_block_hit_ratio",
-				ValueColumn:      "blks_hit_ratio",
-				DimensionColumns: []string{"database"},
-			},
-			{
-				MetricName:       "postgres_deadlocks",
-				ValueColumn:      "deadlocks",
-				DimensionColumns: []string{"database"},
-				IsCumulative:     true,
-			},
-		},
-	},
-	{
-		Query: `SELECT datname as database, usename as user, SUM(calls) as total_calls, SUM(total_time) as total_time FROM pg_stat_statements INNER JOIN pg_stat_database ON pg_stat_statements.dbid = pg_stat_database.datid INNER JOIN pg_user ON pg_stat_statements.userid = pg_user.usesysid GROUP BY pg_stat_database.datname, pg_user.usename;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_query_count",
-				ValueColumn:      "total_calls",
-				DimensionColumns: []string{"database", "user"},
-				IsCumulative:     true,
-			},
-			{
-				MetricName:       "postgres_query_time",
-				ValueColumn:      "total_time",
-				DimensionColumns: []string{"database", "user"},
-				IsCumulative:     true,
+		{
+			Query: `SELECT datname as database, (blks_hit*1.0 / GREATEST(blks_read + blks_hit, 1)) as blks_hit_ratio, deadlocks FROM pg_stat_database WHERE blks_read > 0;`,
+			Metrics: []sql.Metric{
+				{
+					MetricName:       "postgres_block_hit_ratio",
+					ValueColumn:      "blks_hit_ratio",
+					DimensionColumns: []string{"database"},
+				},
+				{
+					MetricName:       "postgres_deadlocks",
+					ValueColumn:      "deadlocks",
+					DimensionColumns: []string{"database"},
+					IsCumulative:     true,
+				},
 			},
 		},
-	},
-	{
-		Query: `WITH max_con AS (SELECT setting::float FROM pg_settings WHERE name = 'max_connections') SELECT COUNT(*)/MAX(setting) AS pct_connections FROM pg_stat_activity, max_con;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:  "postgres_pct_connections",
-				ValueColumn: "pct_connections",
+		{
+			Query: fmt.Sprintf(`SELECT datname as database, usename as user, SUM(calls) as total_calls, SUM(%s) as total_time FROM pg_stat_statements INNER JOIN pg_stat_database ON pg_stat_statements.dbid = pg_stat_database.datid INNER JOIN pg_user ON pg_stat_statements.userid = pg_user.usesysid GROUP BY pg_stat_database.datname, pg_user.usename;`, totalTimeColumn),
+			Metrics: []sql.Metric{
+				{
+					MetricName:       "postgres_query_count",
+					ValueColumn:      "total_calls",
+					DimensionColumns: []string{"database", "user"},
+					IsCumulative:     true,
+				},
+				{
+					MetricName:       "postgres_query_time",
+					ValueColumn:      "total_time",
+					DimensionColumns: []string{"database", "user"},
+					IsCumulative:     true,
+				},
 			},
 		},
-	},
-	{
-		Query: `SELECT COUNT(*) AS locks FROM pg_locks WHERE NOT granted;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:  "postgres_locks",
-				ValueColumn: "locks",
+		{
+			Query: `WITH max_con AS (SELECT setting::float FROM pg_settings WHERE name = 'max_connections') SELECT COUNT(*)/MAX(setting) AS pct_connections FROM pg_stat_activity, max_con;`,
+			Metrics: []sql.Metric{
+				{
+					MetricName:  "postgres_pct_connections",
+					ValueColumn: "pct_connections",
+				},
 			},
 		},
-	},
-	{
-		Query: `SELECT datname AS database, xact_commit, xact_rollback, conflicts FROM pg_stat_database;`,
-		Metrics: []sql.Metric{
-			{
-				MetricName:       "postgres_conflicts",
-				ValueColumn:      "conflicts",
-				DimensionColumns: []string{"database"},
-				IsCumulative:     true,
-			},
-			{
-				MetricName:       "postgres_xact_commits",
-				ValueColumn:      "xact_commit",
-				DimensionColumns: []string{"database"},
-				IsCumulative:     true,
-			},
-			{
-				MetricName:       "postgres_xact_rollbacks",
-				ValueColumn:      "xact_rollback",
-				DimensionColumns: []string{"database"},
-				IsCumulative:     true,
+		{
+			Query: `SELECT COUNT(*) AS locks FROM pg_locks WHERE NOT granted;`,
+			Metrics: []sql.Metric{
+				{
+					MetricName:  "postgres_locks",
+					ValueColumn: "locks",
+				},
 			},
 		},
-	},
+		{
+			Query: `SELECT datname AS database, xact_commit, xact_rollback, conflicts FROM pg_stat_database;`,
+			Metrics: []sql.Metric{
+				{
+					MetricName:       "postgres_conflicts",
+					ValueColumn:      "conflicts",
+					DimensionColumns: []string{"database"},
+					IsCumulative:     true,
+				},
+				{
+					MetricName:       "postgres_xact_commits",
+					ValueColumn:      "xact_commit",
+					DimensionColumns: []string{"database"},
+					IsCumulative:     true,
+				},
+				{
+					MetricName:       "postgres_xact_rollbacks",
+					ValueColumn:      "xact_rollback",
+					DimensionColumns: []string{"database"},
+					IsCumulative:     true,
+				},
+			},
+		},
+	}
 }
 
 var makeDefaultDBQueries = func(dbname string) []sql.Query {
@@ -177,7 +183,7 @@ var makeDefaultDBQueries = func(dbname string) []sql.Query {
 
 }
 
-var makeDefaultStatementsQueries = func(limit int) []sql.Query {
+var makeDefaultStatementsQueries = func(limit int, totalTimeColumn string) []sql.Query {
 	return []sql.Query{
 		{
 			Query:  `SELECT datname as database, usename as user, queryid, query, calls FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY calls DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`,
@@ -193,7 +199,7 @@ var makeDefaultStatementsQueries = func(limit int) []sql.Query {
 			},
 		},
 		{
-			Query:  `SELECT datname as database, usename as user, queryid, query, total_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY total_time DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`,
+			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, %s as total_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn),
 			Params: []interface{}{limit},
 			Metrics: []sql.Metric{
 				{
@@ -206,7 +212,7 @@ var makeDefaultStatementsQueries = func(limit int) []sql.Query {
 			},
 		},
 		{
-			Query:  `SELECT datname as database, usename as user, queryid, query, (total_time / calls) AS average_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY total_time / calls DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`,
+			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, (%s / calls) AS average_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s / calls DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn),
 			Params: []interface{}{limit},
 			Metrics: []sql.Metric{
 				{

--- a/pkg/monitors/postgresql/queries.go
+++ b/pkg/monitors/postgresql/queries.go
@@ -37,7 +37,7 @@ func defaultServerQueries(totalTimeColumn string) []sql.Query {
 			},
 		},
 		{
-			Query: fmt.Sprintf(`SELECT datname as database, usename as user, SUM(calls) as total_calls, SUM(%s) as total_time FROM pg_stat_statements INNER JOIN pg_stat_database ON pg_stat_statements.dbid = pg_stat_database.datid INNER JOIN pg_user ON pg_stat_statements.userid = pg_user.usesysid GROUP BY pg_stat_database.datname, pg_user.usename;`, totalTimeColumn),
+			Query: fmt.Sprintf(`SELECT datname as database, usename as user, SUM(calls) as total_calls, SUM(%s) as total_time FROM pg_stat_statements INNER JOIN pg_stat_database ON pg_stat_statements.dbid = pg_stat_database.datid INNER JOIN pg_user ON pg_stat_statements.userid = pg_user.usesysid GROUP BY pg_stat_database.datname, pg_user.usename;`, totalTimeColumn), //nolint,gosec // column name will only be total_time or total_exec_time.
 			Metrics: []sql.Metric{
 				{
 					MetricName:       "postgres_query_count",
@@ -199,7 +199,7 @@ var makeDefaultStatementsQueries = func(limit int, totalTimeColumn string) []sql
 			},
 		},
 		{
-			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, %s as total_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn),
+			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, %s as total_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn), //nolint,gosec // column name will only be total_time or total_exec_time.
 			Params: []interface{}{limit},
 			Metrics: []sql.Metric{
 				{
@@ -212,7 +212,7 @@ var makeDefaultStatementsQueries = func(limit int, totalTimeColumn string) []sql
 			},
 		},
 		{
-			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, (%s / calls) AS average_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s / calls DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn),
+			Query:  fmt.Sprintf(`SELECT datname as database, usename as user, queryid, query, (%s / calls) AS average_time FROM (SELECT * FROM (SELECT ROW_NUMBER() OVER (PARTITION BY dbid ORDER BY %s / calls DESC) AS r, s.* FROM pg_stat_statements s) q WHERE q.r <= $1) p, pg_stat_database d, pg_user u WHERE p.dbid = d.datid AND p.userid = u.usesysid;`, totalTimeColumn, totalTimeColumn), //nolint,gosec // column name will only be total_time or total_exec_time.
 			Params: []interface{}{limit},
 			Metrics: []sql.Metric{
 				{

--- a/tests/monitors/postgresql/postgres_test.py
+++ b/tests/monitors/postgresql/postgres_test.py
@@ -14,7 +14,7 @@ METADATA = Metadata.from_package("postgresql")
 ENV = ["POSTGRES_USER=test_user", "POSTGRES_PASSWORD=test_pwd", "POSTGRES_DB=postgres"]
 
 
-@pytest.mark.parametrize("version", ["9.2-alpine", "9-alpine", "10-alpine", "11-alpine"])
+@pytest.mark.parametrize("version", ["9.2-alpine", "9-alpine", "10-alpine", "11-alpine", "12-alpine", "13-alpine"])
 def test_postgresql(version):
     with run_service(
         "postgres", buildargs={"POSTGRES_VERSION": version}, environment=ENV, print_logs=False


### PR DESCRIPTION
These changes add support for Postgres 13, whose pg_stat_statements extension provided a breaking column name change of `total_time` -> `total_exec_time` to distinguish it from the added, optional `total_plan_time`.  This is done by querying the view's columns for the configured master db and formatting* the queries before the underlying SQL monitor Configure().