### PR TITLE
Add partition stats for folder mounted volumes in Windows to monitor filesystems

### DIFF
--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -136,7 +136,7 @@ func (m *Monitor) emitDatapoints() {
 		all = true
 	}
 
-	partitions, err := gopsutil.Partitions(all)
+	partitions, err := getPartitions(all)
 	if err != nil && len(partitions) == 0 {
 		m.logger.WithError(err).Errorf("failed to collect any mountpoints")
 		return

--- a/pkg/monitors/filesystems/partitions.go
+++ b/pkg/monitors/filesystems/partitions.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package filesystems
+
+import gopsutil "github.com/shirou/gopsutil/disk"
+
+func getPartitions(all bool) ([]gopsutil.PartitionStat, error) {
+	return gopsutil.Partitions(all)
+}

--- a/pkg/monitors/filesystems/partitions_windows.go
+++ b/pkg/monitors/filesystems/partitions_windows.go
@@ -1,0 +1,197 @@
+// +build windows
+
+package filesystems
+
+import (
+	"strings"
+	"syscall"
+	"unicode/utf16"
+
+	"github.com/pkg/errors"
+	gopsutil "github.com/shirou/gopsutil/disk"
+	"golang.org/x/sys/windows"
+)
+
+const volumeNameBufferLength = uint32(windows.MAX_PATH + 1)
+const volumePathBufferLength = volumeNameBufferLength
+
+func getPartitions(all bool) ([]gopsutil.PartitionStat, error) {
+	return getPartitionsWin(getDriveType, findFirstVolume, findNextVolume, findVolumeClose, getVolumePaths, getFsNameAndFlags)
+}
+
+// getPartitions returns partition stats.
+// Similar to https://github.com/shirou/gopsutil/blob/7e4dab436b94d671021647dc5dc12c94f490e46e/disk/disk_windows.go#L71
+func getPartitionsWin(
+	getDriveType func(rootPath string) (driveType uint32),
+	findFirstVolume func(volName *uint16) (findVol windows.Handle, err error),
+	findNextVolume func(findVol windows.Handle, volName *uint16) (err error),
+	findVolumeClose func(findVol windows.Handle) (err error),
+	getVolumePaths func(volNameBuf []uint16) ([]string, error),
+	getFsNameAndFlags func(rootPath string, fsNameBuf []uint16, fsFlags *uint32) (err error),
+) ([]gopsutil.PartitionStat, error) {
+
+	stats := make([]gopsutil.PartitionStat, 0)
+	volNameBuf := make([]uint16, volumeNameBufferLength)
+
+	handle, err := findFirstVolume(&volNameBuf[0])
+	if err != nil {
+		return stats, errors.WithMessagef(err, "cannot find first-volume")
+	}
+	defer findVolumeClose(handle)
+
+	var volPaths []string
+	if volPaths, err = getVolumePaths(volNameBuf); err != nil {
+		return stats, errors.WithMessagef(err, "find paths error for first-volume %s", windows.UTF16ToString(volNameBuf))
+	}
+
+	var partitionStats []gopsutil.PartitionStat
+
+	if len(volPaths) > 0 {
+		partitionStats, err = getPartitionStats(getDriveType(volPaths[0]), volPaths, getFsNameAndFlags)
+		if err != nil {
+			return stats, errors.WithMessagef(err, "cannot find partition-stats for first-volume %s", windows.UTF16ToString(volNameBuf))
+		}
+		stats = append(stats, partitionStats...)
+	}
+
+	var lastError error
+	for {
+		volNameBuf = make([]uint16, volumeNameBufferLength)
+		if err = findNextVolume(handle, &volNameBuf[0]); err != nil {
+			if errno, ok := err.(syscall.Errno); ok && errno == windows.ERROR_NO_MORE_FILES {
+				break
+			}
+			lastError = errors.WithMessagef(err, "find next-volume last-error")
+			continue
+		}
+
+		volPaths, err = getVolumePaths(volNameBuf)
+		if err != nil {
+			lastError = errors.WithMessagef(err, "find paths last-error for volume %s", windows.UTF16ToString(volNameBuf))
+			continue
+		}
+
+		if len(volPaths) > 0 {
+			partitionStats, err = getPartitionStats(getDriveType(volPaths[0]), volPaths, getFsNameAndFlags)
+			if err != nil {
+				lastError = errors.WithMessagef(err, "find partition-stats last-error for volume %s", windows.UTF16ToString(volNameBuf))
+				continue
+			}
+			stats = append(stats, partitionStats...)
+		}
+	}
+
+	return stats, lastError
+}
+
+func getDriveType(rootPath string) (driveType uint32) {
+	rootPathPtr, _ := windows.UTF16PtrFromString(rootPath)
+	return windows.GetDriveType(rootPathPtr)
+}
+
+func findFirstVolume(volName *uint16) (findVol windows.Handle, err error) {
+	return windows.FindFirstVolume(volName, volumeNameBufferLength)
+}
+
+func findNextVolume(findVol windows.Handle, volName *uint16) (err error) {
+	return windows.FindNextVolume(findVol, volName, volumeNameBufferLength)
+}
+
+func findVolumeClose(findVol windows.Handle) (err error) {
+	return windows.FindVolumeClose(findVol)
+}
+
+// getVolumePaths returns the path for the given volume name.
+func getVolumePaths(volNameBuf []uint16) ([]string, error) {
+	volPathsBuf := make([]uint16, volumePathBufferLength)
+	returnLen := uint32(0)
+	if err := windows.GetVolumePathNamesForVolumeName(&volNameBuf[0], &volPathsBuf[0], volumePathBufferLength, &returnLen); err != nil {
+		return nil, err
+	}
+
+	return split0(volPathsBuf, int(returnLen)), nil
+}
+
+// split0 iterates through s16 upto `end` and slices `s16` into sub-slices separated by the null character (uint16(0)).
+// split0 converts the sub-slices between the null characters into strings then returns them in a slice.
+func split0(s16 []uint16, end int) []string {
+	if end > len(s16) {
+		end = len(s16)
+	}
+
+	from, ss := 0, make([]string, 0)
+
+	for to := 0; to < end; to++ {
+		if s16[to] == 0 {
+			if from < to && s16[from] != 0 {
+				ss = append(ss, string(utf16.Decode(s16[from:to])))
+			}
+			from = to + 1
+		}
+	}
+
+	return ss
+}
+
+// getFsNameAndFlags sets inputs fsNameBuf and fsFlags with fetched filesystem name (NTFS, FAT32 etc) and flags.
+func getFsNameAndFlags(rootPath string, fsNameBuf []uint16, fsFlags *uint32) error {
+	volNameBuf := make([]uint16, 256)
+	volSerialNum := uint32(0)
+	maxComponentLen := uint32(0)
+	rootPathPtr, _ := windows.UTF16PtrFromString(rootPath)
+
+	return windows.GetVolumeInformation(
+		rootPathPtr,
+		&volNameBuf[0],
+		uint32(len(volNameBuf)),
+		&volSerialNum,
+		&maxComponentLen,
+		fsFlags,
+		&fsNameBuf[0],
+		uint32(len(fsNameBuf)))
+}
+
+// getPartitionStats returns partition stats for the given volume paths.
+// Similar to https://github.com/shirou/gopsutil/blob/master/disk/disk_windows.go#L72
+func getPartitionStats(
+	driveType uint32,
+	volPaths []string,
+	getFsNameAndFlags func(rootPath string, fsNameBuf []uint16, fsFlags *uint32) (err error),
+) ([]gopsutil.PartitionStat, error) {
+
+	stats := make([]gopsutil.PartitionStat, 0)
+
+	var lastError error
+	for _, volPath := range volPaths {
+		if driveType == windows.DRIVE_REMOVABLE || driveType == windows.DRIVE_FIXED || driveType == windows.DRIVE_REMOTE || driveType == windows.DRIVE_CDROM {
+			fsFlags, fsNameBuf := uint32(0), make([]uint16, 256)
+
+			if err := getFsNameAndFlags(volPath, fsNameBuf, &fsFlags); err != nil {
+				// Similar to gopsutil, we avoid setting the likely device-is-not-ready error
+				// which happens if there is no disk in the drive.
+				if driveType != windows.DRIVE_CDROM && driveType != windows.DRIVE_REMOVABLE {
+					lastError = errors.WithMessagef(err, "get volume information last-error")
+				}
+				continue
+			}
+
+			opts := "rw"
+			if int64(fsFlags)&gopsutil.FileReadOnlyVolume != 0 {
+				opts = "ro"
+			}
+			if int64(fsFlags)&gopsutil.FileFileCompression != 0 {
+				opts += ".compress"
+			}
+
+			p := strings.TrimRight(volPath, "\\")
+			stats = append(stats, gopsutil.PartitionStat{
+				Device:     p,
+				Mountpoint: p,
+				Fstype:     windows.UTF16PtrToString(&fsNameBuf[0]),
+				Opts:       opts,
+			})
+		}
+	}
+
+	return stats, lastError
+}

--- a/pkg/monitors/filesystems/partitions_windows_test.go
+++ b/pkg/monitors/filesystems/partitions_windows_test.go
@@ -1,0 +1,267 @@
+// +build windows
+
+package filesystems
+
+import (
+	"fmt"
+	"testing"
+	"unsafe"
+
+	gopsutil "github.com/shirou/gopsutil/disk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+const uninitialized = 999
+const closed = 998
+const compressFlag = uint32(16)     // 0x00000010
+const readOnlyFlag = uint32(524288) // 0x00080000
+
+type volumeMock struct {
+	name      string
+	paths     []string
+	driveType uint32
+	fsType    string
+	fsFlags   uint32
+	err       error
+}
+
+type volumesMock struct {
+	handle  int
+	volumes []*volumeMock
+}
+
+var driveVolume = func() *volumeMock {
+	return &volumeMock{
+		name:      "\\\\?\\Volume{1e1e1111-0000-0000-0000-010000000000}\\",
+		paths:     []string{"C:\\"},
+		driveType: windows.DRIVE_FIXED,
+		fsType:    "NTFS",
+		fsFlags:   compressFlag,
+		err:       nil}
+}
+
+var driveAndFolderVolume = func() *volumeMock {
+	return &volumeMock{
+		name:      "\\\\?\\Volume{0000cccc-0000-0000-0000-010000000000}\\",
+		paths:     []string{"D:\\", "C:\\mnt\\driveD\\"},
+		driveType: windows.DRIVE_FIXED,
+		fsType:    "NTFS",
+		fsFlags:   compressFlag | readOnlyFlag,
+		err:       nil}
+}
+
+var removableDriveVolume = func() *volumeMock {
+	return &volumeMock{
+		name:      "\\\\?\\Volume{bbbbaaaa-0000-0000-0000-010000000000}\\",
+		paths:     []string{"A:\\"},
+		driveType: windows.DRIVE_REMOVABLE,
+		fsType:    "FAT16",
+		fsFlags:   compressFlag,
+		err:       nil}
+}
+
+func TestGetPartitions_Supersets_gopsutil_PartitionStats(t *testing.T) {
+	// Partition stats from gopsutil are for drive mounts only.
+	want, err := gopsutil.Partitions(true)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, want, "cannot find partition stats using gopsutil")
+
+	var got []gopsutil.PartitionStat
+	// getPartitions includes partition stats for drive and folder mounts.
+	got, err = getPartitions(true)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, got, "cannot find partition stats using getPartitions")
+
+	// Asserting `got` getPartitions stats superset of `want` gopsutil stats.
+	assert.Subset(t, got, want)
+}
+
+func TestGetPartitionsWin(t *testing.T) {
+	type wantType struct {
+		stats    []gopsutil.PartitionStat
+		numStats int
+		hasError bool
+	}
+
+	tests := []struct {
+		name    string
+		volumes *volumesMock
+		want    wantType
+	}{
+		{
+			name: "should get all partition stats for no errors",
+			volumes: func() *volumesMock {
+				firstVolume, nextVolume1, nextVolume2 := driveVolume(), driveAndFolderVolume(), removableDriveVolume()
+				vols := append(make([]*volumeMock, 0), firstVolume, nextVolume1, nextVolume2)
+				return &volumesMock{handle: 0, volumes: vols}
+			}(),
+			want: wantType{
+				numStats: 4,
+				hasError: false,
+				stats: []gopsutil.PartitionStat{
+					{Device: "C:", Mountpoint: "C:", Fstype: "NTFS", Opts: "rw.compress"},
+					{Device: "D:", Mountpoint: "D:", Fstype: "NTFS", Opts: "ro.compress"},
+					{Device: "C:\\mnt\\driveD", Mountpoint: "C:\\mnt\\driveD", Fstype: "NTFS", Opts: "ro.compress"},
+					{Device: "A:", Mountpoint: "A:", Fstype: "FAT16", Opts: "rw.compress"}},
+			},
+		},
+		{
+			name: "should get no partition stats if first volume not found",
+			volumes: func() *volumesMock {
+				firstVolume, nextVolume1, nextVolume2 := driveVolume(), driveAndFolderVolume(), removableDriveVolume()
+				firstVolume.err = fmt.Errorf("volume not found")
+				vols := append(make([]*volumeMock, 0), firstVolume, nextVolume1, nextVolume2)
+				return &volumesMock{handle: 0, volumes: vols}
+			}(),
+			want: wantType{
+				numStats: 0,
+				hasError: true,
+				stats:    []gopsutil.PartitionStat{},
+			},
+		},
+		{
+			name: "should get partition stats for found next volumes",
+			volumes: func() *volumesMock {
+				firstVolume, nextVolume1, nextVolume2 := driveVolume(), driveAndFolderVolume(), removableDriveVolume()
+				nextVolume1.err = fmt.Errorf("volume not found")
+				vols := append(make([]*volumeMock, 0), firstVolume, nextVolume1, nextVolume2)
+				return &volumesMock{handle: 0, volumes: vols}
+			}(),
+			want: wantType{
+				numStats: 2,
+				hasError: true,
+				stats: []gopsutil.PartitionStat{
+					{Device: "C:", Mountpoint: "C:", Fstype: "NTFS", Opts: "rw.compress"},
+					{Device: "A:", Mountpoint: "A:", Fstype: "FAT16", Opts: "rw.compress"}},
+			},
+		},
+	}
+
+	for _, tst := range tests {
+		test := tst
+		t.Run(test.name, func(t *testing.T) {
+			stats, err := getPartitionsWin(
+				test.volumes.getDriveTypeMock,
+				test.volumes.findFirstVolumeMock,
+				test.volumes.findNextVolumeMock,
+				test.volumes.findVolumeCloseMock,
+				test.volumes.getVolumePathsMock,
+				test.volumes.getFsNameAndFlagsMock)
+
+			if !test.want.hasError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+			require.Equal(t, test.want.numStats, len(stats), "Number of partition stats not equal to expected")
+
+			for i := 0; i < test.want.numStats; i++ {
+				assert.Equal(t, test.want.stats[i], stats[i])
+			}
+		})
+	}
+}
+
+func (v *volumesMock) getDriveTypeMock(rootPath string) (driveType uint32) {
+	for _, volume := range v.volumes {
+		for _, path := range volume.paths {
+			if path == rootPath {
+				return volume.driveType
+			}
+		}
+	}
+	return windows.DRIVE_UNKNOWN
+}
+
+func (v *volumesMock) findFirstVolumeMock(volumeNamePtr *uint16) (windows.Handle, error) {
+	firstVolume := v.volumes[v.handle]
+	if firstVolume.err != nil {
+		return windows.Handle(unsafe.Pointer(&v.handle)), firstVolume.err
+	}
+
+	volumeName, err := windows.UTF16FromString(firstVolume.name)
+	if err != nil {
+		return windows.Handle(unsafe.Pointer(&v.handle)), err
+	}
+
+	start := uintptr(unsafe.Pointer(volumeNamePtr))
+	size := unsafe.Sizeof(*volumeNamePtr)
+	for i := range volumeName {
+		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i]
+	}
+
+	return windows.Handle(unsafe.Pointer(&v.handle)), nil
+}
+
+func (v *volumesMock) findNextVolumeMock(volumeIndexHandle windows.Handle, volumeNamePtr *uint16) error {
+	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle))
+	if volumeIndex == uninitialized {
+		return windows.ERROR_NO_MORE_FILES
+	}
+
+	nextVolumeIndex := volumeIndex + 1
+	if nextVolumeIndex >= len(v.volumes) {
+		return windows.ERROR_NO_MORE_FILES
+	}
+	*(*int)(unsafe.Pointer(volumeIndexHandle)) = nextVolumeIndex
+
+	nextVolume := v.volumes[nextVolumeIndex]
+	if nextVolume.err != nil {
+		return nextVolume.err
+	}
+
+	volumeName, err := windows.UTF16FromString(nextVolume.name)
+	if err != nil {
+		return err
+	}
+
+	start := uintptr(unsafe.Pointer(volumeNamePtr))
+	size := unsafe.Sizeof(*volumeNamePtr)
+	for i := range volumeName {
+		*(*uint16)(unsafe.Pointer(start + size*uintptr(i))) = volumeName[i]
+	}
+
+	return err
+}
+
+func (v *volumesMock) findVolumeCloseMock(volumeIndexHandle windows.Handle) error {
+	volumeIndex := *(*int)(unsafe.Pointer(volumeIndexHandle))
+	if volumeIndex != uninitialized {
+		*(*int)(unsafe.Pointer(volumeIndexHandle)) = closed
+	}
+	return nil
+}
+
+func (v *volumesMock) getVolumePathsMock(volNameBuf []uint16) (volumePaths []string, err error) {
+	volumeName := windows.UTF16ToString(volNameBuf)
+	for _, volume := range v.volumes {
+		if volume.name == volumeName {
+			volumePaths = append(volumePaths, volume.paths...)
+		}
+	}
+	if len(volumePaths) == 0 {
+		err = fmt.Errorf("path not found for volume: %s", volumeName)
+	}
+	return volumePaths, err
+}
+
+func (v *volumesMock) getFsNameAndFlagsMock(rootPath string, fsNameBuf []uint16, fsFlags *uint32) error {
+	for _, volume := range v.volumes {
+		for _, path := range volume.paths {
+			if rootPath == path {
+				*fsFlags = volume.fsFlags
+				fsName, err := windows.UTF16FromString(volume.fsType)
+				if err != nil {
+					return err
+				}
+				copy(fsNameBuf, fsName)
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("cannot find volume information for volume path %s", rootPath)
+}


### PR DESCRIPTION
Made changes to collect partitions stats for partitions in volumes mounted to drives and folders in Windows.

- Tested in Windows Server 2016
- Compared against gopsutil v3.10.20
