### PR TITLE
Make cloud provider metadata log more robust

### DIFF
--- a/pkg/core/hostid/aws.go
+++ b/pkg/core/hostid/aws.go
@@ -20,8 +20,8 @@ func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	resp, err := c.Get("http://169.254.169.254/2014-11-05/dynamic/instance-identity/document")
 	if err != nil {
 		log.WithFields(log.Fields{
-			"error": err,
-		}).Debug("Failed to get AWS instance-identity")
+			"detail": err,
+		}).Info("No AWS metadata server detected, assuming not on EC2")
 		return ""
 	}
 	defer resp.Body.Close()
@@ -30,7 +30,7 @@ func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-		}).Debug("Failed to read AWS instance-identity response")
+		}).Info("Failed to read AWS instance-identity response")
 		return ""
 	}
 
@@ -45,12 +45,12 @@ func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 		log.WithFields(log.Fields{
 			"error": err,
 			"body":  string(body),
-		}).Debug("Failed to unmarshal AWS instance-identity response")
+		}).Info("Failed to unmarshal AWS instance-identity response")
 		return ""
 	}
 
 	if doc.AccountID == "" || doc.InstanceID == "" || doc.Region == "" {
-		log.Debugf("One (or more) required field is empty. AccountID: %s ; InstanceID: %s ; Region: %s", doc.AccountID, doc.InstanceID, doc.Region)
+		log.Errorf("One (or more) required field is empty. AccountID: %s ; InstanceID: %s ; Region: %s", doc.AccountID, doc.InstanceID, doc.Region)
 		return ""
 	}
 

--- a/pkg/core/hostid/azure.go
+++ b/pkg/core/hostid/azure.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+	log "github.com/sirupsen/logrus"
 )
 
 // AzureUniqueID constructs the unique ID of the underlying Azure VM.  If
@@ -26,6 +27,9 @@ func AzureUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 	req.Header.Set("Metadata", "true")
 	resp, err := c.Do(req)
 	if err != nil {
+		log.WithFields(log.Fields{
+			"detail": err,
+		}).Infof("No Azure metadata server detected, assuming not on Azure")
 		return ""
 	}
 	defer resp.Body.Close()

--- a/pkg/core/hostid/gcp.go
+++ b/pkg/core/hostid/gcp.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 // GoogleComputeID generates a unique id for the compute instance that the
@@ -41,7 +41,9 @@ func getMetadata(path string, cloudMetadataTimeout timeutil.Duration) string {
 
 	resp, err := c.Do(req)
 	if err != nil {
-		logrus.WithError(err).Debugf("Failed to query GCP Metadata endpoint at %s", url)
+		log.WithFields(log.Fields{
+			"detail": err,
+		}).Infof("No GCP metadata server detected at %s , assuming not on GCP", url)
 		return ""
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
I set the first error to info and the rest to Error. 
If we made it through the curl, this means that we are on AWS, so the anything error later on is an accurate error

cc: @jrcamp @keitwb 
Signed-off-by: Dani Louca <dlouca@splunk.com>