### PR TITLE
Fix pip failures in ansible tests

### DIFF
--- a/tests/deployments/ansible/images/Dockerfile.amazonlinux1
+++ b/tests/deployments/ansible/images/Dockerfile.amazonlinux1
@@ -3,9 +3,10 @@ FROM amazonlinux:1
 ENV container docker
 
 RUN yum install -y upstart procps initscripts python36-pip
+RUN pip-3.6 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
-RUN pip-3.6 install ansible${ANSIBLE_VERSION}
+RUN pip3 install ansible${ANSIBLE_VERSION}
 
 VOLUME [ "/sys/fs/cgroup" ]
 

--- a/tests/deployments/ansible/images/Dockerfile.amazonlinux2
+++ b/tests/deployments/ansible/images/Dockerfile.amazonlinux2
@@ -3,6 +3,7 @@ FROM amazonlinux:2
 ENV container docker
 
 RUN yum install -y systemd procps initscripts python3-pip
+RUN pip3 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip3 install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.centos7
+++ b/tests/deployments/ansible/images/Dockerfile.centos7
@@ -3,6 +3,7 @@ FROM centos:7
 ENV container docker
 
 RUN yum install -y systemd procps initscripts python3-pip
+RUN pip3 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip3 install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.centos8
+++ b/tests/deployments/ansible/images/Dockerfile.centos8
@@ -3,6 +3,7 @@ FROM centos:8
 ENV container docker
 
 RUN dnf install -y systemd procps initscripts python3-pip
+RUN pip3 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.8.1'
 RUN pip3 install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.debian-8-jessie
+++ b/tests/deployments/ansible/images/Dockerfile.debian-8-jessie
@@ -4,7 +4,7 @@ RUN apt-get update &&\
     apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers curl python gnupg
 
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py pip==20.0.2
+    python /tmp/get-pip.py pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.debian-9-stretch
+++ b/tests/deployments/ansible/images/Dockerfile.debian-9-stretch
@@ -2,6 +2,7 @@ FROM debian:stretch-slim
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https curl python3-pip python3-paramiko gnupg
+RUN pip3 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip3 install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.ubuntu1604
+++ b/tests/deployments/ansible/images/Dockerfile.ubuntu1604
@@ -4,7 +4,7 @@ RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget apt-transport-https curl python gnupg
 
 RUN curl https://bootstrap.pypa.io/2.7/get-pip.py -o /tmp/get-pip.py && \
-    python /tmp/get-pip.py pip==20.0.2
+    python /tmp/get-pip.py pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip install ansible${ANSIBLE_VERSION}

--- a/tests/deployments/ansible/images/Dockerfile.ubuntu1804
+++ b/tests/deployments/ansible/images/Dockerfile.ubuntu1804
@@ -2,6 +2,7 @@ FROM ubuntu:18.04
 
 RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget apt-transport-https libcap2-bin curl python3-pip gnupg
+RUN pip3 install -U pip==20.3.4
 
 ARG ANSIBLE_VERSION='==2.4.0'
 RUN pip3 install ansible${ANSIBLE_VERSION}


### PR DESCRIPTION
Upgrade pip version in ansible tests to resolve test failures due to rust/cryptography dependencies.