### PR TITLE
daemonize fixture threads and bump ci resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,7 @@ jobs:
       - run_pytest:
           with_sudo: true
           split: true
+          pytest_options: --reruns 2
 
   k8s_integration_tests:
     executor: machine_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ executors:
   machine_image:
     machine:
       image: ubuntu-1604:202007-01
+      resource_class: large
 
   goexecutor:
     working_directory: /code
@@ -22,6 +23,7 @@ executors:
   docker1903:
     docker:
       - image: docker:19.03
+    resource_class: large
 
   helm:
     docker:

--- a/test-services/postgres/Dockerfile
+++ b/test-services/postgres/Dockerfile
@@ -5,7 +5,7 @@ CMD ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
 
 RUN apk add --no-cache unzip wget bash
 WORKDIR /opt
-RUN wget --no-check-certificate https://sp.postgresqltutorial.com/wp-content/uploads/2019/05/dvdrental.zip &&\
+RUN wget --no-check-certificate https://www.postgresqltutorial.com/wp-content/uploads/2019/05/dvdrental.zip &&\
     unzip dvdrental.zip &&\
 	tar -xf dvdrental.tar &&\
 	sed -i -e 's/\$\$PATH\$\$/\/opt/' ./restore.sql &&\

--- a/tests/helpers/fake_backend.py
+++ b/tests/helpers/fake_backend.py
@@ -280,7 +280,7 @@ def start(
         ingest_loop.create_task(ingest_server)
 
     ingest_loop.create_task(start_ingest_server())
-    threading.Thread(target=ingest_loop.run_forever).start()
+    threading.Thread(target=ingest_loop.run_forever, daemon=True).start()
 
     api_loop = asyncio.new_event_loop()
 
@@ -290,7 +290,7 @@ def start(
         api_loop.create_task(api_server)
 
     api_loop.create_task(start_api_server())
-    threading.Thread(target=api_loop.run_forever).start()
+    threading.Thread(target=api_loop.run_forever, daemon=True).start()
 
     splunk_hec_loop = asyncio.new_event_loop()
 
@@ -306,7 +306,7 @@ def start(
             splunk_hec_loop.create_task(splunk_hec_server)
 
         splunk_hec_loop.create_task(start_splunk_hec_server())
-        threading.Thread(target=splunk_hec_loop.run_forever).start()
+        threading.Thread(target=splunk_hec_loop.run_forever, daemon=True).start()
 
     def _add_datapoints():
         """
@@ -322,7 +322,7 @@ def start(
                 for dim in dp.dimensions:
                     _datapoints_by_dim[f"{dim.key}:{dim.value}"].append(dp)
 
-    threading.Thread(target=_add_datapoints).start()
+    threading.Thread(target=_add_datapoints, daemon=True).start()
 
     class FakeBackend:  # pylint: disable=too-few-public-methods
         ingest_host = ip_addr

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -375,7 +375,7 @@ def pull_from_reader_in_background(reader):
                 byt = byt.encode("utf-8")
             output.write(byt)
 
-    threading.Thread(target=pull_output).start()
+    threading.Thread(target=pull_output, daemon=True).start()
 
     def get_output():
         return output.getvalue().decode("utf-8")
@@ -451,7 +451,7 @@ def run_simple_sanic_app(app):
         loop.create_task(server)
 
     loop.create_task(start_server())
-    threading.Thread(target=loop.run_forever).start()
+    threading.Thread(target=loop.run_forever, daemon=True).start()
 
     try:
         yield f"http://127.0.0.1:{port}"

--- a/tests/helpers/util.py
+++ b/tests/helpers/util.py
@@ -38,7 +38,8 @@ def retry_on_ebadf(func: T) -> T:
             try:
                 return func(*args, **kwargs)
             except requests.exceptions.ConnectionError as e:
-                if "bad file descriptor" in str(e).lower():
+                msg = str(e).lower()
+                if "bad file descriptor" in msg or "operation on non-socket" in msg:
                     tries += 1
                     if tries >= max_tries:
                         raise

--- a/tests/packaging/common.py
+++ b/tests/packaging/common.py
@@ -127,7 +127,7 @@ def socat_https_proxy(container, target_host, target_port, source_host, bind_add
                 print("socat died, restarting...")
                 time.sleep(0.1)
 
-    threading.Thread(target=keep_running_in_container, args=(container, socket_path)).start()
+    threading.Thread(target=keep_running_in_container, args=(container, socket_path), daemon=True).start()
 
     proc = retry_on_ebadf(
         lambda: subprocess.Popen(


### PR DESCRIPTION
Integration tests are hanging and I was unable to quickly find a solution when rolling back sanic, pytest-xdist, and pytest-rerunfailures.  Making sure that test helper threads are in daemon mode appears to resolve.

Also increasing our build and test machine resource class to large to help speed up runs and corrects stale url for postgres tests.