### PR TITLE
removed language 'The Smart Agent doesn't support Fargate.'

### DIFF
--- a/docs/agent-install-awsecs.md
+++ b/docs/agent-install-awsecs.md
@@ -62,7 +62,7 @@ After you finish editing the configuration files, continue with these steps:
 
 1. Start the web console and navigate to the **Task Definitions** tab.
 2. Click **Create new Task Definition**.
-3. Click **EC2**, then click **Next step**. The Smart Agent doesn't support Fargate.
+3. Click **EC2**, then click **Next step**.
 4. Click **Configure via JSON**.
 5. Open the signalfx-agent-task.json file, copy the contents, paste the contents into the text box, and click **Save**.
 6. Click **Update** and then **Create**.


### PR DESCRIPTION
Removed language 'The Smart Agent doesn't support Fargate.' as it no longer applies.

The ticket (https://signalfuse.atlassian.net/browse/DOCS-2128?atlOrigin=eyJpIjoiZDNjNDlmODgzMGUxNDRjOWIyZWNhNzcwNWM2ZDU2ZTAiLCJwIjoiaiJ9) references docs that we do not usually make changes to. Instead I removed the language from the "Install to AWS ECS" doc (https://docs.signalfx.com/en/latest/integrations/agent/agent-install-awsecs.html). 

Therefore, this language still exists in other areas of the repo