### PR TITLE
Fix cert validation

### DIFF
--- a/pkg/monitors/http/http.go
+++ b/pkg/monitors/http/http.go
@@ -3,7 +3,6 @@ package http
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -131,7 +130,7 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 					}
 				}
 			} else {
-				logger.WithError(err).Error("Failed gathering HTTP stats, ignore other stats")
+				logger.WithError(err).Error("Failed gathering all HTTP stats, ignore TLS stats and push what we've successfully collected")
 			}
 
 			for i := range dps {
@@ -214,15 +213,20 @@ func (m *Monitor) getTLSStats(site *url.URL, logger *logrus.Entry) (dps []*datap
 		serverName = host
 	}
 
+	dimensions := map[string]string{
+		"server_name":     host,
+		"sni_server_name": serverName,
+	}
+
 	ipConn, err := net.Dial("tcp", host+":"+port)
 	if err != nil {
+		logger.WithError(err).Error("connection failed to host during TLS stat collection")
 		return
 	}
 	defer ipConn.Close()
 
 	tlsCfg := &tls.Config{
-		InsecureSkipVerify: m.conf.SkipVerify,
-		ServerName:         serverName,
+		ServerName: serverName,
 	}
 
 	if _, err := auth.TLSConfig(tlsCfg, m.conf.CACertPath, m.conf.ClientCertPath, m.conf.ClientKeyPath); err != nil {
@@ -237,34 +241,11 @@ func (m *Monitor) getTLSStats(site *url.URL, logger *logrus.Entry) (dps []*datap
 
 	err = conn.Handshake()
 	if err != nil {
-		logger.WithError(err).Error("failed during handshake")
+		logger.WithError(err).Debug("cert verification failed during handshake")
 		valid = 0
-	}
-
-	certs := conn.ConnectionState().PeerCertificates
-	for i, cert := range certs {
-		opts := x509.VerifyOptions{
-			Intermediates: x509.NewCertPool(),
-		}
-		if i == 0 {
-			opts.DNSName = serverName
-			for j, cert := range certs {
-				if j != 0 {
-					opts.Intermediates.AddCert(cert)
-				}
-			}
-			secondsLeft = time.Until(cert.NotAfter).Seconds()
-		}
-		_, err := cert.Verify(opts)
-		if err != nil {
-			logger.WithError(err).Debug("failed verify certificate")
-			valid = 0
-		}
-	}
-
-	dimensions := map[string]string{
-		"server_name":     host,
-		"sni_server_name": serverName,
+	} else {
+		cert := conn.ConnectionState().PeerCertificates[0]
+		secondsLeft = time.Until(cert.NotAfter).Seconds()
 	}
 
 	dps = append(dps,


### PR DESCRIPTION
The current code fails to validate intermediate cert that has an expired root cert that is part of the trust store, example: `DST root ca` https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/
example, run the monitor against `letsencrypt.org` and the cert validation will fail, whereas it passes with openssl and chrome.

The problem with the current logic is that it verifies every cert in the chain "independently", so when it reaches the last CA in the chain , in our example: "ISRG Root CA" , the verification func fails to build a chain > 0 with a cert from the trust store as the CA for ISRG is DST which is expired .

The other problem, the current logic does not count for certs with multiple intermediate chains.

I discussed this issue with @keitwb and we decided that it made sense to simply use the client to do the validation, as it covers all those corner cases.

I changed the code to count on `Handshake` to set the TLS stats 

@xp-1000 please take a look


Signed-off-by: Dani Louca <dlouca@splunk.com>