### PR TITLE
Remove host metrics and dimension from fargate config

### DIFF
--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -42,7 +42,12 @@ We have an [example task definition](./example-fargate-task.json) that shows
 launching the agent alongside a Redis cache instance.  The example uses
 auto-discovery, but you could also just hard code the monitor configuration in
 the agent.yaml (or reference config from envvars using remote config, as shown
-in [agent.yaml](./agent.yaml)).
+in [agent.yaml](./agent.yaml)). 
+
+By default, this task will not collect any underlying host metrics, nor send
+a `host` dimension. This is disabled to prevent unwanted monitoring of additional
+hosts. To re-enable monitoring of underlying hosts, set the `disableHostDimension`
+config option to `true` and uncomment the host metric monitors in the example [agent.yaml](./agent.yaml).
 
 
 ## Configuration

--- a/deployments/fargate/README.md
+++ b/deployments/fargate/README.md
@@ -47,7 +47,7 @@ in [agent.yaml](./agent.yaml)).
 By default, this task will not collect any underlying host metrics, nor send
 a `host` dimension. This is disabled to prevent unwanted monitoring of additional
 hosts. To re-enable monitoring of underlying hosts, set the `disableHostDimension`
-config option to `true` and uncomment the host metric monitors in the example [agent.yaml](./agent.yaml).
+config option to `true` and enable host metric monitors in your configuration.
 
 
 ## Configuration

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -18,14 +18,10 @@ observers:
     labelsToDimensions: &labelMap
       com.amazonaws.ecs.container-name: container_spec_name
 
+# disable sending host dimension for serverless environment
+disableHostDimensions: true
+
 monitors:
-  - type: cpu
-  - type: disk-io
-  - type: net-io
-  - type: load
-  - type: memory
-  - type: collectd/protocols
-  - type: vmem
   # If using SignalFx auto instrumentation with default settings
   - type: signalfx-forwarder
     listenAddress: 0.0.0.0:9080
@@ -36,6 +32,16 @@ monitors:
     # Used to add and override a tag on a span
     #extraSpanTags:
      #SPAN_TAG_KEY: "SPAN_TAG_VALUE"
+
+
+    # disable sending host metrics for serverless environment
+    ##- type: cpu
+    ##- type: disk-io
+    ##- type: net-io
+    ##- type: load
+    ##- type: memory
+    ##- type: collectd/protocols
+    ##- type: vmem
 
   - type: ecs-metadata
     excludedImages:

--- a/deployments/fargate/agent.yaml
+++ b/deployments/fargate/agent.yaml
@@ -32,17 +32,6 @@ monitors:
     # Used to add and override a tag on a span
     #extraSpanTags:
      #SPAN_TAG_KEY: "SPAN_TAG_VALUE"
-
-
-    # disable sending host metrics for serverless environment
-    ##- type: cpu
-    ##- type: disk-io
-    ##- type: net-io
-    ##- type: load
-    ##- type: memory
-    ##- type: collectd/protocols
-    ##- type: vmem
-
   - type: ecs-metadata
     excludedImages:
       - signalfx-agent


### PR DESCRIPTION
We do not want to monitor the underlying hosts in a fargate environment
as it is a serverless environment, and users likely do not want to
unexpectedly monitor these hosts either.