### PR TITLE
Fix integration tests

### DIFF
--- a/.circleci/scripts/setup-integration-tests.sh
+++ b/.circleci/scripts/setup-integration-tests.sh
@@ -31,3 +31,6 @@ echo "export AGENT_BIN='$AGENT_BIN'" >> $BASH_ENV
 echo "export TEST_SERVICES_DIR='$TEST_SERVICES_DIR'" >> $BASH_ENV
 echo "export MARKERS='$MARKERS'" >> $BASH_ENV
 echo "export SPLIT=1" >> $BASH_ENV
+
+sudo apt-get update
+sudo apt-get install -y --only-upgrade ca-certificates

--- a/test-services/postgres/Dockerfile
+++ b/test-services/postgres/Dockerfile
@@ -5,10 +5,10 @@ CMD ["postgres", "-c", "shared_preload_libraries=pg_stat_statements"]
 
 RUN apk add --no-cache unzip wget bash
 WORKDIR /opt
-RUN wget --no-check-certificate https://www.postgresqltutorial.com/wp-content/uploads/2019/05/dvdrental.zip &&\
-    unzip dvdrental.zip &&\
-	tar -xf dvdrental.tar &&\
-	sed -i -e 's/\$\$PATH\$\$/\/opt/' ./restore.sql &&\
-	chmod 777 /opt/*
+RUN wget --no-check-certificate --tries=5 --waitretry=5 https://www.postgresqltutorial.com/wp-content/uploads/2019/05/dvdrental.zip
+RUN unzip dvdrental.zip
+RUN tar -xf dvdrental.tar
+RUN sed -i -e 's/\$\$PATH\$\$/\/opt/' ./restore.sql
+RUN chmod 777 /opt/*
 
 COPY init.sh /docker-entrypoint-initdb.d/

--- a/tests/monitors/jenkins/jenkins_test.py
+++ b/tests/monitors/jenkins/jenkins_test.py
@@ -13,9 +13,6 @@ pytestmark = [pytest.mark.collectd, pytest.mark.jenkins, pytest.mark.monitor_wit
 METRICS_KEY = "33DD8B2F1FD645B814993275703F_EE1FD4D4E204446D5F3200E0F6-C55AC14E"
 
 JENKINS_VERSIONS = [
-    # technically we support 1.580.3, but the scripts needed to programmatically
-    # setup jenkins do not work prior to 1.651.3
-    ("jenkins", "1.651.3-alpine"),
     # TODO: jenkins doesn't have a latest tag so we'll need to update this
     # periodically
     ("jenkins/jenkins", "lts-alpine"),


### PR DESCRIPTION
- Update `ca-certificates` on the circleci executor for the `test_http_all_stats` failure
- Remove version 1.651.3 from jenkins tests since plugins fail to install