### PR TITLE
Document Cloud Foundry metric dimensions

### DIFF
--- a/docs/monitors/cloudfoundry-firehose-nozzle.md
+++ b/docs/monitors/cloudfoundry-firehose-nozzle.md
@@ -450,13 +450,41 @@ monitors` after configuring this monitor in a running agent instance.
 
 ## Dimensions
 
-The following dimensions may occur on metrics emitted by this monitor.  Some
-dimensions may be specific to certain metrics.
+The following dimensions are present on all metrics emitted by this monitor:
 
 | Name | Description |
 | ---  | ---         |
-| `instance_id` | The BOSH instance id that pertains to the metric, if any. |
-| `source_id` | The source of the metric |
+| `origin` | Origin name of the metric. Equal to the prefix of the metric name. |
+| `source_id` | For application container metrics, this is the GUID of the application (equal to `app_id`), for system metrics, this is the origin name (equal to `origin`). |
+| `deployment` | Name of the BOSH deployment. |
+| `job` | Name of the BOSH job. |
+| `index` | ID of the BOSH instance. |
+| `ip` | IP address of the BOSH instance. |
 
+### Application-specific dimensions
 
+The following dimensions are available for application metrics (`rep.`):
 
+| Name | Description |
+| ---  | ---         |
+| `process_id` | Process ID. For a process of type "web" (main process of an application), this is equal to `source_id` and `app_id`. |
+| `process_type` | Type of the process (each application has one process with type "web") |
+| `instance_id` | Numerical index of the application instance. Also present for `bbs.` metrics, where it is the BOSH instance ID (equal to `index`) |
+| `process_instance_id` | Unique ID for the application process instance |
+
+The following additional dimensions were added in version 2.8.0 for Pivotal 
+Cloud Foundry (PCF) / Tanzu Application Service (TAS), and in version v11.1.0
+for cf-deployment:
+
+| Name | Description |
+| ---  | ---         |
+| `app_id` | Application ID (GUID). This is equal to the value of `source_id` dimension. |
+| `app_name` | Application name |
+| `organization_id` | Organization ID (GUID) |
+| `organization_name` | Organization name |
+| `space_id` | Space ID (GUID) |
+| `space_name` | Space name |
+
+Note that for TAS 2.8, the documentation states that it is a known issue that
+if the name of an application/space/organization is changed, that change will
+not be reflected in dimension values until the application process is restarted.

--- a/docs/monitors/cloudfoundry-firehose-nozzle.md
+++ b/docs/monitors/cloudfoundry-firehose-nozzle.md
@@ -450,41 +450,27 @@ monitors` after configuring this monitor in a running agent instance.
 
 ## Dimensions
 
-The following dimensions are present on all metrics emitted by this monitor:
+The following dimensions may occur on metrics emitted by this monitor.  Some
+dimensions may be specific to certain metrics.
 
 | Name | Description |
 | ---  | ---         |
-| `origin` | Origin name of the metric. Equal to the prefix of the metric name. |
-| `source_id` | For application container metrics, this is the GUID of the application (equal to `app_id`), for system metrics, this is the origin name (equal to `origin`). |
+| `app_id` | Application ID (GUID). This is equal to the value of `source_id` dimension. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). |
+| `app_name` | Application name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8. |
 | `deployment` | Name of the BOSH deployment. |
-| `job` | Name of the BOSH job. |
 | `index` | ID of the BOSH instance. |
+| `instance_id` | Numerical index of the application instance for applications (`rep.` metrics). Also present for `bbs.` metrics, where it is the BOSH instance ID (equal to `index`). |
 | `ip` | IP address of the BOSH instance. |
+| `job` | Name of the BOSH job. |
+| `organization_id` | Organization ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). |
+| `organization_name` | Organization name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8. |
+| `origin` | Origin name of the metric. Equal to the prefix of the metric name. |
+| `process_id` | Process ID. Only present for applications (`rep.` metrics). For a process of type "web" (main process of an application), this is equal to `source_id` and `app_id`. |
+| `process_instance_id` | Unique ID for the application process instance. Only present for applications (`rep.` metrics). |
+| `process_type` | Type of the process (each application has one process with type "web"). Only present for applications (`rep.` metrics). |
+| `source_id` | For application container metrics, this is the GUID of the application (equal to `app_id`), for system metrics, this is the origin name (equal to `origin`). |
+| `space_id` | Space ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). |
+| `space_name` | Space name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8. |
 
-### Application-specific dimensions
 
-The following dimensions are available for application metrics (`rep.`):
 
-| Name | Description |
-| ---  | ---         |
-| `process_id` | Process ID. For a process of type "web" (main process of an application), this is equal to `source_id` and `app_id`. |
-| `process_type` | Type of the process (each application has one process with type "web") |
-| `instance_id` | Numerical index of the application instance. Also present for `bbs.` metrics, where it is the BOSH instance ID (equal to `index`) |
-| `process_instance_id` | Unique ID for the application process instance |
-
-The following additional dimensions were added in version 2.8.0 for Pivotal 
-Cloud Foundry (PCF) / Tanzu Application Service (TAS), and in version v11.1.0
-for cf-deployment:
-
-| Name | Description |
-| ---  | ---         |
-| `app_id` | Application ID (GUID). This is equal to the value of `source_id` dimension. |
-| `app_name` | Application name |
-| `organization_id` | Organization ID (GUID) |
-| `organization_name` | Organization name |
-| `space_id` | Space ID (GUID) |
-| `space_name` | Space name |
-
-Note that for TAS 2.8, the documentation states that it is a known issue that
-if the name of an application/space/organization is changed, that change will
-not be reflected in dimension values until the application process is restarted.

--- a/pkg/monitors/cloudfoundry/metadata.yaml
+++ b/pkg/monitors/cloudfoundry/metadata.yaml
@@ -1,9 +1,37 @@
 monitors:
 - dimensions:
+    origin:
+      description: Origin name of the metric. Equal to the prefix of the metric name.
     source_id:
-      description: The source of the metric
+      description: For application container metrics, this is the GUID of the application (equal to `app_id`), for system metrics, this is the origin name (equal to `origin`).
+    deployment:
+      description: Name of the BOSH deployment.
+    job:
+      description: Name of the BOSH job.
+    index:
+      description: ID of the BOSH instance.
+    ip:
+      description: IP address of the BOSH instance.
+    process_id:
+      description: Process ID. Only present for applications (`rep.` metrics). For a process of type "web" (main process of an application), this is equal to `source_id` and `app_id`.
+    process_type:
+      description: Type of the process (each application has one process with type "web"). Only present for applications (`rep.` metrics).
     instance_id:
-      description: The BOSH instance id that pertains to the metric, if any.
+      description: Numerical index of the application instance for applications (`rep.` metrics). Also present for `bbs.` metrics, where it is the BOSH instance ID (equal to `index`).
+    process_instance_id:
+      description: Unique ID for the application process instance. Only present for applications (`rep.` metrics).
+    app_id:
+      description: Application ID (GUID). This is equal to the value of `source_id` dimension. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+).
+    app_name:
+      description: Application name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8.
+    organization_id:
+      description: Organization ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+).
+    organization_name:
+      description: Organization name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8.
+    space_id:
+      description: Space ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+).
+    space_name:
+      description: Space name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8.
   monitorType: cloudfoundry-firehose-nozzle
   doc: |
     This is a CloudFoundry [firehose

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -1681,11 +1681,53 @@
       "sendUnknown": false,
       "noneIncluded": false,
       "dimensions": {
+        "app_id": {
+          "description": "Application ID (GUID). This is equal to the value of `source_id` dimension. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+)."
+        },
+        "app_name": {
+          "description": "Application name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8."
+        },
+        "deployment": {
+          "description": "Name of the BOSH deployment."
+        },
+        "index": {
+          "description": "ID of the BOSH instance."
+        },
         "instance_id": {
-          "description": "The BOSH instance id that pertains to the metric, if any."
+          "description": "Numerical index of the application instance for applications (`rep.` metrics). Also present for `bbs.` metrics, where it is the BOSH instance ID (equal to `index`)."
+        },
+        "ip": {
+          "description": "IP address of the BOSH instance."
+        },
+        "job": {
+          "description": "Name of the BOSH job."
+        },
+        "organization_id": {
+          "description": "Organization ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+)."
+        },
+        "organization_name": {
+          "description": "Organization name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8."
+        },
+        "origin": {
+          "description": "Origin name of the metric. Equal to the prefix of the metric name."
+        },
+        "process_id": {
+          "description": "Process ID. Only present for applications (`rep.` metrics). For a process of type \"web\" (main process of an application), this is equal to `source_id` and `app_id`."
+        },
+        "process_instance_id": {
+          "description": "Unique ID for the application process instance. Only present for applications (`rep.` metrics)."
+        },
+        "process_type": {
+          "description": "Type of the process (each application has one process with type \"web\"). Only present for applications (`rep.` metrics)."
         },
         "source_id": {
-          "description": "The source of the metric"
+          "description": "For application container metrics, this is the GUID of the application (equal to `app_id`), for system metrics, this is the origin name (equal to `origin`)."
+        },
+        "space_id": {
+          "description": "Space ID (GUID). Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+)."
+        },
+        "space_name": {
+          "description": "Space name. Only available for applications on TAS/PCF 2.8.0+ (cf-deployment v11.1.0+). Name change does not take effect until process is restarted on TAS 2.8."
         }
       },
       "doc": "This is a CloudFoundry [firehose\nnozzle](https://docs.pivotal.io/tiledev/2-8/nozzle.html) by connecting to\nthe Cloud Foundry Reverse Log Proxy (RLP) Gateway that feeds metrics from\nthe Loggregator. This uses the new RLP Gateway model that was [introduced\nin Pivotal Cloud Foundry (PCF)\n2.4](https://docs.pivotal.io/tiledev/2-4/release-notes.html#log-api), so it\nwill not work with older releases.\n\nPivotal has a helpful guide for [Key Performance Indicators\n(KPIs)](https://docs.pivotal.io/platform/2-8/monitoring/kpi.html) to\nmonitor.  Most of these metrics come through the firehose.  They also have\na guide for [Key Capacity Scaling\nIndicators](https://docs.pivotal.io/platform/2-8/monitoring/key-cap-scaling.html)\nthat will help determine when to scale up or down your cluster.\n\nThis supports `gauge` and `counter` metrics at this time.  Firehose `gauge`\nmetrics gets converted to SignalFx gauges, an firehose `counter` metrics\nget converted to SignalFx cumulative counters metrics.  All of the `tags`\nin the firehose envelopes will be converted to dimensions when sending to\nSignalFx.\n\nTo create a UAA user with the proper permissions to access the RLP Gateway,\nrun the following:\n\n```sh\n$ uaac client add my-v2-nozzle \\\n    --name signalfx-nozzle \\\n    --secret \u003csignalfx-nozzle client secret\u003e \\\n    --authorized_grant_types client_credentials,refresh_token \\\n    --authorities logs.admin\n```\n\nThen set the `uaaUsername` config value to `signalfx-nozzle` and the\n`uaaPassword` field to the `\u003csignalfx-nozzle client secret\u003e` that you\nselect.\n",


### PR DESCRIPTION
Document all common Cloud Foundry metric dimensions. This includes application metadata dimensions added in TAS 2.8.0, for which we needed to document which version they were added in, to avoid confusion as to why they are present for some installations but not others.