### PR TITLE
use latest FQDN function

### DIFF
--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -45,6 +45,7 @@ if not set.
 | `signalFxRealm` | no | string | The SignalFx Realm that the organization you want to send to is a part of.  This defaults to the original realm (`us0`) but if you are setting up the agent for the first time, you quite likely need to change this. (**default:** `"us0"`) |
 | `hostname` | no | string | The hostname that will be reported as the `host` dimension. If blank, this will be auto-determined by the agent based on a reverse lookup of the machine's IP address. |
 | `useFullyQualifiedHost` | no | bool | If true (the default), and the `hostname` option is not set, the hostname will be determined by doing a reverse DNS query on the IP address that is returned by querying for the bare hostname.  This is useful in cases where the hostname reported by the kernel is a short name. (**default**: `true`) |
+| `useNewFQDNFunction` | no | bool | If true, the agent will use the newly improved FQDN function, otherwise, use the legacy function. (**default**: `false`) (**default:** `false`) |
 | `disableHostDimensions` | no | bool | Our standard agent model is to collect metrics for services running on the same host as the agent.  Therefore, host-specific dimensions (e.g. `host`, `AWSUniqueId`, etc) are automatically added to every datapoint that is emitted from the agent by default.  Set this to true if you are using the agent primarily to monitor things on other hosts.  You can set this option at the monitor level as well. (**default:** `false`) |
 | `intervalSeconds` | no | integer | How often to send metrics to SignalFx.  Monitors can override this individually. (**default:** `10`) |
 | `cloudMetadataTimeout` | no | int64 | This flag sets the HTTP timeout duration for metadata queries from AWS, Azure and GCP. This should be a duration string that is accepted by https://golang.org/pkg/time/#ParseDuration (**default:** `"2s"`) |
@@ -402,6 +403,7 @@ where applicable:
   signalFxRealm: "us0"
   hostname: 
   useFullyQualifiedHost: 
+  useNewFQDNFunction: false
   disableHostDimensions: false
   intervalSeconds: 10
   cloudMetadataTimeout: "2s"

--- a/pkg/core/config/config.go
+++ b/pkg/core/config/config.go
@@ -65,6 +65,9 @@ type Config struct {
 	// useful in cases where the hostname reported by the kernel is a short
 	// name. (**default**: `true`)
 	UseFullyQualifiedHost *bool `yaml:"useFullyQualifiedHost" noDefault:"true"`
+	// If true, the agent will use the newly improved FQDN function, otherwise,
+	// use the legacy function. (**default**: `false`)
+	UseNewFQDNFunction bool `yaml:"useNewFQDNFunction" default:"false"`
 	// Our standard agent model is to collect metrics for services running on
 	// the same host as the agent.  Therefore, host-specific dimensions (e.g.
 	// `host`, `AWSUniqueId`, etc) are automatically added to every datapoint

--- a/pkg/core/hostid/dims.go
+++ b/pkg/core/hostid/dims.go
@@ -22,7 +22,7 @@ func Dimensions(conf *config.Config) map[string]string {
 		// Using the FQDN needs to default to true but the defaults lib that we
 		// use can't distinguish between false and unspecified, so figure out
 		// if the user specified it explicitly as false with this logic.
-		return getHostname(conf.UseFullyQualifiedHost == nil || *conf.UseFullyQualifiedHost)
+		return getHostname(conf.UseFullyQualifiedHost == nil || *conf.UseFullyQualifiedHost, conf.UseNewFQDNFunction)
 	})
 
 	// The envvar exists primarily for testing but could be useful otherwise.

--- a/pkg/core/hostid/host.go
+++ b/pkg/core/hostid/host.go
@@ -7,13 +7,20 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func getHostname(useFullyQualifiedHost bool) string {
+func getHostname(useFullyQualifiedHost bool, useNewFQDNFunction bool) string {
 	var host string
 	if useFullyQualifiedHost {
 		log.Info("Trying to get fully qualified hostname")
-		host = fqdn.Get()
-		if host == "unknown" || host == "localhost" {
-			log.Info("Error getting fully qualified hostname, using plain hostname")
+		var err error
+		if useNewFQDNFunction {
+			host, err = fqdn.FqdnHostname()
+		} else {
+			host = fqdn.Get()
+		}
+		if host == "unknown" || host == "localhost" || err != nil {
+			log.WithFields(log.Fields{
+				"detail": err,
+			}).Info("Error getting fully qualified hostname, using plain hostname")
 			host = ""
 		}
 	}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -57643,6 +57643,14 @@
         "elementKind": ""
       },
       {
+        "yamlName": "useNewFQDNFunction",
+        "doc": "If true, the agent will use the newly improved FQDN function, otherwise, use the legacy function. (**default**: `false`)",
+        "default": false,
+        "required": false,
+        "type": "bool",
+        "elementKind": ""
+      },
+      {
         "yamlName": "disableHostDimensions",
         "doc": "Our standard agent model is to collect metrics for services running on the same host as the agent.  Therefore, host-specific dimensions (e.g. `host`, `AWSUniqueId`, etc) are automatically added to every datapoint that is emitted from the agent by default.  Set this to true if you are using the agent primarily to monitor things on other hosts.  You can set this option at the monitor level as well.",
         "default": false,


### PR DESCRIPTION
`fqdn.Get()` has been deprecated for a while and the new function `fqdn.FqdnHostname` is supposedly more accurate https://github.com/Showmax/go-fqdn/blob/master/fqdn.go#L220-L238 and should address many reported issues with wrong hostname.

The only concern I have is that this change might impact a large number of users, especially the ones with invalid hostname dimension but not aware or don't pay much attention to this dimension. It can also result of a large amount of meta updates and a temporary invalid content.
If the concern is valid, I am happy to introduce a new config option to give the user the option to keep using the legacy function `fqdn.Get()` (by default) or switch to the new one `fqdn.FqdnHostname`

cc: @keitwb @jrcamp 
Signed-off-by: Dani Louca <dlouca@splunk.com>

**Update**
@keitwb shares the same concerns described above and suggested to manually set the hostname when we can.
If this is not an option, we'll make the new function configurable