### PR TITLE
Fix check-links errors

### DIFF
--- a/scripts/docs/check-links/Dockerfile
+++ b/scripts/docs/check-links/Dockerfile
@@ -1,13 +1,13 @@
-FROM node:8.16.0-alpine
+FROM ghcr.io/tcort/markdown-link-check:3.8.5
 
 RUN apk add bash
-
-RUN npm install -g markdown-link-check@3.8.5
 
 VOLUME /usr/src/signalfx-agent
 WORKDIR /usr/src/signalfx-agent
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 RUN chmod a+x /docker-entrypoint.sh
+
+ENV PATH=/src:$PATH
 
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
`markdown-link-check` is failing due to upstream dependencies installed at build time:
```
/usr/local/lib/node_modules/markdown-link-check/node_modules/marked/src/marked.js:118
    throw e;
    ^
SyntaxError: Invalid regular expression: /[\p{L}\p{N}]/: Invalid escape
```