### PR TITLE
dispatch datapoints that are successfully set

### DIFF
--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -212,9 +212,9 @@ func (m *Monitor) emitDatapoints() {
 	diskSummary, err := calculateUtil(float64(used), float64(total))
 	if err != nil {
 		m.logger.WithError(err).Errorf("failed to calculate utilization data")
-		return
+	} else {
+		dps = append(dps, datapoint.New(diskSummaryUtilization, nil, datapoint.NewFloatValue(diskSummary), datapoint.Gauge, time.Time{}))
 	}
-	dps = append(dps, datapoint.New(diskSummaryUtilization, nil, datapoint.NewFloatValue(diskSummary), datapoint.Gauge, time.Time{}))
 
 	m.Output.SendDatapoints(dps...)
 }


### PR DESCRIPTION
In case of an error while calculating disk.summary_utilization , the current logic returns and does not dispatch the datapoints that are already determined.
This PR makes sure that all datapoints already calculated will be dispatched.

Signed-off-by: Dani Louca <dlouca@splunk.com>