### PR TITLE
Expose globalDimensions in Cloud Foundry tile

### DIFF
--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/spec
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/spec
@@ -7,6 +7,7 @@ templates:
   logrotate.conf.erb: config/logrotate.conf
   logrotate.cron.erb: config/logrotate.cron
   envvars.erb: config/envvars
+  global-dimensions.yaml.erb: config/global-dimensions.yaml
   nozzle-filtering.yaml.erb: config/nozzle-filtering.yaml
   extra-nozzle-metrics.yaml.erb: config/extra-nozzle-metrics.yaml
   token.erb: config/token

--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/spec
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/spec
@@ -22,6 +22,9 @@ properties:
   signalfx.agent_config_yaml:
     description: "A full agent.yaml config file for the Smart Agent to use.  If not provided, the options below will be used to construct an agent config file."
 
+  signalfx.global_dimensions:
+    description: A YAML that will be inserted at the end of the agent.yaml's `globalDimensions` map.
+
   signalfx.extra_monitors:
     description: |
       YAML that will be inserted at the end of the agent.yaml's `monitors`

--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
@@ -14,7 +14,7 @@ globalDimensions:
   bosh_id: {"#from": "/var/vcap/instance/id", optional: true}
   deployment: {"#from": "/var/vcap/instance/deployment", optional: true}
 <% end %>
-  {"#from": "/var/vcap/jobs/signalfx-agent/config/global-dimensions.yaml", optional: true}
+  _: {"#from": "/var/vcap/jobs/signalfx-agent/config/global-dimensions.yaml", optional: true, flatten: true}
 
 <% if_p("signalfx.interval_seconds") do |interval_seconds| %>
 intervalSeconds: <%= interval_seconds %>

--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
@@ -14,7 +14,7 @@ globalDimensions:
   bosh_id: {"#from": "/var/vcap/instance/id", optional: true}
   deployment: {"#from": "/var/vcap/instance/deployment", optional: true}
 <% end %>
-  _: {"#from": "/var/vcap/jobs/signalfx-agent/config/global-dimensions.yaml", optional: true, flatten: true}
+  {"#from": "/var/vcap/jobs/signalfx-agent/config/global-dimensions.yaml", optional: true}
 
 <% if_p("signalfx.interval_seconds") do |interval_seconds| %>
 intervalSeconds: <%= interval_seconds %>

--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/agent.yaml.erb
@@ -9,11 +9,12 @@ ingestUrl: {"#from": "/var/vcap/jobs/signalfx-agent/config/ingest_url"}
 apiUrl: {"#from": "/var/vcap/jobs/signalfx-agent/config/api_url"}
 cluster: <%= p("signalfx.cluster", "") %>
 
-<% if not p("nozzle.enabled") %>
 globalDimensions:
+<% if not p("nozzle.enabled") %>
   bosh_id: {"#from": "/var/vcap/instance/id", optional: true}
   deployment: {"#from": "/var/vcap/instance/deployment", optional: true}
 <% end %>
+  _: {"#from": "/var/vcap/jobs/signalfx-agent/config/global-dimensions.yaml", optional: true, flatten: true}
 
 <% if_p("signalfx.interval_seconds") do |interval_seconds| %>
 intervalSeconds: <%= interval_seconds %>

--- a/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/global-dimensions.yaml.erb
+++ b/deployments/cloudfoundry/bosh/jobs/signalfx-agent/templates/global-dimensions.yaml.erb
@@ -1,0 +1,1 @@
+<%= p("signalfx.global_dimensions", "") %>

--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -82,14 +82,14 @@ forms:
     type: text
     label: Datapoint To Exclude
     description: |
-      YAML list that will be put in the datapointsToExclude config option for the firehose nozzle agent monitor (see Additional Monitor Level Filtering at https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md#additional-monitor-level-filtering).
+      A YAML list that will be put in the `datapointsToExclude` config option for the firehose nozzle agent monitor (see Additional Monitor Level Filtering at https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md#additional-monitor-level-filtering).
     optional: true
 
-  - name: extra_config
+  - name: global_dimensions
     type: text
-    label: Extra Configuration
+    label: Global Dimensions
     description: |
-      A YAML appended at the end of the Smart Agent configuration file. It is suggested to only use the options with `extra` prefix. See more at https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md.
+      A YAML map that will go into the `globalDimensions` config option. See `globalDimensions` at https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md#config-schema.
     optional: true
 
   - name: http_proxy
@@ -212,7 +212,7 @@ packages:
         realm: (( .properties.signalfx_realm.value ))
         ingest_url: (( .properties.ingest_url.value ))
         max_datapoints_buffered: (( .properties.max_buffered.value ))
-        extra_config: (( .properties.extra_config.value ))
+        global_dimensions: (( .properties.global_dimensions.value ))
 
 # TODO: including this majorly bogs down the Ops Manager "apply changes"
 # operation and breaks it badly.

--- a/deployments/cloudfoundry/tile/tile.yml
+++ b/deployments/cloudfoundry/tile/tile.yml
@@ -85,6 +85,13 @@ forms:
       YAML list that will be put in the datapointsToExclude config option for the firehose nozzle agent monitor (see Additional Monitor Level Filtering at https://github.com/signalfx/signalfx-agent/blob/main/docs/filtering.md#additional-monitor-level-filtering).
     optional: true
 
+  - name: extra_config
+    type: text
+    label: Extra Configuration
+    description: |
+      A YAML appended at the end of the Smart Agent configuration file. It is suggested to only use the options with `extra` prefix. See more at https://github.com/signalfx/signalfx-agent/blob/main/docs/config-schema.md.
+    optional: true
+
   - name: http_proxy
     type: string
     label: HTTP Proxy URL
@@ -205,6 +212,7 @@ packages:
         realm: (( .properties.signalfx_realm.value ))
         ingest_url: (( .properties.ingest_url.value ))
         max_datapoints_buffered: (( .properties.max_buffered.value ))
+        extra_config: (( .properties.extra_config.value ))
 
 # TODO: including this majorly bogs down the Ops Manager "apply changes"
 # operation and breaks it badly.


### PR DESCRIPTION
## Why

Add possibility to add `globalDimensions` e.g. to identify a Cloud Foundry foundation.

## What

Add `global_dimensions` option to the Cloud Foundry's Ops Manager tile which appends its value to `globalDimensions` Smart Agent config option.

## Testing

The new input in the tile config:

![image](https://user-images.githubusercontent.com/5067549/124260935-874fd000-db30-11eb-8064-35a5605676df.png)

Metrics with additional dimensions:

https://app.signalfx.com/#/chart/v2/new?template=default&filters=sf_metric:rep.memory

![image](https://user-images.githubusercontent.com/5067549/124261119-b7976e80-db30-11eb-9b0a-89cf80ce60d2.png)
