### PR TITLE
Update rhel image build

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7-atomic
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 ARG AGENT_VERSION="5.15.0"
 LABEL name="SignalFx Smart Agent" \
@@ -22,7 +22,7 @@ CMD ["/usr/bin/signalfx-agent"]
 COPY packaging/rpm/signalfx-agent.repo /etc/yum.repos.d/signalfx-agent.repo
 RUN rpm --import https://splunk.jfrog.io/splunk/signalfx-agent-rpm/splunk-B3CD4420.pub
 
-RUN microdnf install --enablerepo=rhel-7-server-rpms signalfx-agent-${AGENT_VERSION}-1 &&\
+RUN microdnf install signalfx-agent-${AGENT_VERSION}-1 &&\
     microdnf clean all
 
 RUN setcap -r /usr/lib/signalfx-agent/bin/signalfx-agent &&\

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,6 +28,11 @@ point but for now the process is manual.
 1. Ensure you have access to the `o11y-gdi/signalfx-agent-releaser` gitlab
    repo and CI/CD pipeline.
 
+1. Ensure you have access to the Red Hat Container Certification Project, the
+   project ID, and a personal API key.  See [here](
+   https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/appendix/connect-portal-api/project-creation#api-key)
+   for details on how to create a personal API key.
+
 ## Release Process
 
 1. Make sure everything that go out in the release is in the `main` branch.
@@ -136,10 +141,11 @@ point but for now the process is manual.
 1. Build and release the certified RedHat container by running:
 
    ```sh
-   $ scripts/release-redhat <X.Y.Z> <OSPID>
+   $ scripts/release-redhat <X.Y.Z> <PROJECT_ID> <API_KEY>
    ```
 
-1. Wait for the RedHat build to complete and then publish it.
+1. Log into the Red Hat project portal, wait for the image build and scan to
+   complete, publish it, and add the `latest` tag.
 
 1. If the Helm assets have changed then update the repo from `dtools/helm_repo`
    by running (requires S3 access):

--- a/scripts/release-redhat
+++ b/scripts/release-redhat
@@ -11,17 +11,18 @@ set -x
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 usage() {
-  echo "$0 <version> <project_id> [redhat_tag]"
+  echo "$0 <version> <project_id> <api_token> [redhat_tag]"
 }
 
-if [[ "$#" -lt 2 ]]; then
+if [[ "$#" -lt 3 ]]; then
   usage
   exit 1
 fi
 
 version=${1-$(scripts/latest-final-release)}
 project_id=$2
-redhat_tag=${3-$version}
+api_token=$3
+redhat_tag=${4-$version}
 build_branch="redhat-project"
 
 update_dockerfile() {
@@ -39,15 +40,17 @@ update_branch() {
   update_dockerfile
   read -n1 -p "Press key"
 
-  git add Dockerfile.rhel
-  git commit -m "Update RHEL Dockerfile version to $version"
+  if ! git diff --exit-code; then
+    git add Dockerfile.rhel
+    git commit -m "Update RHEL Dockerfile version to $version"
+  fi
   git push -f origin ${build_branch}
 
   popd
 }
 
 trigger_build() {
-  curl -H "Content-Type: application/json" -X POST -d "{\"tag\":\"${redhat_tag}\"}" https://connect.redhat.com/api/v2/projects/${project_id}/build
+  curl -H "Content-Type: application/json" -X POST -d "{\"tag\":\"${redhat_tag}\"}" https://catalog.redhat.com/api/containers/v1/projects/certification/id/${project_id}/requests/builds -H "X-API-KEY: ${api_token}"
 }
 
 update_branch


### PR DESCRIPTION
- Update the base image to `ubi7/ubi-minimal`.  The `rhel7-atomic` image is deprecated and the `rhel-7-server-rpms` dnf repo no longer exists.
- The old api to trigger the image build is also deprecated.  The new api now requires the project ID and a personal API key.