### PR TITLE
cleanup function name when logging

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 # yapf: disable
 setup(
     name="sfxpython",
-    version="0.3.2",
+    version="0.3.3",
     author="SignalFx, Inc",
     description="Python packages used by the Python extension mechanism of the SignalFx Smart Agent",
     url="https://github.com/signalfx/signalfx-agent",

--- a/python/sfxrunner/scheduler/simple.py
+++ b/python/sfxrunner/scheduler/simple.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import types
 from functools import partial as p
 from threading import Event, Thread
 
@@ -45,7 +46,13 @@ class SimpleScheduler(object):
             if self.shutdown_event.is_set():
                 return
 
-            logger.debug("Running func %s", func)
+            func_name = "<unknown>"
+            if isinstance(func, types.FunctionType):
+                func_name = f"{func.__module__}.{func.__name__}"
+            elif isinstance(func, p):
+                func_name = f"{func.func.__module__}.{func.func.__name__}"
+
+            logger.debug("Running func %s", func_name)
             try:
                 func()
             except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
The provided function may be a partial which has other context provided with it
which we don't want to log. So instead just log the plain function name.