### PR TITLE
Add refresh cache logic to keep docker and sfx in sync

### DIFF
--- a/docs/monitors/docker-container-stats.md
+++ b/docs/monitors/docker-container-stats.md
@@ -52,6 +52,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `enableExtraNetworkMetrics` | no | `bool` | Whether it will send all extra network metrics as well. (**default:** `false`) |
 | `dockerURL` | no | `string` | The URL of the docker server (**default:** `unix:///var/run/docker.sock`) |
 | `timeoutSeconds` | no | `integer` | The maximum amount of time to wait for docker API requests (**default:** `5`) |
+| `cacheSyncInterval` | no | `int64` | The time to wait before resyncing the list of containers the monitor maintains through the docker event listener example: cacheSyncInterval: "20m" (**default:** `60m`) |
 | `labelsToDimensions` | no | `map of strings` | A mapping of container label names to dimension names. The corresponding label values will become the dimension value for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a dimension called `container_spec_name` that has the value of the `io.kubernetes.container.name` container label. |
 | `envToDimensions` | no | `map of strings` | A mapping of container environment variable names to dimension names.  The corresponding env var values become the dimension values on the emitted metrics.  E.g. `APP_VERSION: version` would result in datapoints having a dimension called `version` whose value is the value of the `APP_VERSION` envvar configured for that particular container, if present. |
 | `excludedImages` | no | `list of strings` | A list of filters of images to exclude.  Supports literals, globs, and regex. |

--- a/docs/observers/docker.md
+++ b/docs/observers/docker.md
@@ -112,6 +112,7 @@ Observer Type: `docker`
 | Config option | Required | Type | Description |
 | --- | --- | --- | --- |
 | `dockerURL` | no | `string` |  (**default:** `unix:///var/run/docker.sock`) |
+| `cacheSyncInterval` | no | `int64` | The time to wait before resyncing the list of containers the monitor maintains through the docker event listener example: cacheSyncInterval: "20m" (**default:** `60m`) |
 | `labelsToDimensions` | no | `map of strings` | A mapping of container label names to dimension names that will get applied to the metrics of all discovered services. The corresponding label values will become the dimension values for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a dimension called `container_spec_name` that has the value of the `io.kubernetes.container.name` container label. |
 | `useHostnameIfPresent` | no | `bool` | If true, the "Config.Hostname" field (if present) of the docker container will be used as the discovered host that is used to configure monitors.  If false or if no hostname is configured, the field `NetworkSettings.IPAddress` is used instead. (**default:** `false`) |
 | `useHostBindings` | no | `bool` | If true, the observer will configure monitors for matching container endpoints using the host bound ip and port.  This is useful if containers exist that are not accessible to an instance of the agent running outside of the docker network stack. (**default:** `false`) |

--- a/pkg/monitors/docker/docker.go
+++ b/pkg/monitors/docker/docker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,6 +50,9 @@ type Config struct {
 	DockerURL string `yaml:"dockerURL" default:"unix:///var/run/docker.sock"`
 	// The maximum amount of time to wait for docker API requests
 	TimeoutSeconds int `yaml:"timeoutSeconds" default:"5"`
+	// The time to wait before resyncing the list of containers the monitor maintains
+	// through the docker event listener example: cacheSyncInterval: "20m"
+	CacheSyncInterval timeutil.Duration `yaml:"cacheSyncInterval" default:"60m"`
 	// A mapping of container label names to dimension names. The corresponding
 	// label values will become the dimension value for the mapped name.  E.g.
 	// `io.kubernetes.container.name: container_spec_name` would result in a
@@ -140,11 +144,7 @@ func (m *Monitor) Configure(conf *Config) error {
 		// Repeat the watch setup in the face of errors in case the docker
 		// engine is non-responsive when the monitor starts.
 		if !isRegistered {
-			err := dockercommon.ListAndWatchContainers(m.ctx, m.client, changeHandler, imageFilter, m.logger)
-			if err != nil {
-				m.logger.WithError(err).Error("Could not list docker containers")
-				return
-			}
+			dockercommon.ListAndWatchContainers(m.ctx, m.client, changeHandler, imageFilter, m.logger, conf.CacheSyncInterval.AsDuration())
 			isRegistered = true
 		}
 

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -24342,6 +24342,14 @@
             "elementKind": ""
           },
           {
+            "yamlName": "cacheSyncInterval",
+            "doc": "The time to wait before resyncing the list of containers the monitor maintains through the docker event listener example: cacheSyncInterval: \"20m\"",
+            "default": "60m",
+            "required": false,
+            "type": "int64",
+            "elementKind": ""
+          },
+          {
             "yamlName": "labelsToDimensions",
             "doc": "A mapping of container label names to dimension names. The corresponding label values will become the dimension value for the mapped name.  E.g. `io.kubernetes.container.name: container_spec_name` would result in a dimension called `container_spec_name` that has the value of the `io.kubernetes.container.name` container label.",
             "default": null,
@@ -55898,6 +55906,14 @@
           "default": "unix:///var/run/docker.sock",
           "required": false,
           "type": "string",
+          "elementKind": ""
+        },
+        {
+          "yamlName": "cacheSyncInterval",
+          "doc": "The time to wait before resyncing the list of containers the monitor maintains through the docker event listener example: cacheSyncInterval: \"20m\"",
+          "default": "60m",
+          "required": false,
+          "type": "int64",
           "elementKind": ""
         },
         {


### PR DESCRIPTION
Add refresh cache logic to keep docker and sfx in sync when the event stream fails

cc: @keitwb @jrcamp 
Signed-off-by: Dani Louca <dlouca@splunk.com>