### PR TITLE
Fix ansible-lint failure

### DIFF
--- a/deployments/ansible/Dockerfile
+++ b/deployments/ansible/Dockerfile
@@ -5,10 +5,10 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 RUN apt-get update  && \
-    apt-get install -y apt-transport-https ca-certificates python3 python3-pip sshpass openssh-client
+    apt-get install -y apt-transport-https ca-certificates python3 python3-pip sshpass openssh-client git
 
 RUN pip3 install --upgrade pip==20.3.1
-RUN pip3 install --upgrade ansible==3.0.0 ansible-lint==5.0.0
+RUN pip3 install --upgrade ansible==3.0.0 ansible-lint==5.3.2
 
 RUN mkdir -p /etc/ansible && \
     echo 'localhost' > /etc/ansible/hosts


### PR DESCRIPTION
Upgrade ansible-lint to 5.3.2 for https://github.com/ansible-community/ansible-lint/issues/1795.