### PR TITLE
Fix make-latest-tile script name in a comment

### DIFF
--- a/deployments/cloudfoundry/bosh/release
+++ b/deployments/cloudfoundry/bosh/release
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# This script is meant to be run when releasing the agent bosh release.  It
+# This script is meant to be run when releasing the agent bosh release. It
 # does not use the formal "final" BOSH release process as the Ops Manager tiles
 # don't really require them and we are dumping everything to a tarball anyway.
 # This script is mostly intended to be invoked by the tile
-# `make-latest-version` script and not run standalone, although that is
-# entirely possible.
+# `make-latest-tile` script and not run standalone, although that is entirely
+# possible.
 
 set -euo pipefail
 set -x


### PR DESCRIPTION
The script name in the comment is not correct (I guess that outdated).

See: https://github.com/signalfx/signalfx-agent/blob/main/deployments/cloudfoundry/tile/make-latest-tile