### PR TITLE
Update salt dev image

### DIFF
--- a/deployments/salt/Dockerfile
+++ b/deployments/salt/Dockerfile
@@ -7,14 +7,14 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade -y -o DPkg::Options::=--force-confold
-RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python-pip vim
+RUN apt-get install -y software-properties-common ca-certificates wget curl apt-transport-https python3-pip vim
 
-RUN curl -L https://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
-RUN echo 'deb http://repo.saltstack.com/apt/ubuntu/16.04/amd64/latest xenial main' > /etc/apt/sources.list.d/saltstack.list && \
+RUN curl -L https://repo.saltproject.io/py3/ubuntu/16.04/amd64/latest/SALTSTACK-GPG-KEY.pub | apt-key add -
+RUN echo 'deb http://repo.saltproject.io/py3/ubuntu/16.04/amd64/latest xenial main' > /etc/apt/sources.list.d/saltstack.list && \
     apt-get update && \
     apt-get install -y salt-minion
 
-RUN pip install salt-lint==0.2.0
+RUN pip3 install salt-lint==0.2.0
 
 RUN sed -i "s|#file_client:.*|file_client: local|" /etc/salt/minion
 


### PR DESCRIPTION
Salt installation in the dev image fails due to salt repo changes, which is causing the circleci test job to fail.