### PR TITLE
Use SDK to derive AWSUniqueId

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d
 	github.com/antonmedv/expr v1.8.9
+	github.com/aws/aws-sdk-go v1.38.0
 	github.com/beevik/ntp v0.3.0
 	github.com/cloudfoundry-incubator/uaago v0.0.0-20190307164349-8136b7bbe76e
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,8 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.28 h1:sscPpn/Ns3i0F4HPEWAVcwdIRaZZCuL7llJ2/60yPIk=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.38.0 h1:mqnmtdW8rGIQmp2d0WRFLua0zW0Pel0P6/vd3gJuViY=
+github.com/aws/aws-sdk-go v1.38.0/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/baiyubin/aliyun-sts-go-sdk v0.0.0-20180326062324-cfa1a18b161f/go.mod h1:AuiFmCCPBSrqvVMvuqFuk0qogytodnVFVSN5CeJB8Gc=
 github.com/beevik/ntp v0.3.0 h1:xzVrPrE4ziasFXgBVBZJDP0Wg/KpMwk2KHJ4Ba8GrDw=
@@ -1815,6 +1817,7 @@ golang.org/x/net v0.0.0-20200602114024-627f9648deb9/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/pkg/core/hostid/aws.go
+++ b/pkg/core/hostid/aws.go
@@ -1,51 +1,47 @@
 package hostid
 
 import (
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 
-	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 // AWSUniqueID constructs the unique EC2 instance of the underlying host.  If
 // not running on EC2, returns the empty string.
 func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
-	c := http.Client{
+	// Pass in the HTTP client so cloudMetadataTimeout from the config
+	// is respected.
+	c := &http.Client{
 		Timeout: cloudMetadataTimeout.AsDuration(),
 	}
 
-	resp, err := c.Get("http://169.254.169.254/2014-11-05/dynamic/instance-identity/document")
+	sess, err := session.NewSession(aws.NewConfig().WithHTTPClient(c))
 	if err != nil {
 		log.WithFields(log.Fields{
 			"detail": err,
-		}).Info("No AWS metadata server detected, assuming not on EC2")
-		return ""
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"error": err,
-		}).Info("Failed to read AWS instance-identity response")
+		}).Info("Failed to create new session for AWS metadata collection")
 		return ""
 	}
 
-	var doc struct {
-		AccountID  string `json:"accountId"`
-		InstanceID string `json:"instanceId"`
-		Region     string `json:"region"`
+	client := ec2metadata.New(sess)
+
+	// Checks whether it's an EC2 instance and Metadata service is available.
+	if !client.Available() {
+		log.Debug("No EC2 metadata server detected, assuming not on AWS EC2")
+		return ""
 	}
 
-	err = json.Unmarshal(body, &doc)
+	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err,
-			"body":  string(body),
-		}).Info("Failed to unmarshal AWS instance-identity response")
+		}).Error("Failed to get AWS instance-identity")
 		return ""
 	}
 


### PR DESCRIPTION
Use SDK to derive AWSUniqueId, this will give us support for both imdsv2 vs imdsv1 endpoints as opposed to just the latter.