### PR TITLE
enable noneIncluded flag in nagios monitor

### DIFF
--- a/docs/monitors/nagios.md
+++ b/docs/monitors/nagios.md
@@ -65,9 +65,10 @@ Configuration](../monitor-config.md#common-configuration).**
 ## Metrics
 
 These are the metrics available for this monitor.
-Metrics that are categorized as
-[container/host](https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics)
-(*default*) are ***in bold and italics*** in the list below.
+**All of the metrics emitted from this monitor are categorized as
+[custom](https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics)**
+but the ones that are emitted by default from the monitor are ***in bold and italics*** in the list below.
+
 
 
  - ***`nagios.state`*** (*gauge*)<br>    Nagios status check [state](https://nagios-plugins.org/doc/guidelines.html#AEN78).

--- a/pkg/monitors/nagios/metadata.yaml
+++ b/pkg/monitors/nagios/metadata.yaml
@@ -40,4 +40,5 @@ monitors:
       default: true
       type: gauge
   monitorType: nagios
+  noneIncluded: true
   properties:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -42577,7 +42577,7 @@
       "monitorType": "nagios",
       "sendAll": false,
       "sendUnknown": false,
-      "noneIncluded": false,
+      "noneIncluded": true,
       "dimensions": {
         "command": {
           "description": "The configured `command` for this monitor."


### PR DESCRIPTION
None of these metrics appear in our built-in content.