### PR TITLE
add storage metrics for varnish

### DIFF
--- a/docs/monitors/telegraf-varnish.md
+++ b/docs/monitors/telegraf-varnish.md
@@ -45,7 +45,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | --- | --- | --- | --- |
 | `useSudo` | no | `bool` | If running as a restricted user enable this flag to prepend sudo. (**default:** `false`) |
 | `binary` | no | `string` | The location of the varnishstat binary. (**default:** `/usr/bin/varnishstat`) |
-| `stats` | no | `list of strings` | Which stats to gather. Glob matching can be used (i.e. `stats = ["MAIN.*"]`). Stats []string `yaml:"stats" default:"[\"MAIN.cache_hit\", \"MAIN.cache_miss\", \"MAIN.uptime\"]"` (**default:** `[MAIN.*]`) |
+| `stats` | no | `list of strings` | Which stats to gather. Glob matching can be used (i.e. `stats = ["MAIN.*", "SMA.*"]`). Be careful, if you extend collected stats you will have to set `extraMetrics: ["*"]` too. (**default:** `[MAIN.* SMA.s0.g_bytes.* SMA.s0.g_space.*]`) |
 | `instanceName` | no | `string` | Optional name for the varnish instance to query. It corresponds to `-n` parameter value. |
 
 
@@ -70,6 +70,8 @@ Metrics that are categorized as
  - ***`varnish.cache_miss`*** (*cumulative*)<br>    Requests fetched from a backend server.
  - ***`varnish.client_req`*** (*cumulative*)<br>    Good client requests.
  - `varnish.n_lru_nuked` (*cumulative*)<br>    Objects forcefully evicted from the cache because of a lack of space.
+ - ***`varnish.s0.g_bytes`*** (*gauge*)<br>    Space allocated from the storage.
+ - ***`varnish.s0.g_space`*** (*gauge*)<br>    Space left in the storage.
  - ***`varnish.sess_dropped`*** (*gauge*)<br>    Sessions dropped due to a full queue.
  - ***`varnish.sess_queued`*** (*gauge*)<br>    Client connections queued to wait for a thread..
  - ***`varnish.thread_queue_len`*** (*gauge*)<br>    Length of session queue waiting for threads.

--- a/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
+++ b/pkg/monitors/telegraf/monitors/varnish/genmetadata.go
@@ -25,6 +25,8 @@ const (
 	varnishCacheMiss        = "varnish.cache_miss"
 	varnishClientReq        = "varnish.client_req"
 	varnishNLruNuked        = "varnish.n_lru_nuked"
+	varnishS0GBytes         = "varnish.s0.g_bytes"
+	varnishS0GSpace         = "varnish.s0.g_space"
 	varnishSessDropped      = "varnish.sess_dropped"
 	varnishSessQueued       = "varnish.sess_queued"
 	varnishThreadQueueLen   = "varnish.thread_queue_len"
@@ -48,6 +50,8 @@ var metricSet = map[string]monitors.MetricInfo{
 	varnishCacheMiss:        {Type: datapoint.Counter},
 	varnishClientReq:        {Type: datapoint.Counter},
 	varnishNLruNuked:        {Type: datapoint.Counter},
+	varnishS0GBytes:         {Type: datapoint.Gauge},
+	varnishS0GSpace:         {Type: datapoint.Gauge},
 	varnishSessDropped:      {Type: datapoint.Gauge},
 	varnishSessQueued:       {Type: datapoint.Gauge},
 	varnishThreadQueueLen:   {Type: datapoint.Gauge},
@@ -64,6 +68,8 @@ var defaultMetrics = map[string]bool{
 	varnishCacheHit:         true,
 	varnishCacheMiss:        true,
 	varnishClientReq:        true,
+	varnishS0GBytes:         true,
+	varnishS0GSpace:         true,
 	varnishSessDropped:      true,
 	varnishSessQueued:       true,
 	varnishThreadQueueLen:   true,

--- a/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
+++ b/pkg/monitors/telegraf/monitors/varnish/metadata.yaml
@@ -101,6 +101,14 @@ monitors:
       description: Number of requests to the backend.
       default: true
       type: cumulative
+    varnish.s0.g_bytes:
+      description: Space allocated from the storage.
+      default: true
+      type: gauge
+    varnish.s0.g_space:
+      description: Space left in the storage.
+      default: true
+      type: gauge
   monitorType: telegraf/varnish
   sendAll: false
   properties:

--- a/pkg/monitors/telegraf/monitors/varnish/varnish.go
+++ b/pkg/monitors/telegraf/monitors/varnish/varnish.go
@@ -30,9 +30,9 @@ type Config struct {
 	UseSudo bool `yaml:"useSudo" default:"false"`
 	// The location of the varnishstat binary.
 	Binary string `yaml:"binary" default:"/usr/bin/varnishstat"`
-	// Which stats to gather. Glob matching can be used (i.e. `stats = ["MAIN.*"]`).
-	//Stats []string `yaml:"stats" default:"[\"MAIN.cache_hit\", \"MAIN.cache_miss\", \"MAIN.uptime\"]"`
-	Stats []string `yaml:"stats" default:"[\"MAIN.*\"]"`
+	// Which stats to gather. Glob matching can be used (i.e. `stats = ["MAIN.*", "SMA.*"]`).
+	// Be careful, if you extend collected stats you will have to set `extraMetrics: ["*"]` too.
+	Stats []string `yaml:"stats" default:"[\"MAIN.*\", \"SMA.s0.g_bytes.*\", \"SMA.s0.g_space.*\"]"`
 	// Optional name for the varnish instance to query. It corresponds to `-n` parameter value.
 	InstanceName string `yaml:"instanceName"`
 }

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -53943,6 +53943,8 @@
             "varnish.cache_miss",
             "varnish.client_req",
             "varnish.n_lru_nuked",
+            "varnish.s0.g_bytes",
+            "varnish.s0.g_space",
             "varnish.sess_dropped",
             "varnish.sess_queued",
             "varnish.thread_queue_len",
@@ -54032,6 +54034,18 @@
           "group": null,
           "default": false
         },
+        "varnish.s0.g_bytes": {
+          "type": "gauge",
+          "description": "Space allocated from the storage.",
+          "group": null,
+          "default": true
+        },
+        "varnish.s0.g_space": {
+          "type": "gauge",
+          "description": "Space left in the storage.",
+          "group": null,
+          "default": true
+        },
         "varnish.sess_dropped": {
           "type": "gauge",
           "description": "Sessions dropped due to a full queue.",
@@ -54099,9 +54113,11 @@
           },
           {
             "yamlName": "stats",
-            "doc": "Which stats to gather. Glob matching can be used (i.e. `stats = [\"MAIN.*\"]`). Stats []string `yaml:\"stats\" default:\"[\\\"MAIN.cache_hit\\\", \\\"MAIN.cache_miss\\\", \\\"MAIN.uptime\\\"]\"`",
+            "doc": "Which stats to gather. Glob matching can be used (i.e. `stats = [\"MAIN.*\", \"SMA.*\"]`). Be careful, if you extend collected stats you will have to set `extraMetrics: [\"*\"]` too.",
             "default": [
-              "MAIN.*"
+              "MAIN.*",
+              "SMA.s0.g_bytes.*",
+              "SMA.s0.g_space.*"
             ],
             "required": false,
             "type": "slice",


### PR DESCRIPTION
Hello,

Adding 2 important metrics which deserve to be default in my opinion but I can set to false if you prefer.
The PR remains useful because it, at least, add them to metadata so it allow us to add them as extreMetrics explicitly (without to have to set `extraMetrics: ["*"]` and use filtering after.