### PR TITLE
prometheus-exporter monitor: Don't set timestamp

### DIFF
--- a/pkg/monitors/prometheusexporter/prometheus.go
+++ b/pkg/monitors/prometheusexporter/prometheus.go
@@ -142,10 +142,6 @@ func (m *Monitor) Configure(conf *Config) error {
 			return
 		}
 
-		now := time.Now()
-		for i := range dps {
-			dps[i].Timestamp = now
-		}
 		m.Output.SendDatapoints(dps...)
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 


### PR DESCRIPTION
Let it be unset so it represents the 'latest available'.