### PR TITLE
writer: Sanitize token in HTTP error logs

### DIFF
--- a/pkg/core/writer/signalfx/writer.go
+++ b/pkg/core/writer/signalfx/writer.go
@@ -275,7 +275,7 @@ func (sw *Writer) sendDatapoints(ctx context.Context, dps []*datapoint.Datapoint
 	err := sw.client.AddDatapoints(ctx, dps)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"error": err,
+			"error": utils.SanitizeHTTPError(err),
 		}).Error("Error shipping datapoints to SignalFx")
 		// If there is an error sending datapoints then just forget about them.
 		return err
@@ -340,7 +340,7 @@ func (sw *Writer) listenForEventsAndDimensionUpdates() {
 				go func(buf []*event.Event) {
 					if err := sw.sendEvents(buf); err != nil {
 
-						log.WithError(err).Error("Error shipping events to SignalFx")
+						log.WithError(utils.SanitizeHTTPError(err)).Error("Error shipping events to SignalFx")
 					}
 				}(sw.eventBuffer)
 				initEventBuffer()
@@ -350,7 +350,7 @@ func (sw *Writer) listenForEventsAndDimensionUpdates() {
 				log.WithFields(log.Fields{
 					"dimName":  dim.Name,
 					"dimValue": dim.Value,
-				}).WithError(err).Warn("Dropping dimension update")
+				}).WithError(utils.SanitizeHTTPError(err)).Warn("Dropping dimension update")
 			}
 		}
 	}

--- a/pkg/core/writer/splunk/splunk.go
+++ b/pkg/core/writer/splunk/splunk.go
@@ -22,6 +22,7 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/writer/processor"
+	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -91,7 +92,7 @@ func New(conf *config.WriterConfig, dpChan chan []*datapoint.Datapoint, eventCha
 		SendFunc: func(ctx context.Context, entries []logEntry) error {
 			err := out.sendToSplunk(ctx, entries)
 			if err != nil {
-				logrus.WithError(err).Error("Failed to send to Splunk HEC")
+				logrus.WithError(utils.SanitizeHTTPError(err)).Error("Failed to send to Splunk HEC")
 			}
 			return err
 		},

--- a/pkg/utils/http.go
+++ b/pkg/utils/http.go
@@ -1,0 +1,13 @@
+package utils
+
+import (
+	"errors"
+	"regexp"
+)
+
+var accessTokenSanitizer = regexp.MustCompile(`(?i)x-sf-token:\[[^\s]+\]`)
+
+// SanitizeHTTPError will remove any sensitive data from HTTP client errors.
+func SanitizeHTTPError(err error) error {
+	return errors.New(accessTokenSanitizer.ReplaceAllString(err.Error(), ""))
+}


### PR DESCRIPTION
A recent Go version started adding headers to HTTP client error
messages.

This just uses a regexp helper func to get rid of the one for the token.