### PR TITLE
Release v5.10.0

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/rhel7-atomic
 
-ARG AGENT_VERSION="5.9.2"
+ARG AGENT_VERSION="5.10.0"
 LABEL name="SignalFx Smart Agent" \
 	  maintainer="SignalFx, Inc." \
 	  vendor="SignalFx, Inc." \

--- a/deployments/cloudfoundry/buildpack/bin/supply
+++ b/deployments/cloudfoundry/buildpack/bin/supply
@@ -11,7 +11,7 @@ BUILDPACK_DIR=`dirname $(readlink -f ${BASH_SOURCE%/*})`
 TARGET_DIR="$BUILD_DIR/.signalfx"
 
 # Set a default version of the SignalFx Agent to use if none is specified
-SIGNALFX_AGENT_VERSION="${SIGNALFX_AGENT_VERSION-5.9.2}"
+SIGNALFX_AGENT_VERSION="${SIGNALFX_AGENT_VERSION-5.10.0}"
 
 echo "-----> Installing signalfx-agent ${SIGNALFX_AGENT_VERSION}"
 echo "       BUILD_DIR: $BUILD_DIR"

--- a/deployments/ecs/signalfx-agent-task.json
+++ b/deployments/ecs/signalfx-agent-task.json
@@ -33,7 +33,7 @@
                 },
                 {
                     "name": "CONFIG_URL",
-                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.9.2/deployments/ecs/agent.yaml"
+                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.10.0/deployments/ecs/agent.yaml"
                 }
             ],
             "ulimits": null,
@@ -60,7 +60,7 @@
             "memory": null,
             "memoryReservation": null,
             "volumesFrom": [],
-            "image": "quay.io/signalfx/signalfx-agent:5.9.2",
+            "image": "quay.io/signalfx/signalfx-agent:5.10.0",
             "disableNetworking": null,
             "healthCheck": null,
             "essential": true,

--- a/deployments/fargate/example-fargate-task.json
+++ b/deployments/fargate/example-fargate-task.json
@@ -34,14 +34,14 @@
                 },
                 {
                     "name": "CONFIG_URL",
-                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.9.2/deployments/fargate/agent.yaml"
+                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.10.0/deployments/fargate/agent.yaml"
                 }
             ],
             "dockerLabels": {
                 "app": "signalfx-agent"
             },
             "name": "signalfx-agent",
-            "image": "quay.io/signalfx/signalfx-agent:5.9.2"
+            "image": "quay.io/signalfx/signalfx-agent:5.10.0"
         }
     ],
     "cpu": "128",

--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.9.2
+    version: 5.10.0
 spec:
   selector:
     matchLabels:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.9.2
+        version: 5.10.0
 
       annotations:
         {}
@@ -45,7 +45,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.9.2"
+        image: "quay.io/signalfx/signalfx-agent:5.10.0"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent

--- a/deployments/k8s/helm/signalfx-agent/Chart.yaml
+++ b/deployments/k8s/helm/signalfx-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The SignalFx Smart Agent
 name: signalfx-agent
-appVersion: 5.9.2
+appVersion: 5.10.0
 version: 1.9.2
 keywords:
 - monitoring

--- a/deployments/k8s/helm/signalfx-agent/README.md
+++ b/deployments/k8s/helm/signalfx-agent/README.md
@@ -88,7 +88,7 @@ gatherClusterMetrics: false
 # If your kube install is using CRI-O instead of docker, set the below to false.
 gatherDockerMetrics: true
 
-agentVersion: 5.9.2
+agentVersion: 5.10.0
 
 # Kubelet on Windows doesn't seem to have the usage_bytes metrics so we'll
 # transform the working set metric to it so that built-in content works.
@@ -107,7 +107,7 @@ kubeletAPI:
 image:
   repository: quay.io/signalfx/signalfx-agent
   # This is a special windows container release of the agent for Windows.
-  tag: 5.9.2-windows
+  tag: 5.10.0-windows
   pullPolicy: Always
 ```
 

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -1,6 +1,6 @@
 # Version of the signalfx-agent to deploy.  This will be the default for the
 # docker image tag if not overridden with imageTag
-agentVersion: 5.9.2
+agentVersion: 5.10.0
 
 # If false, datapoints, events, and spans will not be emitted to the SignalFx
 # backend.

--- a/deployments/k8s/serverless/deployment.yaml
+++ b/deployments/k8s/serverless/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.9.2
+    version: 5.10.0
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.9.2
+        version: 5.10.0
 
       annotations:
         {}
@@ -36,7 +36,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.9.2"
+        image: "quay.io/signalfx/signalfx-agent:5.10.0"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent

--- a/deployments/splunk/docker-compose.yml
+++ b/deployments/splunk/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - /opt/splunk/var
       - /opt/splunk/etc
   signalfx-agent:
-    image: quay.io/signalfx/signalfx-agent:5.9.2
+    image: quay.io/signalfx/signalfx-agent:5.10.0
     container_name: signalfx-agent
     restart: always
     depends_on:

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 # yapf: disable
 setup(
     name="sfxpython",
-    version="0.3.1",
+    version="0.3.2",
     author="SignalFx, Inc",
     description="Python packages used by the Python extension mechanism of the SignalFx Smart Agent",
     url="https://github.com/signalfx/signalfx-agent",


### PR DESCRIPTION
Deprecation Notice:
* SA deprecation notice for April 15 GA (#1720)
* Pull deprecation notice to integrations repo (#1721)

Changes:
* prometheus-exporter monitor: Don't set timestamp (#1703)
* Update ingest-protocols lib (#1704)
* sfxcollectd: Fix single item handling with #flatten (#1705)
* Allow non defined in collectd/jenkins metrics (#1706)
* writer: Sanitize token in HTTP error logs (#1710)
* excludeJobMetrics parameter available on collectd-jenkins v2.4.0 (#1712)
* Update scripts, docs, and CI for main (#1724)
* Add an option to control remote config watch (#1730)
* Security updates for third-party dependencies

Breaking Changes:

* Use static 404 for unsupported signalfx-forwarder paths instead of 200 (#1731)