### PR TITLE
Added and updated coredns metrics for metric name changes in coredns-1.7.0-release

### DIFF
--- a/docs/monitors/coredns.md
+++ b/docs/monitors/coredns.md
@@ -67,10 +67,11 @@ Metrics that are categorized as
 
 
  - `coredns_build_info` (*gauge*)<br>    A metric with a constant '1' value labeled by version, revision, and goversion from which CoreDNS was built.
+ - ***`coredns_cache_entries`*** (*cumulative*)<br>    Size of DNS cache.
  - `coredns_cache_hits_total` (*cumulative*)<br>    The count of cache misses.
  - `coredns_cache_misses_total` (*cumulative*)<br>    The count of cache misses.
- - ***`coredns_cache_size`*** (*cumulative*)<br>    Size of DNS cache.
- - ***`coredns_dns_request_count_total`*** (*cumulative*)<br>    Counter of DNS requests made per zone, protocol and family.
+ - ***`coredns_cache_size`*** (*cumulative*)<br>    Deprecated in coredns version 1.7.0. Size of DNS cache.
+ - ***`coredns_dns_request_count_total`*** (*cumulative*)<br>    Deprecated in coredns version 1.7.0. Counter of DNS requests made per zone, protocol and family.
  - `coredns_dns_request_duration_seconds` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (sum)
  - `coredns_dns_request_duration_seconds_bucket` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (bucket)
  - `coredns_dns_request_duration_seconds_count` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (count)
@@ -78,14 +79,17 @@ Metrics that are categorized as
  - `coredns_dns_request_size_bytes_bucket` (*cumulative*)<br>    Size of the EDNS0 UDP buffer in bytes (64K for TCP). (bucket)
  - `coredns_dns_request_size_bytes_count` (*cumulative*)<br>    Size of the EDNS0 UDP buffer in bytes (64K for TCP). (count)
  - ***`coredns_dns_request_type_count_total`*** (*cumulative*)<br>    Counter of DNS requests per type, per zone.
- - ***`coredns_dns_response_rcode_count_total`*** (*cumulative*)<br>    Counter of response status codes.
+ - ***`coredns_dns_requests_total`*** (*cumulative*)<br>    Counter of DNS requests made per zone, protocol and family.
+ - ***`coredns_dns_response_rcode_count_total`*** (*cumulative*)<br>    Deprecated in coredns version 1.7.0. Counter of response status codes.
  - `coredns_dns_response_size_bytes` (*cumulative*)<br>    Size of the returned response in bytes. (sum)
  - `coredns_dns_response_size_bytes_bucket` (*cumulative*)<br>    Size of the returned response in bytes. (bucket)
  - `coredns_dns_response_size_bytes_count` (*cumulative*)<br>    Size of the returned response in bytes. (count)
+ - ***`coredns_dns_responses_total`*** (*cumulative*)<br>    Counter of response status codes.
  - `coredns_health_request_duration_seconds` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (sum)
  - `coredns_health_request_duration_seconds_bucket` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (bucket)
  - `coredns_health_request_duration_seconds_count` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (count)
- - `coredns_panic_count_total` (*cumulative*)<br>    A metrics that counts the number of panics.
+ - `coredns_panic_count_total` (*cumulative*)<br>    Deprecated in coredns version 1.7.0. A metrics that counts the number of panics.
+ - `coredns_panics_total` (*cumulative*)<br>    A metrics that counts the number of panics.
  - `coredns_proxy_request_count_total` (*cumulative*)<br>    Counter of requests made per protocol, proxy protocol, family and upstream.
  - `coredns_proxy_request_duration_seconds` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (sum)
  - `coredns_proxy_request_duration_seconds_bucket` (*cumulative*)<br>    Histogram of the time (in seconds) each request took. (bucket)

--- a/pkg/monitors/coredns/genmetadata.go
+++ b/pkg/monitors/coredns/genmetadata.go
@@ -13,6 +13,7 @@ var groupSet = map[string]bool{}
 
 const (
 	corednsBuildInfo                          = "coredns_build_info"
+	corednsCacheEntries                       = "coredns_cache_entries"
 	corednsCacheHitsTotal                     = "coredns_cache_hits_total"
 	corednsCacheMissesTotal                   = "coredns_cache_misses_total"
 	corednsCacheSize                          = "coredns_cache_size"
@@ -24,14 +25,17 @@ const (
 	corednsDNSRequestSizeBytesBucket          = "coredns_dns_request_size_bytes_bucket"
 	corednsDNSRequestSizeBytesCount           = "coredns_dns_request_size_bytes_count"
 	corednsDNSRequestTypeCountTotal           = "coredns_dns_request_type_count_total"
+	corednsDNSRequestsTotal                   = "coredns_dns_requests_total"
 	corednsDNSResponseRcodeCountTotal         = "coredns_dns_response_rcode_count_total"
 	corednsDNSResponseSizeBytes               = "coredns_dns_response_size_bytes"
 	corednsDNSResponseSizeBytesBucket         = "coredns_dns_response_size_bytes_bucket"
 	corednsDNSResponseSizeBytesCount          = "coredns_dns_response_size_bytes_count"
+	corednsDNSResponsesTotal                  = "coredns_dns_responses_total"
 	corednsHealthRequestDurationSeconds       = "coredns_health_request_duration_seconds"
 	corednsHealthRequestDurationSecondsBucket = "coredns_health_request_duration_seconds_bucket"
 	corednsHealthRequestDurationSecondsCount  = "coredns_health_request_duration_seconds_count"
 	corednsPanicCountTotal                    = "coredns_panic_count_total"
+	corednsPanicsTotal                        = "coredns_panics_total"
 	corednsProxyRequestCountTotal             = "coredns_proxy_request_count_total"
 	corednsProxyRequestDurationSeconds        = "coredns_proxy_request_duration_seconds"
 	corednsProxyRequestDurationSecondsBucket  = "coredns_proxy_request_duration_seconds_bucket"
@@ -73,6 +77,7 @@ const (
 
 var metricSet = map[string]monitors.MetricInfo{
 	corednsBuildInfo:                          {Type: datapoint.Gauge},
+	corednsCacheEntries:                       {Type: datapoint.Counter},
 	corednsCacheHitsTotal:                     {Type: datapoint.Counter},
 	corednsCacheMissesTotal:                   {Type: datapoint.Counter},
 	corednsCacheSize:                          {Type: datapoint.Counter},
@@ -84,14 +89,17 @@ var metricSet = map[string]monitors.MetricInfo{
 	corednsDNSRequestSizeBytesBucket:          {Type: datapoint.Counter},
 	corednsDNSRequestSizeBytesCount:           {Type: datapoint.Counter},
 	corednsDNSRequestTypeCountTotal:           {Type: datapoint.Counter},
+	corednsDNSRequestsTotal:                   {Type: datapoint.Counter},
 	corednsDNSResponseRcodeCountTotal:         {Type: datapoint.Counter},
 	corednsDNSResponseSizeBytes:               {Type: datapoint.Counter},
 	corednsDNSResponseSizeBytesBucket:         {Type: datapoint.Counter},
 	corednsDNSResponseSizeBytesCount:          {Type: datapoint.Counter},
+	corednsDNSResponsesTotal:                  {Type: datapoint.Counter},
 	corednsHealthRequestDurationSeconds:       {Type: datapoint.Counter},
 	corednsHealthRequestDurationSecondsBucket: {Type: datapoint.Counter},
 	corednsHealthRequestDurationSecondsCount:  {Type: datapoint.Counter},
 	corednsPanicCountTotal:                    {Type: datapoint.Counter},
+	corednsPanicsTotal:                        {Type: datapoint.Counter},
 	corednsProxyRequestCountTotal:             {Type: datapoint.Counter},
 	corednsProxyRequestDurationSeconds:        {Type: datapoint.Counter},
 	corednsProxyRequestDurationSecondsBucket:  {Type: datapoint.Counter},
@@ -132,11 +140,14 @@ var metricSet = map[string]monitors.MetricInfo{
 }
 
 var defaultMetrics = map[string]bool{
+	corednsCacheEntries:               true,
 	corednsCacheSize:                  true,
 	corednsDNSRequestCountTotal:       true,
 	corednsDNSRequestSizeBytes:        true,
 	corednsDNSRequestTypeCountTotal:   true,
+	corednsDNSRequestsTotal:           true,
 	corednsDNSResponseRcodeCountTotal: true,
+	corednsDNSResponsesTotal:          true,
 }
 
 var groupMetricsMap = map[string][]string{}

--- a/pkg/monitors/coredns/metadata.yaml
+++ b/pkg/monitors/coredns/metadata.yaml
@@ -22,6 +22,10 @@ monitors:
       description: A metric with a constant '1' value labeled by version, revision,
         and goversion from which CoreDNS was built.
       type: gauge
+    coredns_cache_entries:
+      default: true
+      description: Size of DNS cache.
+      type: cumulative
     coredns_cache_hits_total:
       default: false
       description: The count of cache misses.
@@ -32,9 +36,13 @@ monitors:
       type: cumulative
     coredns_cache_size:
       default: true
-      description: Size of DNS cache.
+      description: Deprecated in coredns version 1.7.0. Size of DNS cache.
       type: cumulative
     coredns_dns_request_count_total:
+      default: true
+      description: Deprecated in coredns version 1.7.0. Counter of DNS requests made per zone, protocol and family.
+      type: cumulative
+    coredns_dns_requests_total:
       default: true
       description: Counter of DNS requests made per zone, protocol and family.
       type: cumulative
@@ -68,6 +76,10 @@ monitors:
       type: cumulative
     coredns_dns_response_rcode_count_total:
       default: true
+      description: Deprecated in coredns version 1.7.0. Counter of response status codes.
+      type: cumulative
+    coredns_dns_responses_total:
+      default: true
       description: Counter of response status codes.
       type: cumulative
     coredns_dns_response_size_bytes_count:
@@ -95,6 +107,10 @@ monitors:
       description: Histogram of the time (in seconds) each request took. (bucket)
       type: cumulative
     coredns_panic_count_total:
+      default: false
+      description: Deprecated in coredns version 1.7.0. A metrics that counts the number of panics.
+      type: cumulative
+    coredns_panics_total:
       default: false
       description: A metrics that counts the number of panics.
       type: cumulative

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -23089,6 +23089,7 @@
           "description": "",
           "metrics": [
             "coredns_build_info",
+            "coredns_cache_entries",
             "coredns_cache_hits_total",
             "coredns_cache_misses_total",
             "coredns_cache_size",
@@ -23100,14 +23101,17 @@
             "coredns_dns_request_size_bytes_bucket",
             "coredns_dns_request_size_bytes_count",
             "coredns_dns_request_type_count_total",
+            "coredns_dns_requests_total",
             "coredns_dns_response_rcode_count_total",
             "coredns_dns_response_size_bytes",
             "coredns_dns_response_size_bytes_bucket",
             "coredns_dns_response_size_bytes_count",
+            "coredns_dns_responses_total",
             "coredns_health_request_duration_seconds",
             "coredns_health_request_duration_seconds_bucket",
             "coredns_health_request_duration_seconds_count",
             "coredns_panic_count_total",
+            "coredns_panics_total",
             "coredns_proxy_request_count_total",
             "coredns_proxy_request_duration_seconds",
             "coredns_proxy_request_duration_seconds_bucket",
@@ -23155,6 +23159,12 @@
           "group": null,
           "default": false
         },
+        "coredns_cache_entries": {
+          "type": "cumulative",
+          "description": "Size of DNS cache.",
+          "group": null,
+          "default": true
+        },
         "coredns_cache_hits_total": {
           "type": "cumulative",
           "description": "The count of cache misses.",
@@ -23169,13 +23179,13 @@
         },
         "coredns_cache_size": {
           "type": "cumulative",
-          "description": "Size of DNS cache.",
+          "description": "Deprecated in coredns version 1.7.0. Size of DNS cache.",
           "group": null,
           "default": true
         },
         "coredns_dns_request_count_total": {
           "type": "cumulative",
-          "description": "Counter of DNS requests made per zone, protocol and family.",
+          "description": "Deprecated in coredns version 1.7.0. Counter of DNS requests made per zone, protocol and family.",
           "group": null,
           "default": true
         },
@@ -23221,9 +23231,15 @@
           "group": null,
           "default": true
         },
+        "coredns_dns_requests_total": {
+          "type": "cumulative",
+          "description": "Counter of DNS requests made per zone, protocol and family.",
+          "group": null,
+          "default": true
+        },
         "coredns_dns_response_rcode_count_total": {
           "type": "cumulative",
-          "description": "Counter of response status codes.",
+          "description": "Deprecated in coredns version 1.7.0. Counter of response status codes.",
           "group": null,
           "default": true
         },
@@ -23245,6 +23261,12 @@
           "group": null,
           "default": false
         },
+        "coredns_dns_responses_total": {
+          "type": "cumulative",
+          "description": "Counter of response status codes.",
+          "group": null,
+          "default": true
+        },
         "coredns_health_request_duration_seconds": {
           "type": "cumulative",
           "description": "Histogram of the time (in seconds) each request took. (sum)",
@@ -23264,6 +23286,12 @@
           "default": false
         },
         "coredns_panic_count_total": {
+          "type": "cumulative",
+          "description": "Deprecated in coredns version 1.7.0. A metrics that counts the number of panics.",
+          "group": null,
+          "default": false
+        },
+        "coredns_panics_total": {
           "type": "cumulative",
           "description": "A metrics that counts the number of panics.",
           "group": null,


### PR DESCRIPTION
Description:
Currently when installing with the helm chart, we are planning to use signalfx receivers for monitoring Kubernetes control plane components. The coredns monitor in the signalfx agent is a little out of date, coredns updated several metric names in coredns-1.7.0-release. 4 of the metrics the signalfx coredns monitor had name changes. 3 of the metrics with new names are used in our k8s services dashboard. 

Added new metrics and did not delete older metrics for backwards compatibility. I did update the descriptions of the deprecated metrics.

The project docs did get regenerated.

Questions:
Do I have to update other projects or docs for newly added metrics?