### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 * @keitwb @jcheng-splunk @mstumpfx @asuresh4 @rmfitzpatrick @signalfx/gdi-data-collection-maintainers
 
 # Docs reviewers
-*.md @signalfx/docs @signalfx/gdi-data-collection-approvers
-*.rst @signalfx/docs @signalfx/gdi-data-collection-approvers
-docs/ @signalfx/docs @signalfx/gdi-data-collection-approvers
-README* @signalfx/docs @signalfx/gdi-data-collection-approvers
+*.md @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
+*.rst @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
+docs/ @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
+README* @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,8 +2,8 @@
 * @keitwb @jcheng-splunk @mstumpfx @asuresh4 @rmfitzpatrick @signalfx/gdi-data-collection-maintainers
 
 # Docs reviewers
-*.md @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
-*.rst @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
-docs/ @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
-README* @signalfx/docs @signalfx/gdi-data-collection-approvers @signalfx/docs
+*.md @signalfx/gdi-data-collection-approvers @signalfx/docs
+*.rst @signalfx/gdi-data-collection-approvers @signalfx/docs
+docs/ @signalfx/gdi-data-collection-approvers @signalfx/docs
+README* @signalfx/gdi-data-collection-approvers @signalfx/docs
 


### PR DESCRIPTION
As per https://github.com/signalfx/gdi-specification/pull/117.

If tech writers AND maintainers are the reviewers for docs, there's no way tech writers can block PRs. Please feel free to correct me if I'm wrong on this point.

For an example, see: https://github.com/signalfx/splunk-otel-java/blob/main/.github/CODEOWNERS