### PR TITLE
remove process_start_time_seconds from default metrics

### DIFF
--- a/docs/monitors/prometheus-go.md
+++ b/docs/monitors/prometheus-go.md
@@ -56,58 +56,49 @@ Configuration](../monitor-config.md#common-configuration).**
 ## Metrics
 
 These are the metrics available for this monitor.
-Metrics that are categorized as
+This monitor emits all metrics by default; however, **none are categorized as
 [container/host](https://docs.signalfx.com/en/latest/admin-guide/usage.html#about-custom-bundled-and-high-resolution-metrics)
-(*default*) are ***in bold and italics*** in the list below.
+-- they are all custom**.
 
 
- - `go_gc_duration_seconds` (*cumulative*)<br>    A summary of the GC invocation durations
- - `go_gc_duration_seconds_bucket` (*cumulative*)<br>    A summary of the GC invocation durations
- - `go_gc_duration_seconds_count` (*cumulative*)<br>    A summary of the GC invocation durations
- - `go_goroutines` (*gauge*)<br>    Number of goroutines that currently exist
- - `go_info` (*gauge*)<br>    Information about the Go environment
- - `go_memstats_alloc_bytes` (*gauge*)<br>    Number of bytes allocated and still in use
- - `go_memstats_alloc_bytes_total` (*cumulative*)<br>    Total number of bytes allocated, even if freed
- - `go_memstats_buck_hash_sys_bytes` (*gauge*)<br>    Number of bytes used by the profiling bucket hash table
- - `go_memstats_frees_total` (*cumulative*)<br>    Total number of frees
- - `go_memstats_gc_cpu_fraction` (*gauge*)<br>    The fraction of this program's available CPU time used by the GC since the program started
- - `go_memstats_gc_sys_bytes` (*gauge*)<br>    Number of bytes used for garbage collection system metadata
- - `go_memstats_heap_alloc_bytes` (*gauge*)<br>    Number of heap bytes allocated and still in use
- - `go_memstats_heap_idle_bytes` (*gauge*)<br>    Number of heap bytes waiting to be used
- - `go_memstats_heap_inuse_bytes` (*gauge*)<br>    Number of heap bytes that are in use
- - `go_memstats_heap_objects` (*gauge*)<br>    Number of allocated objects
- - `go_memstats_heap_released_bytes` (*gauge*)<br>    Number of heap bytes released to OS
- - `go_memstats_heap_sys_bytes` (*gauge*)<br>    Number of heap bytes obtained from system
- - `go_memstats_last_gc_time_seconds` (*gauge*)<br>    Number of seconds since 1970 of last garbage collection
- - `go_memstats_lookups_total` (*cumulative*)<br>    Total number of pointer lookups
- - `go_memstats_mallocs_total` (*cumulative*)<br>    Total number of mallocs
- - `go_memstats_mcache_inuse_bytes` (*gauge*)<br>    Number of bytes in use by mcache structures
- - `go_memstats_mcache_sys_bytes` (*gauge*)<br>    Number of bytes used for mcache structures obtained from system
- - `go_memstats_mspan_inuse_bytes` (*gauge*)<br>    Number of bytes in use by mspan structures
- - `go_memstats_mspan_sys_bytes` (*gauge*)<br>    Number of bytes used for mspan structures obtained from system
- - `go_memstats_next_gc_bytes` (*gauge*)<br>    Number of heap bytes when next garbage collection will take place
- - `go_memstats_other_sys_bytes` (*gauge*)<br>    Number of bytes used for other system allocations
- - `go_memstats_stack_inuse_bytes` (*gauge*)<br>    Number of bytes in use by the stack allocator
- - `go_memstats_stack_sys_bytes` (*gauge*)<br>    Number of bytes obtained from system for stack allocator
- - `go_memstats_sys_bytes` (*gauge*)<br>    Number of bytes obtained from system
- - `go_threads` (*gauge*)<br>    Number of OS threads created
- - `process_cpu_seconds_total` (*cumulative*)<br>    Total user and system CPU time spent in seconds
- - `process_max_fds` (*gauge*)<br>    Maximum number of open file descriptors
- - `process_open_fds` (*gauge*)<br>    Number of open file descriptors
- - `process_resident_memory_bytes` (*gauge*)<br>    Resident memory size in bytes
+ - ***`go_gc_duration_seconds`*** (*cumulative*)<br>    A summary of the GC invocation durations
+ - ***`go_gc_duration_seconds_bucket`*** (*cumulative*)<br>    A summary of the GC invocation durations
+ - ***`go_gc_duration_seconds_count`*** (*cumulative*)<br>    A summary of the GC invocation durations
+ - ***`go_goroutines`*** (*gauge*)<br>    Number of goroutines that currently exist
+ - ***`go_info`*** (*gauge*)<br>    Information about the Go environment
+ - ***`go_memstats_alloc_bytes`*** (*gauge*)<br>    Number of bytes allocated and still in use
+ - ***`go_memstats_alloc_bytes_total`*** (*cumulative*)<br>    Total number of bytes allocated, even if freed
+ - ***`go_memstats_buck_hash_sys_bytes`*** (*gauge*)<br>    Number of bytes used by the profiling bucket hash table
+ - ***`go_memstats_frees_total`*** (*cumulative*)<br>    Total number of frees
+ - ***`go_memstats_gc_cpu_fraction`*** (*gauge*)<br>    The fraction of this program's available CPU time used by the GC since the program started
+ - ***`go_memstats_gc_sys_bytes`*** (*gauge*)<br>    Number of bytes used for garbage collection system metadata
+ - ***`go_memstats_heap_alloc_bytes`*** (*gauge*)<br>    Number of heap bytes allocated and still in use
+ - ***`go_memstats_heap_idle_bytes`*** (*gauge*)<br>    Number of heap bytes waiting to be used
+ - ***`go_memstats_heap_inuse_bytes`*** (*gauge*)<br>    Number of heap bytes that are in use
+ - ***`go_memstats_heap_objects`*** (*gauge*)<br>    Number of allocated objects
+ - ***`go_memstats_heap_released_bytes`*** (*gauge*)<br>    Number of heap bytes released to OS
+ - ***`go_memstats_heap_sys_bytes`*** (*gauge*)<br>    Number of heap bytes obtained from system
+ - ***`go_memstats_last_gc_time_seconds`*** (*gauge*)<br>    Number of seconds since 1970 of last garbage collection
+ - ***`go_memstats_lookups_total`*** (*cumulative*)<br>    Total number of pointer lookups
+ - ***`go_memstats_mallocs_total`*** (*cumulative*)<br>    Total number of mallocs
+ - ***`go_memstats_mcache_inuse_bytes`*** (*gauge*)<br>    Number of bytes in use by mcache structures
+ - ***`go_memstats_mcache_sys_bytes`*** (*gauge*)<br>    Number of bytes used for mcache structures obtained from system
+ - ***`go_memstats_mspan_inuse_bytes`*** (*gauge*)<br>    Number of bytes in use by mspan structures
+ - ***`go_memstats_mspan_sys_bytes`*** (*gauge*)<br>    Number of bytes used for mspan structures obtained from system
+ - ***`go_memstats_next_gc_bytes`*** (*gauge*)<br>    Number of heap bytes when next garbage collection will take place
+ - ***`go_memstats_other_sys_bytes`*** (*gauge*)<br>    Number of bytes used for other system allocations
+ - ***`go_memstats_stack_inuse_bytes`*** (*gauge*)<br>    Number of bytes in use by the stack allocator
+ - ***`go_memstats_stack_sys_bytes`*** (*gauge*)<br>    Number of bytes obtained from system for stack allocator
+ - ***`go_memstats_sys_bytes`*** (*gauge*)<br>    Number of bytes obtained from system
+ - ***`go_threads`*** (*gauge*)<br>    Number of OS threads created
+ - ***`process_cpu_seconds_total`*** (*cumulative*)<br>    Total user and system CPU time spent in seconds
+ - ***`process_max_fds`*** (*gauge*)<br>    Maximum number of open file descriptors
+ - ***`process_open_fds`*** (*gauge*)<br>    Number of open file descriptors
+ - ***`process_resident_memory_bytes`*** (*gauge*)<br>    Resident memory size in bytes
  - ***`process_start_time_seconds`*** (*gauge*)<br>    Start time of the process since unix epoch in seconds
- - `process_virtual_memory_bytes` (*gauge*)<br>    Virtual memory size in bytes
- - `process_virtual_memory_max_bytes` (*gauge*)<br>    Maximum amount of virtual memory available in bytes
-
-### Non-default metrics (version 4.7.0+)
-
-To emit metrics that are not _default_, you can add those metrics in the
-generic monitor-level `extraMetrics` config option.  Metrics that are derived
-from specific configuration options that do not appear in the above list of
-metrics do not need to be added to `extraMetrics`.
-
-To see a list of metrics that will be emitted you can run `agent-status
-monitors` after configuring this monitor in a running agent instance.
-
+ - ***`process_virtual_memory_bytes`*** (*gauge*)<br>    Virtual memory size in bytes
+ - ***`process_virtual_memory_max_bytes`*** (*gauge*)<br>    Maximum amount of virtual memory available in bytes
+The agent does not do any built-in filtering of metrics coming out of this
+monitor.
 
 

--- a/docs/monitors/traefik.md
+++ b/docs/monitors/traefik.md
@@ -140,7 +140,7 @@ Metrics that are categorized as
  - `process_max_fds` (*gauge*)<br>    Maximum number of open file descriptors.
  - `process_open_fds` (*gauge*)<br>    Number of open file descriptors.
  - `process_resident_memory_bytes` (*gauge*)<br>    Resident memory size in bytes.
- - ***`process_start_time_seconds`*** (*gauge*)<br>    Start time of the process since unix epoch in seconds.
+ - `process_start_time_seconds` (*gauge*)<br>    Start time of the process since unix epoch in seconds.
  - `process_virtual_memory_bytes` (*gauge*)<br>    Virtual memory size in bytes.
  - ***`traefik_backend_open_connections`*** (*gauge*)<br>    How many open connections exist on a backend, partitioned by method and protocol.
  - `traefik_backend_request_duration_seconds_bucket` (*cumulative*)<br>    The sum of request durations that are within a configured time interval. The request durations are measured at a backend in seconds. This value is partitioned by status code, protocol, and method.

--- a/pkg/monitors/prometheus/go/genmetadata.go
+++ b/pkg/monitors/prometheus/go/genmetadata.go
@@ -91,9 +91,7 @@ var metricSet = map[string]monitors.MetricInfo{
 	processVirtualMemoryMaxBytes: {Type: datapoint.Gauge},
 }
 
-var defaultMetrics = map[string]bool{
-	processStartTimeSeconds: true,
-}
+var defaultMetrics = map[string]bool{}
 
 var groupMetricsMap = map[string][]string{}
 
@@ -104,5 +102,5 @@ var monitorMetadata = monitors.Metadata{
 	SendUnknown:     false,
 	Groups:          groupSet,
 	GroupMetricsMap: groupMetricsMap,
-	SendAll:         false,
+	SendAll:         true,
 }

--- a/pkg/monitors/prometheus/go/metadata.yaml
+++ b/pkg/monitors/prometheus/go/metadata.yaml
@@ -9,6 +9,7 @@ monitors:
     metrics from a Prometheus exporter and sends them to SignalFx.  It is a
     wrapper around the [prometheus-exporter](./prometheus-exporter.md) monitor
     that provides a restricted but expandable set of metrics.
+  sendAll: true
   metrics:
     go_gc_duration_seconds:
       description: A summary of the GC invocation durations
@@ -149,7 +150,7 @@ monitors:
       type: gauge
     process_start_time_seconds:
       description: Start time of the process since unix epoch in seconds
-      default: true
+      default: false
       type: gauge
     process_virtual_memory_bytes:
       description: Virtual memory size in bytes

--- a/pkg/monitors/traefik/genmetadata.go
+++ b/pkg/monitors/traefik/genmetadata.go
@@ -118,7 +118,6 @@ var metricSet = map[string]monitors.MetricInfo{
 }
 
 var defaultMetrics = map[string]bool{
-	processStartTimeSeconds:                      true,
 	traefikBackendOpenConnections:                true,
 	traefikBackendRequestDurationSecondsSum:      true,
 	traefikBackendRequestsTotal:                  true,

--- a/pkg/monitors/traefik/metadata.yaml
+++ b/pkg/monitors/traefik/metadata.yaml
@@ -230,7 +230,7 @@ monitors:
       type: gauge
     process_start_time_seconds:
       description: Start time of the process since unix epoch in seconds.
-      default: true
+      default: false
       type: gauge
     process_virtual_memory_bytes:
       description: Virtual memory size in bytes.

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -44819,7 +44819,7 @@
     },
     {
       "monitorType": "prometheus/go",
-      "sendAll": false,
+      "sendAll": true,
       "sendUnknown": false,
       "noneIncluded": false,
       "dimensions": null,
@@ -45077,7 +45077,7 @@
           "type": "gauge",
           "description": "Start time of the process since unix epoch in seconds",
           "group": null,
-          "default": true
+          "default": false
         },
         "process_virtual_memory_bytes": {
           "type": "gauge",
@@ -54603,7 +54603,7 @@
           "type": "gauge",
           "description": "Start time of the process since unix epoch in seconds.",
           "group": null,
-          "default": true
+          "default": false
         },
         "process_virtual_memory_bytes": {
           "type": "gauge",


### PR DESCRIPTION
`process_start_time_seconds` is a generic prometheus metric and not application specific. It does not need to be sent by default.