### PR TITLE
[monitor/processlist] Fix process status in windows

### DIFF
--- a/pkg/monitors/processlist/processlist_windows_test.go
+++ b/pkg/monitors/processlist/processlist_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package processlist
@@ -18,6 +19,7 @@ func TestMonitor_Configure(t *testing.T) {
 		name       string
 		m          *Monitor
 		processes  []Win32Process
+		threads    []Win32Thread
 		cpuPercent map[uint32]uint64
 		usernames  map[uint32]string
 		want       *event.Event
@@ -56,6 +58,16 @@ func TestMonitor_Configure(t *testing.T) {
 					VirtualSize:    1900,
 				},
 			},
+			threads: []Win32Thread{
+				{
+					ThreadState:   3,
+					ProcessHandle: "1",
+				},
+				{
+					ThreadState:   5,
+					ProcessHandle: "0",
+				},
+			},
 			usernames: map[uint32]string{
 				0: "tedMosby",
 				1: "barneyStinson",
@@ -65,7 +77,7 @@ func TestMonitor_Configure(t *testing.T) {
 				Category:   event.AGENT,
 				Dimensions: map[string]string{},
 				Properties: map[string]interface{}{
-					"message": "{\"t\":\"eJyqVjJQsopWKklN8c0vTqpU0rHQUSrNy87LL89T0jHUMdQx0FFS0jHQMzCAEEoGBlYGIJaSjpKzVUyMR2pOTn54flFOil5qRapSrI6SIci8pMSivNTK4JLMvOL8PAoMNYKYWgsIAAD//+q6LfA=\",\"v\":\"0.0.30\"}",
+					"message": "{\"t\":\"eJyqVjJQsopWKklN8c0vTqpU0rHQUSrNy87LL89T0jHUMdQx0FEKVtIx0DMwgBBKBgZWBiCWko6Ss1VMjEdqTk5+eH5RTopeakWqUqyOkiHIwKTEorzUyuCSzLzi/DyspgYRZ6oRxNhaQAAAAP//UTMulQ==\",\"v\":\"0.0.30\"}",
 				},
 			},
 		},
@@ -88,6 +100,12 @@ func TestMonitor_Configure(t *testing.T) {
 					VirtualSize:    1900,
 				},
 			},
+			threads: []Win32Thread{
+				{
+					ThreadState:   5,
+					ProcessHandle: "0",
+				},
+			},
 			usernames: map[uint32]string{
 				0: "ted\"bud\"Mosby",
 			},
@@ -96,7 +114,7 @@ func TestMonitor_Configure(t *testing.T) {
 				Category:   event.AGENT,
 				Dimensions: map[string]string{},
 				Properties: map[string]interface{}{
-					"message": "{\"t\":\"eJyqVjJQsopWKklNUU8qTVH3zS9OqlTSsdBRKs3Lzssvz1PSMdQx1DHQUVLSMdAzMIAQSgYGVgYglpKOkrNVTIxHak5Ofnh+UU6KkXphaT7IML3UilSl2FpAAAAA///fVRrM\",\"v\":\"0.0.30\"}",
+					"message": "{\"t\":\"eJyqVjJQsopWKklNUU8qTVH3zS9OqlTSsdBRKs3Lzssvz1PSMdQx1DHQUQpW0jHQMzCAEEoGBlYGIJaSjpKzVUyMR2pOTn54flFOipF6YWk+yDS91IpUpdhaQAAAAP///QsbHw==\",\"v\":\"0.0.30\"}",
 				},
 			},
 		},
@@ -104,6 +122,7 @@ func TestMonitor_Configure(t *testing.T) {
 	for i := range tests {
 		origGetAllProcesses := getAllProcesses
 		origGetUsername := getUsername
+		origGetAllThreads := getAllThreads
 
 		tt := tests[i]
 
@@ -117,6 +136,9 @@ func TestMonitor_Configure(t *testing.T) {
 					t.Error("unable to find username")
 				}
 				return username, nil
+			}
+			getAllThreads = func() ([]Win32Thread, error) {
+				return tt.threads, nil
 			}
 			if err := tt.m.Configure(&Config{config.MonitorConfig{IntervalSeconds: 10}}); (err != nil) != tt.wantErr {
 				t.Errorf("Monitor.Configure() error = %v, wantErr %v", err, tt.wantErr)
@@ -141,5 +163,93 @@ func TestMonitor_Configure(t *testing.T) {
 		})
 		getAllProcesses = origGetAllProcesses
 		getUsername = origGetUsername
+		getAllThreads = origGetAllThreads
+	}
+}
+
+func TestMapThreadsToProcess(t *testing.T) {
+	type args struct {
+		threadList []Win32Thread
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string][]uint32
+	}{
+		{
+			name: "check correct mapping",
+			args: args{
+				threadList: []Win32Thread{
+					{ProcessHandle: "2", ThreadState: 3},
+				},
+			},
+			want: map[string][]uint32{
+				"2": {3},
+			},
+		},
+		{
+			name: "check correct mapping 2",
+			args: args{
+				threadList: []Win32Thread{
+					{ProcessHandle: "1", ThreadState: 3},
+					{ProcessHandle: "2", ThreadState: 3},
+					{ProcessHandle: "1", ThreadState: 5},
+					{ProcessHandle: "1", ThreadState: 5},
+				},
+			},
+			want: map[string][]uint32{
+				"1": {3, 5, 5},
+				"2": {3},
+			},
+		},
+	}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mapThreadsToProcess(tt.args.threadList); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mapThreadsToProcess() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStatusMapping(t *testing.T) {
+	type args struct {
+		threadStates []uint32
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "running process",
+			args: args{
+				threadStates: []uint32{5, 5, 5, 5, 2, 5},
+			},
+			want: "R",
+		},
+		{
+			name: "waiting process",
+			args: args{
+				threadStates: []uint32{5, 5, 5, 5, 5, 5},
+			},
+			want: "S",
+		},
+		{
+			name: "empty list",
+			args: args{
+				threadStates: []uint32{},
+			},
+			want: "",
+		},
+	}
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			if got := statusMapping(tt.args.threadStates); got != tt.want {
+				t.Errorf("statusMapping() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**Description**:- 
Fixed process status in windows. We are determining the process status depending upon the state of threads as the [process](https://docs.microsoft.com/en-us/windows/win32/cimwin32prov/win32-process)' WMI query does not return status. If all the threads are in the waiting state then the process status will be “S” (sleeping) otherwise it will be “R” (running).

**Testing**:-

- Added unit tests as per new changes.
- Tested on `windows server 2012`
 