### PR TITLE
K8s helm add pdb

### DIFF
--- a/deployments/k8s/generate-from-helm
+++ b/deployments/k8s/generate-from-helm
@@ -27,7 +27,7 @@ render() {
       --output-dir $tmpdir \
       $AGENT_CHART_DIR
 
-  templates="configmap.yaml daemonset.yaml deployment.yaml clusterrole.yaml clusterrolebinding.yaml serviceaccount.yaml configmap-role.yaml configmap-rolebinding.yaml"
+  templates="configmap.yaml daemonset.yaml deployment.yaml clusterrole.yaml clusterrolebinding.yaml serviceaccount.yaml configmap-role.yaml configmap-rolebinding.yaml pdb.yaml"
   for f in $templates; do
 	fullpath=$tmpdir/signalfx-agent/templates/$f
 	if [[ "$f" == "daemonset.yaml" && $isServerless == "true" ]]; then
@@ -35,6 +35,10 @@ render() {
 	fi
 
 	if [[ "$f" == "deployment.yaml" && $isServerless == "false" ]]; then
+	  continue
+	fi
+
+	if [[ "$f" == "pdb.yaml" && $isServerless == "false" ]]; then
 	  continue
 	fi
 

--- a/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/clusterrole.yaml
@@ -18,6 +18,9 @@ rules:
   - nodes
   - nodes/spec
   - nodes/proxy
+  {{- if and .Values.podDisruptionBudget .Values.isServerless }}
+  - poddisruptionbudgets
+  {{- end }}
   - pods
   - pods/status
   - replicationcontrollers

--- a/deployments/k8s/helm/signalfx-agent/templates/pdb.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.podDisruptionBudget }}
+{{- if and .Values.podDisruptionBudget .Values.isServerless }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/deployments/k8s/helm/signalfx-agent/templates/pdb.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "signalfx-agent.fullname" . }}
+  namespace: {{ template "signalfx-agent.namespace" . }}
+  labels:
+    app: {{ template "signalfx-agent.name" . }}
+    chart: {{ template "signalfx-agent.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "signalfx-agent.name" . }}
+      release: {{ .Release.Name }}
+{{ toYaml .Values.podDisruptionBudget | trim | indent 2 }}
+{{- end }}

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -342,3 +342,6 @@ configureStandardObservers: true
 # Added to configs regardless of the value of `configureStandardObservers`
 observers: []
 
+# optional poddisruptionbudget object
+podDisruptionBudget:
+  minAvailable: 1

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -344,4 +344,4 @@ observers: []
 
 # optional poddisruptionbudget object
 podDisruptionBudget:
-  minAvailable: 1
+  maxUnavailable: 1

--- a/deployments/k8s/serverless/clusterrole.yaml
+++ b/deployments/k8s/serverless/clusterrole.yaml
@@ -16,6 +16,7 @@ rules:
   - nodes
   - nodes/spec
   - nodes/proxy
+  - poddisruptionbudgets
   - pods
   - pods/status
   - replicationcontrollers

--- a/deployments/k8s/serverless/pdb.yaml
+++ b/deployments/k8s/serverless/pdb.yaml
@@ -1,0 +1,13 @@
+---
+# Source: signalfx-agent/templates/pdb.yaml
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: signalfx-agent
+  labels:
+    app: signalfx-agent
+spec:
+  selector:
+    matchLabels:
+      app: signalfx-agent
+  maxUnavailable: 1


### PR DESCRIPTION
We have an internal helm standard of requiring poddisruptionbudgets for all non-daemonset installs.