### PR TITLE
Add Helm 3+ as the supported version for K8s

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,7 @@ formula source](https://github.com/signalfx/signalfx-agent/tree/main/deployments
 See [Docker Deployment](./deployments/docker) for more information.
 
 #### Kubernetes
-See our [Kubernetes setup instructions](./docs/kubernetes-setup.md) and the
-documentation on [Monitoring
+See our [Kubernetes setup instructions](./docs/kubernetes-setup.md) and [Monitor
 Kubernetes](https://docs.splunk.com/Observability/infrastructure/navigators/k8s.html)
 for more information. Helm 3+ is the supported version.
 

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ See [Docker Deployment](./deployments/docker) for more information.
 #### Kubernetes
 See our [Kubernetes setup instructions](./docs/kubernetes-setup.md) and the
 documentation on [Monitoring
-Kubernetes](https://docs.signalfx.com/en/latest/integrations/kubernetes-quickstart.html)
-for more information.
+Kubernetes](https://docs.splunk.com/Observability/infrastructure/navigators/k8s.html)
+for more information. Helm 3+ is the supported version.
 
 #### AWS Elastic Container Service (ECS)
 See the [ECS directory](./deployments/ecs), which includes a sample

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ See [Docker Deployment](./deployments/docker) for more information.
 #### Kubernetes
 See our [Kubernetes setup instructions](./docs/kubernetes-setup.md) and [Monitor
 Kubernetes](https://docs.splunk.com/Observability/infrastructure/navigators/k8s.html)
-for more information. Helm 3+ is the supported version.
+for more information. Helm version 3 or higher is supported.
 
 #### AWS Elastic Container Service (ECS)
 See the [ECS directory](./deployments/ecs), which includes a sample

--- a/docs/agent-k8s-install-helm.md
+++ b/docs/agent-k8s-install-helm.md
@@ -15,8 +15,7 @@ to install the Smart Agent. To learn more, see
 * Terminal or a similar command-line interface application
 * Helm:
 
-  - The installation chart for the Smart Agent is compatible with Helm version 2 or Helm version 3.
-  - To learn more, see the [Helm site](https://helm.sh/).
+  - The installation chart for the Smart Agent is compatible with Helm version 2 or Helm version 3. Helm version 2 is [deprecated](https://helm.sh/blog/helm-v2-deprecation-timeline/). To learn more, see the [Helm site](https://helm.sh/).
 
 * Tiller installed on all of your Kubernetes hosts. Because of
   the way that the installation chart works, you need Tiller even if you're using
@@ -84,13 +83,15 @@ Determine if you want OpenShift support:
    - If you want OpenShift support, substitute the values from the previous steps and run this command:
 
      ```
-     helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> signalfx/signalfx-agent --set kubernetesDistro=openshift
+     helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> --generate-name --set kubernetesDistro=openshift signalfx/signalfx-agent
      ```
+
+     The ``--generate-name`` option is only supported for Helm version 3+.
 
    - If you don't want OpenShift support, substitute the values from the previous steps and run this command:
 
      ```
-     helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> signalfx/signalfx-agent
+     helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> --generate-name signalfx/signalfx-agent
      ```
 
 ### Verify the SignalFx Smart Agent

--- a/docs/agent-k8s-install-helm.md
+++ b/docs/agent-k8s-install-helm.md
@@ -15,7 +15,7 @@ to install the Smart Agent. To learn more, see
 * Terminal or a similar command-line interface application
 * Helm:
 
-  - The installation chart for the Smart Agent is compatible with Helm version 2 or Helm version 3. Helm version 2 is [deprecated](https://helm.sh/blog/helm-v2-deprecation-timeline/). To learn more, see the [Helm site](https://helm.sh/).
+  - The installation chart for the Smart Agent is compatible with Helm version 3 or higher. Helm version 2 is [deprecated](https://helm.sh/blog/helm-v2-deprecation-timeline/). To learn more, see the [Helm site](https://helm.sh/).
 
 * Tiller installed on all of your Kubernetes hosts. Because of
   the way that the installation chart works, you need Tiller even if you're using
@@ -85,14 +85,14 @@ Determine if you want OpenShift support:
      ```
      helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> --generate-name --set kubernetesDistro=openshift signalfx/signalfx-agent
      ```
-
-     The ``--generate-name`` option is only supported for Helm version 3+.
-
+     
    - If you don't want OpenShift support, substitute the values from the previous steps and run this command:
 
      ```
      helm install -f <values_yaml_file> --set signalFxAccessToken=<access_token> --set clusterName=<cluster_name> --set agentVersion=<version> --set signalFxRealm=<realm> --generate-name signalfx/signalfx-agent
      ```
+
+**Note:** The ``--generate-name`` option is only supported for Helm version 3 or higher.
 
 ### Verify the SignalFx Smart Agent
 


### PR DESCRIPTION
Add Helm 3+ as the supported version for K8s. This relates to https://github.com/signalfx/signalfx-agent/pull/1891 and https://signalfuse.atlassian.net/browse/DOCS-2570. 