### PR TITLE
Fix Timezone field mistmatch

### DIFF
--- a/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
+++ b/pkg/monitors/telegraf/monitors/telegraflogparser/telegraflogparser.go
@@ -44,7 +44,7 @@ type Config struct {
 	CustomPatternFiles []string `yaml:"customPatternFiles"`
 	// Specifies the timezone.  The default is UTC time.  Other options are `Local` for the
 	// local time on the machine, `UTC`, and `Canada/Eastern` (unix style timezones).
-	TimeZone string `yaml:"timezone"`
+	Timezone string `yaml:"timezone"`
 }
 
 // Monitor for Utilization


### PR DESCRIPTION
There is a mismatch between the telegraf struct->field `GrokConfig->Timezone` https://github.com/signalfx/telegraf/blob/signalfx-agent/plugins/inputs/logparser/logparser.go#L29 and the SA telegraflogparser config struct->field `Config → TimeZone` (note the upper case Z), this is causing the Timezone setting to NOT be set in telegraf and defaulting to UTC.


Signed-off-by: Dani Louca <dlouca@splunk.com>