### PR TITLE
Change link to the new docs site

### DIFF
--- a/docs/kubernetes-setup.md
+++ b/docs/kubernetes-setup.md
@@ -4,4 +4,4 @@ The agent was first written for Kubernetes and is relatively easy to setup in a
 cluster.  The agent is intended to be run on each node and will monitor
 services running on those same nodes to minimize cross-node traffic.
 
-For information on monitoring kubernetes, see [Monitoring Kubernetes](https://docs.signalfx.com/en/latest/kubernetes/index.html).
+For information on monitoring kubernetes, see [Monitoring Kubernetes](https://docs.splunk.com/Observability/infrastructure/navigators/k8s.html).


### PR DESCRIPTION
Updating the link for "Monitor Kubernetes" to point to the new docs site. This relates to https://signalfuse.atlassian.net/browse/DOCS-2570. 