### PR TITLE
add dimensions.yaml for integrations repo

### DIFF
--- a/scripts/docs/to-integrations-repo
+++ b/scripts/docs/to-integrations-repo
@@ -298,6 +298,14 @@ def generate_metric_yaml(monitor, metrics, send_all):
     return out
 
 
+def generate_dimension_yaml(monitor, dimensions):
+    out = "\n"
+    for dim, desc in sorted(dimensions.items(), key=lambda t:t[0]):
+        out += yaml.dump({dim: desc.get("description")})
+        out += "\n"
+    return out
+
+
 def sync_metrics(integration_dirs):
     for integrations_dir, monitors_info in integration_dirs.items():
         metric_yaml = ""
@@ -318,6 +326,27 @@ def sync_metrics(integration_dirs):
         )
         out_path = INTEGRATIONS_REPO / integrations_dir / "metrics.yaml"
         out_path.write_text(metric_yaml, encoding="utf-8")
+
+
+def sync_dimensions(integration_dirs):
+    for integrations_dir, monitors_info in integration_dirs.items():
+        dim_yaml = ""
+        for monitor, monitor_dims in monitors_info.get("dimensions", {}).items():
+            if not monitor_dims:
+                continue
+
+            dim_yaml += generate_dimension_yaml(monitor, monitor_dims)
+
+        if dim_yaml == "":
+            continue
+
+        print(f"Syncing dimensions to {integrations_dir} directory")
+
+        dim_yaml = (
+            "# This file was generated in the Smart Agent repo and copied here, DO NOT EDIT HERE.\n" + dim_yaml
+        )
+        out_path = INTEGRATIONS_REPO / integrations_dir / "dimensions.yaml"
+        out_path.write_text(dimensions, encoding="utf-8")
 
 
 def generate_config_yaml(mon_config):
@@ -347,8 +376,10 @@ def run():
     monitor_docs = load_monitor_docs_from_self_describe_json()
     integration_dirs = monitor_docs_per_integrations_repo(monitor_docs)
 
+
     sync_docs(integration_dirs)
     sync_metrics(integration_dirs)
+    sync_dimensions(integration_dirs)
     sync_config(integration_dirs)
 
     sync_agent_info()


### PR DESCRIPTION
This provides dimensions per integration (if they exist) in a more machine readable format for docs team to consume. 