### PR TITLE
Correct invalid doc links and remove advertised windows python compiler requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,7 @@ additional dependencies required.  This means that the agent should work on any
 relatively modern Linux distribution (kernel version 2.6+).
 
 The agent is also available on Windows in standalone form.  It
-contains its own Python runtime, but has an external depencency on the
-[Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
-in order to operate.  The agent supports Windows Server 2012 and above.
+contains its own Python runtime.  The agent supports Windows Server 2012 and above.
 
 To get started deploying the Smart Agent directly on a host, see the
 [Smart Agent Quick Install](./docs/quick-install.md) guide.
@@ -107,10 +105,9 @@ sudo sh /tmp/signalfx-agent.sh --realm YOUR_SIGNALFX_REALM -- YOUR_SIGNALFX_API_
 ```
 
 ##### Windows
-The Agent has two dependencies on Windows which must be satisfied before running the installer script.
+The Agent has one dependency on Windows which must be satisfied before running the installer script.
 
-- [.Net Framework 3.5](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10) (Windows 8+)
-- [Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
+- [.Net Framework 3.5+](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10) (Windows 8+)
 
 The installer script is written for PowerShell v3.0 and above and will not function correctly on earlier versions.
 

--- a/deployments/chef/README.md
+++ b/deployments/chef/README.md
@@ -68,9 +68,7 @@ node['signalfx_agent']['conf'] = {
 
 ## Windows
 This cookbook should work on Windows as well.  Note that we have come across
-some issues with Python having a side-by-side manifest issue at times.  If this
-is the case, make sure you have installed the [Microsoft Visual C++ Compiler
-for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266) first.
+some issues with Python having a side-by-side manifest issue at times.
 
 ## Development
 

--- a/deployments/cloudfoundry/buildpack/README.md
+++ b/deployments/cloudfoundry/buildpack/README.md
@@ -1,6 +1,6 @@
 # SignalFx Smart Agent CloudFoundry Buildpack
 
-A [CloudFoundry buildpack](https://docs.run.pivotal.io/buildpacks/) to install
+A [CloudFoundry buildpack](https://docs.pivotal.io/application-service/2-11/buildpacks/) to install
 and run the SignalFx Smart Agent in PWS (Diego managed) apps.  This will
 probably work for generic CloudFoundry apps as well, but it is only tested and
 supported on Pivotal Platform.

--- a/docs/agent-install-config-mgmt.md
+++ b/docs/agent-install-config-mgmt.md
@@ -30,7 +30,6 @@ packages:
 
 - Windows 8 or higher
 - Windows PowerShell access
-- Microsoft Visual C++ Compiler for Python
 
 ## Install the Smart Agent using an Ansible role
 

--- a/docs/agent-install-standalone-windows.md
+++ b/docs/agent-install-standalone-windows.md
@@ -12,7 +12,6 @@ a ZIP file.
 * Windows decompression application, such as WinZip or the native Windows
   decompression feature.
 * .NET Framework 3.5 or higher
-* Visual C++ compiler for Python
 * TLS 1.0 or 1.2
 * Administrator account in which to run the Smart Agent
 

--- a/docs/smart-agent-quickstart.md
+++ b/docs/smart-agent-quickstart.md
@@ -23,11 +23,10 @@ sudo sh /tmp/signalfx-agent.sh --realm YOUR_SIGNALFX_REALM YOUR_SIGNALFX_API_TOK
 
 ##### Windows
 
-Ensure that the folowing dependencies are installed:
-- [.Net Framework 3.5](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10) (Windows 8+)
-- [Visual C++ Compiler for Python 2.7](https://www.microsoft.com/EN-US/DOWNLOAD/DETAILS.ASPX?ID=44266)
+Ensure that the following dependency is installed:
+- [.Net Framework 3.5+](https://docs.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-10) (Windows 8+)
 
-Once the dependencies have been installed, use the following powershell script
+Once the dependency has been installed, use the following powershell script
 to install the agent.  The agent will be installed as a Windows service and will
 log to the Windows Event Log.
 

--- a/docs/smartagent-deprecation-notice.md
+++ b/docs/smartagent-deprecation-notice.md
@@ -3,5 +3,5 @@
 Smart Agent is deprecated as part of the release of Splunk Observability Cloud:
 
 * Smart Agent continues to function and is still supported by Splunk.
-* Apart from the [documented exceptions](https://docs.splunk.com/Observability/get-started/migrate/migrate-to-otel.html) where integration with Splunk Observability Cloud still requires deploying Smart Agent, Smart Agent functionality is replaced by the [Splunk Distribution of OpenTelemetry Connector](https://docs.splunk.com/Observability/get-started/get-data-in/get-data-in.html).
+* Apart from the [documented exceptions](https://docs.splunk.com/Observability/gdi/migrate/migrate-to-otel.html) where integration with Splunk Observability Cloud still requires deploying Smart Agent, Smart Agent functionality is replaced by the [Splunk Distribution of OpenTelemetry Connector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html).
 * Splunk is committed to further development of OpenTelemetry, and may discontinue support for Smart Agent in the future after providing customers advance notice of such discontinuation.


### PR DESCRIPTION
These changes correct some removed and shifted links detected by the ci job: https://app.circleci.com/pipelines/github/signalfx/signalfx-agent/11445/workflows/51a6d2a4-2a3a-4eef-a193-7ab5ae15d7df/jobs/266379

The visual c++ compiler for python 2.7 has been obsoleted by Microsoft and was removed from their site and chocalatey: https://community.chocolatey.org/packages/vcpython27.  Given that we're using Python 3 now this is no longer a requirement (https://github.com/signalfx/signalfx-agent/pull/1103).