### PR TITLE
Improve cloudfoundry-firehose-nozzle dev docs

### DIFF
--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -100,5 +100,3 @@ writer:
 ```
 
 More: [docs/monitors/cloudfoundry-firehose-nozzle.md](../../../docs/monitors/cloudfoundry-firehose-nozzle.md)
-
-

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -25,47 +25,31 @@ Required tools:
 - https://github.com/cloudfoundry/cf-uaac
 - https://github.com/pivotal-cf/om
 
-1. Download the hammer config from https://self-service.isv.ci and name it like your env so that you can have a variable:
+1. Download the hammer config from https://self-service.isv.ci and name it like your environement and export a variable
 
     ```sh
     export TAS_ENV=<TAS environement name>
     ```
 
-2. Login in CF CLI
+2. Create a new space and configure it as a default target space
 
     ```sh
     hammer -t $TAS_ENV.json cf-login
-    ```
-
-3. Create a new space and configure it as a default target space
-
-    ```sh
     cf create-space test-space && cf target -s test-space
     ```
 
-4. Deploy a sample application:
+3. Deploy a sample application:
 
     ```sh
-    git clone https://github.com/cloudfoundry-samples/test-app && cd test-app && cf push && cd .. && rm -rf test-app
+    hammer -t $TAS_ENV.json cf-login
+    git clone https://github.com/cloudfoundry-samples/test-app && cd test-app && cf push && cd .. && rm -rf test-app && cf apps
     ```
 
-5. Test if the sample application is working:
-
-    ```sh
-    cf apps
-    ```
-
-6. Get the UAA credentials:
+4. Create a UAA user with the proper permissions to access the RLP Gateway:
 
     ```sh
     eval "$(hammer -t $TAS_ENV.json om)"
     export UAA_CREDS=$(om credentials -p cf -c .uaa.identity_client_credentials -t json | jq '.password' -r)
-    ```
-   
-
-6. Create a UAA user with the proper permissions to access the RLP Gateway:
-
-    ```sh
     uaac target https://uaa.sys.$TAS_ENV.cf-app.com
     uaac token client get identity -s $UAA_CREDS
     export NOZZLE_SECRET=$(openssl rand -base64 12)

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -2,57 +2,58 @@
 
 ## Developer Resources
 
-- https://github.com/cf-platform-eng/firehose-nozzle-v2/tree/master/gateway
-- https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md
-- https://github.com/cloudfoundry/go-loggregator/blob/master/rlp_gateway_client.go
+- <https://github.com/cf-platform-eng/firehose-nozzle-v2/tree/master/gateway>
+- <https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md>
+- <https://github.com/cloudfoundry/go-loggregator/blob/master/rlp_gateway_client.go>
 
 ## Tanzu Application Service Setup
 
 ### Create a new TAS environment
 
 1. Get access to [Pivotal Partners Slack](https://pivotalpartners.slack.com/archives/C42PWTRR9)
-1. Create a new TAS environment via: https://self-service.isv.ci/
-
+1. Create a new TAS environment via: <https://self-service.isv.ci/>
 
 ### Configure TAS for monitoring
 
-Required tools:
+Required CLI tools:
 
-- https://github.com/pivotal/hammer
-- https://github.com/cloudfoundry/bosh-cli
-- https://github.com/cloudfoundry/cli (most probably v6)
-- https://github.com/cloudfoundry-community/firehose-plugin
-- https://github.com/cloudfoundry/cf-uaac
-- https://github.com/pivotal-cf/om
+- [`hammer`](https://github.com/pivotal/hammer)
+- [`bosh`](https://github.com/cloudfoundry/bosh-cli)
+- [`cf`](https://github.com/cloudfoundry/cli) (most probably v6)
+  - [nozzle-plugin](https://github.com/cloudfoundry-community/firehose-plugin)
+- [`uaac`](https://github.com/cloudfoundry/cf-uaac)
+- [`om`](https://github.com/pivotal-cf/om)
+- [`jq`](https://stedolan.github.io/jq/)
 
-1. Download the hammer config from https://self-service.isv.ci and name it like your environement and export a variable
+1. Download the hammer config from <https://self-service.isv.ci> and name it like your environement and export a variable
 
     ```sh
-    export TAS_ENV=<TAS environement name>
+    export TAS_JSON=<path to the downloaded JSON>
     ```
 
 2. Create a new space and configure it as a default target space
 
     ```sh
-    hammer -t $TAS_ENV.json cf-login
+    hammer -t $TAS_JSON cf-login
     cf create-space test-space && cf target -s test-space
     ```
 
 3. Deploy a sample application:
 
     ```sh
-    hammer -t $TAS_ENV.json cf-login
+    hammer -t $TAS_JSON cf-login
     git clone https://github.com/cloudfoundry-samples/test-app && cd test-app && cf push && cd .. && rm -rf test-app && cf apps
     ```
 
 4. Create a UAA user with the proper permissions to access the RLP Gateway:
 
     ```sh
-    eval "$(hammer -t $TAS_ENV.json om)"
-    export UAA_CREDS=$(om credentials -p cf -c .uaa.identity_client_credentials -t json | jq '.password' -r)
-    uaac target https://uaa.sys.$TAS_ENV.cf-app.com
+    eval "$(hammer -t $TAS_JSON om)"
+    UAA_CREDS=$(om credentials -p cf -c .uaa.identity_client_credentials -t json | jq '.password' -r)
+    TAS_SYS_DOMAIN=$(jq '.sys_domain' -r $TAS_JSON)
+    uaac target https://uaa.$TAS_SYS_DOMAIN
     uaac token client get identity -s $UAA_CREDS
-    export NOZZLE_SECRET=$(openssl rand -base64 12)
+    NOZZLE_SECRET=$(openssl rand -hex 12)
     uaac client add my-v2-nozzle --name signalfx-nozzle --secret $NOZZLE_SECRET --authorized_grant_types client_credentials,refresh_token --authorities logs.admin
     echo "signalfx-nozzle client secret: $NOZZLE_SECRET"
     ```

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -1,5 +1,106 @@
+# cloudfoundry-firehose-nozzle
+
 ## Developer Resources
 
 - https://github.com/cf-platform-eng/firehose-nozzle-v2/tree/master/gateway
 - https://github.com/cloudfoundry/loggregator/blob/master/docs/rlp_gateway.md
 - https://github.com/cloudfoundry/go-loggregator/blob/master/rlp_gateway_client.go
+
+## Tanzu Application Service Setup
+
+### Creating new TAS environment
+
+1. Get access to [Pivotal Partners Slack](https://pivotalpartners.slack.com/archives/C42PWTRR9)
+1. Create a new TAS environment via: https://self-service.isv.ci/
+
+
+### Configuring TAS for monitoring
+
+#### Tools
+
+- https://github.com/pivotal/hammer
+- https://github.com/cloudfoundry/bosh-cli
+- https://github.com/cloudfoundry/cli (most probably v6)
+- https://github.com/cloudfoundry-community/firehose-plugin
+- https://github.com/cloudfoundry/cf-uaac
+
+### Connecting
+
+> :warning: The example assumes that the environement is named `wildblueyonder`.
+
+1. Download the hammer config from https://self-service.isv.ci/
+
+2. Login in CF CLI
+
+    ```sh
+    hammer -t wildblueyonder.json cf-login
+    ```
+
+3. Create a new space and configure it as a default target space
+
+    ```sh
+    cf create-space test-space && cf target -s test-space
+    ```
+
+4. Deploy a sample application:
+
+    ```sh
+    git clone https://github.com/cloudfoundry-samples/test-app && cd test-app && cf push && cd .. && rm -rf test-app
+    ```
+
+5. Test if the sample application is working:
+
+    ```sh
+    cf apps
+    ```
+
+6. Get the UAA credentials:
+    
+    1. Login to the `Tanzu Ops Manager` UI (URL and credentials in from https://self-service.isv.ci/)
+    2. Navigate: `Small Footprint Pivotal Application Service` > `Credentials` > `UAA` > `Identity Client Credentials`
+    3. Export the credentials:
+        
+        ```sh
+        export UAA_CREDS=<creds>
+        ```
+
+6. Login in UAA CLI:
+
+    ```sh
+    uaac target https://uaa.sys.wildblueyonder.cf-app.com
+    uaac token client get identity -s $UAA_CREDS
+    ```
+
+7. Create a UAA user with the proper permissions to access the RLP Gateway (replace `<signalfx-nozzle client secret>` with something else):
+
+    ```sh
+    export NOZZLE_SECRET=<signalfx-nozzle client secret>
+    uaac client add my-v2-nozzle --name signalfx-nozzle --secret $NOZZLE_SECRET --authorized_grant_types client_credentials,refresh_token --authorities logs.admin
+    ```
+
+### Configure SignalFx Smart Agent monitor
+
+Example config:
+
+```yaml
+---
+signalFxAccessToken: <signafx token>
+intervalSeconds: 10
+logging:
+  level: debug
+monitors:
+  - type: cloudfoundry-firehose-nozzle
+    rlpGatewayUrl: https://log-stream.sys.wildblueyonder.cf-app.com
+    rlpGatewaySkipVerify: true
+    uaaUser: my-v2-nozzle
+    uaaPassword: <signalfx-nozzle client secret>
+    uaaUrl: https://uaa.sys.wildblueyonder.cf-app.com
+    uaaSkipVerify: true
+# Required: What format to send data in
+writer:
+  traceExportFormat: sapm
+```
+
+More: [docs/monitors/cloudfoundry-firehose-nozzle.md](../../../docs/monitors/cloudfoundry-firehose-nozzle.md)
+
+

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -82,7 +82,7 @@ Example config:
 
 ```yaml
 ---
-signalFxAccessToken: <signafx token>
+signalFxAccessToken: <signalfx token>
 intervalSeconds: 10
 logging:
   level: debug

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -57,7 +57,6 @@ Required tools:
     echo "signalfx-nozzle client secret: $NOZZLE_SECRET"
     ```
 
-
 ### Configure SignalFx Smart Agent monitor
 
 Example config:

--- a/pkg/monitors/cloudfoundry/README.md
+++ b/pkg/monitors/cloudfoundry/README.md
@@ -8,15 +8,15 @@
 
 ## Tanzu Application Service Setup
 
-### Creating new TAS environment
+### Create a new TAS environment
 
 1. Get access to [Pivotal Partners Slack](https://pivotalpartners.slack.com/archives/C42PWTRR9)
 1. Create a new TAS environment via: https://self-service.isv.ci/
 
 
-### Configuring TAS for monitoring
+### Configure TAS for monitoring
 
-#### Tools
+Required tools:
 
 - https://github.com/pivotal/hammer
 - https://github.com/cloudfoundry/bosh-cli
@@ -24,11 +24,9 @@
 - https://github.com/cloudfoundry-community/firehose-plugin
 - https://github.com/cloudfoundry/cf-uaac
 
-### Connecting
-
 > :warning: The example assumes that the environement is named `wildblueyonder`.
 
-1. Download the hammer config from https://self-service.isv.ci/
+1. Download the hammer config from https://self-service.isv.ci
 
 2. Login in CF CLI
 
@@ -56,7 +54,7 @@
 
 6. Get the UAA credentials:
     
-    1. Login to the `Tanzu Ops Manager` UI (URL and credentials in from https://self-service.isv.ci/)
+    1. Login to the `Tanzu Ops Manager` UI (URL and credentials in from https://self-service.isv.ci)
     2. Navigate: `Small Footprint Pivotal Application Service` > `Credentials` > `UAA` > `Identity Client Credentials`
     3. Export the credentials:
         


### PR DESCRIPTION
## Why

Setting up env for testing Cloud Foundry monitoring is not strightforward.

## What

Provide instructions on how to set up an environment for testing the `cloudfoundry-firehose-nozzle` monitor.