### PR TITLE
Update agent download/extract on windows

### DIFF
--- a/deployments/chef/metadata.rb
+++ b/deployments/chef/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Splunk, Inc.'
 maintainer_email 'signalfx-support@splunk.com'
 license 'Apache-2.0'
 description 'Installs/Configures the SignalFx Agent'
-version '1.1.0'
+version '1.2.0'
 chef_version '>= 12.1' if respond_to?(:chef_version)
 
 supports 'amazon'

--- a/deployments/chef/recipes/win.rb
+++ b/deployments/chef/recipes/win.rb
@@ -1,14 +1,34 @@
-windows_service node['signalfx_agent']['service_name'] do
-  action :stop
-  only_if { ::File.exist?(node['signalfx_agent']['version_file']) && (::File.readlines(node['signalfx_agent']['version_file']).first.strip != node['signalfx_agent']['package_version']) }
-end
+if !::File.exist?(node['signalfx_agent']['version_file']) || (::File.readlines(node['signalfx_agent']['version_file']).first.strip != node['signalfx_agent']['package_version'])
+  windows_service node['signalfx_agent']['service_name'] do
+    action :stop
+  end
 
-windows_zipfile node['signalfx_agent']['install_dir'] do
-  source node['signalfx_agent']['package_url']
-  action :unzip
-  overwrite true
-  only_if { !::File.exist?(node['signalfx_agent']['version_file']) || (::File.readlines(node['signalfx_agent']['version_file']).first.strip != node['signalfx_agent']['package_version']) }
-  notifies :restart, 'service[signalfx-agent]', :delayed
+  if Gem::Requirement.new(">= 15.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
+    tmpdir = Dir.mktmpdir
+    zipname = File.basename(node['signalfx_agent']['package_url'])
+    zippath = "#{tmpdir}\\#{zipname}"
+    remote_file zippath do
+      source node['signalfx_agent']['package_url']
+      action :create
+    end
+    archive_file zippath do
+      destination node['signalfx_agent']['install_dir']
+      action :extract
+      overwrite true
+      notifies :restart, 'service[signalfx-agent]', :delayed
+    end
+    directory tmpdir do
+      action :delete
+      recursive true
+    end
+  else
+    windows_zipfile node['signalfx_agent']['install_dir'] do
+      source node['signalfx_agent']['package_url']
+      action :unzip
+      overwrite true
+      notifies :restart, 'service[signalfx-agent]', :delayed
+    end
+  end
 end
 
 # Make a file that has the current installed version so that we can easily


### PR DESCRIPTION
The windows cookbook (`windows_zipfile`) is deprecated and does not support the latest chef versions >= 17.0.  Use the built-in `remote_file` and `archive_file` resources available with chef >= 15.0.