### PR TITLE
Set encoding for ansible/salt test images

### DIFF
--- a/deployments/ansible/Dockerfile
+++ b/deployments/ansible/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
 RUN apt-get update  && \
     apt-get install -y apt-transport-https ca-certificates python3 python3-pip sshpass openssh-client

--- a/tests/deployments/ansible/images/Dockerfile.amazonlinux1
+++ b/tests/deployments/ansible/images/Dockerfile.amazonlinux1
@@ -1,6 +1,8 @@
 FROM amazonlinux:1
 
 ENV container docker
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 RUN yum install -y upstart procps initscripts python36-pip
 RUN pip-3.6 install -U pip==20.3.4

--- a/tests/deployments/ansible/images/Dockerfile.centos7
+++ b/tests/deployments/ansible/images/Dockerfile.centos7
@@ -1,6 +1,8 @@
 FROM centos:7
 
 ENV container docker
+ENV LANG en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 RUN yum install -y systemd procps initscripts python3-pip
 RUN pip3 install -U pip==20.3.4

--- a/tests/deployments/ansible/images/Dockerfile.debian-9-stretch
+++ b/tests/deployments/ansible/images/Dockerfile.debian-9-stretch
@@ -1,5 +1,8 @@
 FROM debian:stretch-slim
 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget libcap2-bin apt-transport-https curl python3-pip python3-paramiko gnupg
 RUN pip3 install -U pip==20.3.4

--- a/tests/deployments/ansible/images/Dockerfile.ubuntu1804
+++ b/tests/deployments/ansible/images/Dockerfile.ubuntu1804
@@ -1,5 +1,8 @@
 FROM ubuntu:18.04
 
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
 RUN apt-get update &&\
     apt-get install -yq ca-certificates procps systemd wget apt-transport-https libcap2-bin curl python3-pip gnupg
 RUN pip3 install -U pip==20.3.4

--- a/tests/deployments/salt/images/Dockerfile.debian-8-jessie
+++ b/tests/deployments/salt/images/Dockerfile.debian-8-jessie
@@ -1,11 +1,14 @@
 FROM debian:jessie-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers curl python-apt python-pip python-dev python-zmq gnupg
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
-RUN pip install msgpack==0.6.2 Jinja2==2.11.3 MarkupSafe==1.1.1
-RUN pip install salt==2019.2
+RUN apt-get update &&\
+    apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers curl python3-apt python3-pip python3-dev python3-zmq gnupg
+
+RUN pip3 install msgpack==0.6.2 Jinja2==2.11.3 MarkupSafe==1.1.1
+RUN pip3 install salt==2019.2
 
 ENV container docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i = \

--- a/tests/deployments/salt/images/Dockerfile.ubuntu1604
+++ b/tests/deployments/salt/images/Dockerfile.ubuntu1604
@@ -1,11 +1,14 @@
 FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update &&\
-    apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers curl python-apt python-pip python-dev python-zmq gnupg
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 
-RUN pip install msgpack==0.6.2 Jinja2==2.11.3 MarkupSafe==1.1.1
-RUN pip install salt==2019.2
+RUN apt-get update &&\
+    apt-get install -yq ca-certificates procps wget apt-transport-https init-system-helpers curl python3-apt python3-pip python3-dev python3-zmq gnupg
+
+RUN pip3 install msgpack==0.6.2 Jinja2==2.11.3 MarkupSafe==1.1.1
+RUN pip3 install salt==2019.2
 
 ENV container docker
 RUN rm -f /lib/systemd/system/multi-user.target.wants/* \


### PR DESCRIPTION
pip fails to install packages for tests unless the encoding is set to utf-8