### PR TITLE
Better logging for aws metadata

### DIFF
--- a/pkg/core/hostid/aws.go
+++ b/pkg/core/hostid/aws.go
@@ -31,17 +31,11 @@ func AWSUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 
 	client := ec2metadata.New(sess)
 
-	// Checks whether it's an EC2 instance and Metadata service is available.
-	if !client.Available() {
-		log.Debug("No EC2 metadata server detected, assuming not on AWS EC2")
-		return ""
-	}
-
 	doc, err := client.GetInstanceIdentityDocument()
 	if err != nil {
 		log.WithFields(log.Fields{
-			"error": err,
-		}).Error("Failed to get AWS instance-identity")
+			"detail": err,
+		}).Info("No AWS metadata server detected, assuming not on EC2")
 		return ""
 	}
 


### PR DESCRIPTION
Part of the logging in this [change](https://github.com/signalfx/signalfx-agent/commit/8b4d34d8efebe975955390b7b5ce108b3ba317b9#diff-5c32148c814c31d5bd8804f4de667e16e11040ec1e9190a18373e301a1ab772a)  was undone when we converted to use SDK

In this PR, I opted not to use `Available()` as this func does not return the actual error , which is needed for debugging. 

Signed-off-by: Dani Louca <dlouca@splunk.com>