### PR TITLE
Update helm test version to 2.17.0

### DIFF
--- a/tests/deployments/helm/helm_test.py
+++ b/tests/deployments/helm/helm_test.py
@@ -221,7 +221,7 @@ def run_helm_image(k8s_cluster, helm_version):
         yield cont
 
 
-@pytest.mark.parametrize("helm_version", ["2.15.0", "3.0.0"])
+@pytest.mark.parametrize("helm_version", ["2.17.0", "3.0.0"])
 def test_helm(k8s_cluster, helm_version):
     helm_major_version = int(helm_version.split(".")[0])
     with run_helm_image(k8s_cluster, helm_version) as cont:


### PR DESCRIPTION
The tiller image for 2.15.0 no longer exists, causing the helm test to fail.