### PR TITLE
Fix collectd/jenkins tests

### DIFF
--- a/tests/monitors/jenkins/jenkins_test.py
+++ b/tests/monitors/jenkins/jenkins_test.py
@@ -18,7 +18,7 @@ JENKINS_VERSIONS = [
     ("jenkins", "1.651.3-alpine"),
     # TODO: jenkins doesn't have a latest tag so we'll need to update this
     # periodically
-    ("jenkins/jenkins", "2.222.4-alpine"),
+    ("jenkins/jenkins", "lts-alpine"),
 ]
 
 METADATA = Metadata.from_package("collectd/jenkins")
@@ -35,7 +35,7 @@ ENHANCED_METRICS = {
         "gauge.jenkins.node.vm.memory.non-heap.used",
         "gauge.jenkins.node.vm.memory.total.used",
     },
-    ("jenkins/jenkins", "2.222.4-alpine"): METADATA.all_metrics
+    ("jenkins/jenkins", "lts-alpine"): METADATA.all_metrics
     - {"gauge.jenkins.job.duration", "gauge.jenkins.node.slave.online.status"},
 }
 


### PR DESCRIPTION
Jenkins plugins are failing to install in `2.222.4-alpine`.