### PR TITLE
Remove win2016 image from azure devops

### DIFF
--- a/.azure-pipelines/config.yml
+++ b/.azure-pipelines/config.yml
@@ -43,7 +43,7 @@ jobs:
 
 - job: 'win_go_build'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - template: 'templates/install-go.yml'
     parameters:
@@ -59,7 +59,7 @@ jobs:
 
 - job: 'win_go_test'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - template: 'templates/install-go.yml'
     parameters:
@@ -101,7 +101,7 @@ jobs:
 
 - job: 'win_bundle_build'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - template: 'templates/install-go.yml'
     parameters:
@@ -160,9 +160,9 @@ jobs:
       # Install IIS for windows-iis integration test.
       chocoPackages: '--source windowsfeatures IIS-WebServerRole'
 
-- job: 'win_2016_integration_tests'
+- job: 'win_2022_integration_tests'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   dependsOn: 'win_bundle_build'
   steps:
   - template: 'templates/extract-bundle.yml'
@@ -182,9 +182,9 @@ jobs:
       markers: 'chef and windows_only'
       changesInclude: 'deployments/chef tests/deployments/chef tests/packaging/common.py .azure-pipelines'
 
-- job: 'win_2016_chef_tests'
+- job: 'win_2022_chef_tests'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   steps:
   - template: 'templates/run-pytest.yml'
     parameters:
@@ -200,9 +200,9 @@ jobs:
       markers: 'puppet and windows_only'
       changesInclude: 'deployments/puppet tests/deployments/puppet tests/packaging/common.py .azure-pipelines'
 
-- job: 'win_2016_puppet_tests'
+- job: 'win_2022_puppet_tests'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   steps:
   - template: 'templates/run-pytest.yml'
     parameters:
@@ -223,9 +223,9 @@ jobs:
       markers: 'installer and windows_only'
       changesInclude: 'deployments/installer tests/packaging scripts/windows .azure-pipelines'
 
-- job: 'win_2016_installer_tests'
+- job: 'win_2022_installer_tests'
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2022'
   dependsOn: 'win_bundle_build'
   steps:
   - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
Windows 2016 will be removed: https://github.com/actions/virtual-environments/issues/4312.

Replace image with Windows 2019 and add tests for Windows 2022.