### PR TITLE
Retry datapoint submissions for temporary errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2
 	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/gateway v1.2.19-0.20191125135538-2c417b7ae0bd
-	github.com/signalfx/golib/v3 v3.3.33
+	github.com/signalfx/golib/v3 v3.3.36
 	github.com/signalfx/ingest-protocols v0.1.3
 	github.com/signalfx/signalfx-agent/pkg/apm v0.0.0-00010101000000-000000000000
 	github.com/signalfx/signalfx-go v1.6.38-0.20200518153434-ceee8d2570d5

--- a/go.sum
+++ b/go.sum
@@ -1581,8 +1581,9 @@ github.com/signalfx/golib v2.3.1+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBny
 github.com/signalfx/golib v2.4.1+incompatible h1:UZaLOB4i2Dz7/Fkal2+xY9NRtv+adghUCsXj9csN7xo=
 github.com/signalfx/golib v2.4.1+incompatible/go.mod h1:nWYefOwlUKWm/SpN/LgVSBnyH1T9NpT1ANlmgRIi1Cs=
 github.com/signalfx/golib/v3 v3.0.0/go.mod h1:p+krygP/cDlWvCBEgdkQp3H16rbP4NW7YQa81TDMRe8=
-github.com/signalfx/golib/v3 v3.3.33 h1:eRUZr8wydlnNrmpHckharCzAGOe2tM7vYUbj0fPLYmg=
 github.com/signalfx/golib/v3 v3.3.33/go.mod h1:PB7OovVijH7OGhzMewarEcIZG3eG6akWMDucIb5Jnb4=
+github.com/signalfx/golib/v3 v3.3.36 h1:3vJZm77BrQnpxTbhzdI0ZciPxgoVHxZlPEme4pNGqPc=
+github.com/signalfx/golib/v3 v3.3.36/go.mod h1:PB7OovVijH7OGhzMewarEcIZG3eG6akWMDucIb5Jnb4=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/ingest-protocols v0.1.3 h1:DQOQPCxhFVV+9lv9cPlBjRufvL59afLX3R2BuPGJQQo=
 github.com/signalfx/ingest-protocols v0.1.3/go.mod h1:DRkLEiNXgz6GDZNHvQyIZIZazic936eMjQShpyiteVc=

--- a/pkg/apm/go.mod
+++ b/pkg/apm/go.mod
@@ -3,6 +3,6 @@ module github.com/signalfx/signalfx-agent/pkg/apm
 go 1.15
 
 require (
-	github.com/signalfx/golib/v3 v3.3.33
+	github.com/signalfx/golib/v3 v3.3.36
 	github.com/stretchr/testify v1.7.0
 )

--- a/pkg/apm/go.sum
+++ b/pkg/apm/go.sum
@@ -72,8 +72,8 @@ github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2 h1:X886QgwZH5qr9HIQkk3m
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.2/go.mod h1:tCQQqyJAVF1+mxNdqOi18sS/zaSrE6EMyWwRA2QTl70=
 github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083 h1:WsShHmu12ZztYPfh9b+I+VjYD1o8iOHhB67WZCMEEE8=
 github.com/signalfx/gohistogram v0.0.0-20160107210732-1ccfd2ff5083/go.mod h1:adPDS6s7WaajdFBV9mQ7i0dKfQ8xiDnF9ZNETVPpp7c=
-github.com/signalfx/golib/v3 v3.3.33 h1:eRUZr8wydlnNrmpHckharCzAGOe2tM7vYUbj0fPLYmg=
-github.com/signalfx/golib/v3 v3.3.33/go.mod h1:PB7OovVijH7OGhzMewarEcIZG3eG6akWMDucIb5Jnb4=
+github.com/signalfx/golib/v3 v3.3.36 h1:3vJZm77BrQnpxTbhzdI0ZciPxgoVHxZlPEme4pNGqPc=
+github.com/signalfx/golib/v3 v3.3.36/go.mod h1:PB7OovVijH7OGhzMewarEcIZG3eG6akWMDucIb5Jnb4=
 github.com/signalfx/gomemcache v0.0.0-20180823214636-4f7ef64c72a9/go.mod h1:Ytb8KfCSyuwy/VILnROdgCvbQLA5ch0nkbG7lKT0BXw=
 github.com/signalfx/sapm-proto v0.4.0 h1:5lQX++6FeIjUZEIcnSgBqhOpmSjMkRBW3y/4ZiKMo5E=
 github.com/signalfx/sapm-proto v0.4.0/go.mod h1:x3gtwJ1GRejtkghB4nYpwixh2zqJrLbPU959ZNhM0Fk=

--- a/pkg/monitors/elasticsearch/query/datapoints_test.go
+++ b/pkg/monitors/elasticsearch/query/datapoints_test.go
@@ -139,7 +139,7 @@ func TestExtendedStatsAggregationsFromFiltersAggregation(t *testing.T) {
 									"max":            100.0,
 									"avg":            50.14530580444098,
 									"sum":            257446.0,
-									"sum_of_squares": 1.7184548E7,
+									"sum_of_squares": 1.7184548e7,
 									"variance":       832.6528246727477,
 									"std_deviation":  28.855724296450223,
 									"std_deviation_bounds": map[string]interface{}{
@@ -162,7 +162,7 @@ func TestExtendedStatsAggregationsFromFiltersAggregation(t *testing.T) {
 									"max":            100.0,
 									"avg":            50.03486560186989,
 									"sum":            256879.0,
-									"sum_of_squares": 1.7288541E7,
+									"sum_of_squares": 1.7288541e7,
 									"variance":       863.9724891034797,
 									"std_deviation":  29.39340893981982,
 									"std_deviation_bounds": map[string]interface{}{
@@ -232,7 +232,7 @@ func TestExtendedStatsAggregationsFromFiltersAggregation(t *testing.T) {
 		{
 			Metric:     "metric_agg_1.sum_of_squares",
 			Dimensions: dims["madrid"],
-			Value:      datapoint.NewFloatValue(1.7288541E7),
+			Value:      datapoint.NewFloatValue(1.7288541e7),
 			MetricType: datapoint.Gauge,
 		},
 		{
@@ -292,7 +292,7 @@ func TestExtendedStatsAggregationsFromFiltersAggregation(t *testing.T) {
 		{
 			Metric:     "metric_agg_1.sum_of_squares",
 			Dimensions: dims["nairobi"],
-			Value:      datapoint.NewFloatValue(1.7184548E7),
+			Value:      datapoint.NewFloatValue(1.7184548e7),
 			MetricType: datapoint.Gauge,
 		},
 		{
@@ -455,7 +455,7 @@ func TestMultipleMetricAggregationWithTermsAggregation(t *testing.T) {
 									"max":            100.0,
 									"avg":            50.14530580444098,
 									"sum":            257446.0,
-									"sum_of_squares": 1.7184548E7,
+									"sum_of_squares": 1.7184548e7,
 									"variance":       832.6528246727477,
 									"std_deviation":  28.855724296450223,
 									"std_deviation_bounds": map[string]interface{}{
@@ -559,7 +559,7 @@ func TestMultipleMetricAggregationWithTermsAggregation(t *testing.T) {
 		{
 			Metric:     "metric_agg_3.sum_of_squares",
 			Dimensions: dims["metric_agg_3"],
-			Value:      datapoint.NewFloatValue(1.7184548E7),
+			Value:      datapoint.NewFloatValue(1.7184548e7),
 			MetricType: datapoint.Gauge,
 		},
 		{

--- a/pkg/monitors/elasticsearch/query/response_test.go
+++ b/pkg/monitors/elasticsearch/query/response_test.go
@@ -601,7 +601,7 @@ func getSimpleMultiValueAggregationTestContexts() ([]*testContext, *errors.Error
 										"max":            100.0,
 										"avg":            49.27212287941311,
 										"sum":            214925.0,
-										"sum_of_squares": 1.4335299E7,
+										"sum_of_squares": 1.4335299e7,
 										"variance":       858.662996364543,
 										"std_deviation":  29.302952007682485,
 										"std_deviation_bounds": map[string]interface{}{
@@ -624,7 +624,7 @@ func getSimpleMultiValueAggregationTestContexts() ([]*testContext, *errors.Error
 										"max":            100.0,
 										"avg":            50.197615772581386,
 										"sum":            218962.0,
-										"sum_of_squares": 1.4644106E7,
+										"sum_of_squares": 1.4644106e7,
 										"variance":       837.3992790472341,
 										"std_deviation":  28.93785201163407,
 										"std_deviation_bounds": map[string]interface{}{
@@ -820,7 +820,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            50.14530580444098,
 										"sum":            257446.0,
-										"sum_of_squares": 1.7184548E7,
+										"sum_of_squares": 1.7184548e7,
 										"variance":       832.6528246727477,
 										"std_deviation":  28.855724296450223,
 										"std_deviation_bounds": map[string]interface{}{
@@ -861,7 +861,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            50.03486560186989,
 										"sum":            256879.0,
-										"sum_of_squares": 1.7288541E7,
+										"sum_of_squares": 1.7288541e7,
 										"variance":       863.9724891034797,
 										"std_deviation":  29.39340893981982,
 										"std_deviation_bounds": map[string]interface{}{
@@ -902,7 +902,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            49.577522399688355,
 										"sum":            254531.0,
-										"sum_of_squares": 1.7057901E7,
+										"sum_of_squares": 1.7057901e7,
 										"variance":       864.6055017695604,
 										"std_deviation":  29.40417490373706,
 										"std_deviation_bounds": map[string]interface{}{
@@ -943,7 +943,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            49.273081417997666,
 										"sum":            252968.0,
-										"sum_of_squares": 1.6862378E7,
+										"sum_of_squares": 1.6862378e7,
 										"variance":       856.6157265001883,
 										"std_deviation":  29.267998334361515,
 										"std_deviation_bounds": map[string]interface{}{
@@ -994,7 +994,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            50.084047707789786,
 										"sum":            268751.0,
-										"sum_of_squares": 1.7938575E7,
+										"sum_of_squares": 1.7938575e7,
 										"variance":       834.5950604703294,
 										"std_deviation":  28.889358948760517,
 										"std_deviation_bounds": map[string]interface{}{
@@ -1035,7 +1035,7 @@ func getMultipleMetricAggregationTestContexts() ([]*testContext, *errors.Error) 
 										"max":            100.0,
 										"avg":            49.27953783078643,
 										"sum":            264434.0,
-										"sum_of_squares": 1.7629144E7,
+										"sum_of_squares": 1.7629144e7,
 										"variance":       856.8689327718637,
 										"std_deviation":  29.27232366539875,
 										"std_deviation_bounds": map[string]interface{}{


### PR DESCRIPTION
EOF and similar connection errors are common but generally don't prevent successful retried submissions.  These changes determine if httpsink's `AddDatapoints()` calls fail for retryable reasons and try once more before dropping points.