### PR TITLE
Upgrade collectd-jenkins to v2.4.1

### DIFF
--- a/collectd-plugins.yaml
+++ b/collectd-plugins.yaml
@@ -26,7 +26,7 @@
   repo: signalfx/collectd-health_checker
 
 - name: jenkins
-  version: v2.4.0
+  version: v2.4.1
   repo: signalfx/collectd-jenkins
 
 - name: kong


### PR DESCRIPTION
urllib3 in collectd-jenkins was upgraded to 1.26.6 for CVE-2021-33503