### PR TITLE
Fix AzureUniqueID when VMSS is used

### DIFF
--- a/pkg/core/hostid/azure.go
+++ b/pkg/core/hostid/azure.go
@@ -63,7 +63,7 @@ func AzureUniqueID(cloudMetadataTimeout timeutil.Duration) string {
 		return strings.ToLower(fmt.Sprintf("%s/%s/microsoft.compute/virtualmachines/%s", compute.Doc.SubscriptionID, compute.Doc.ResourceGroupName, compute.Doc.Name))
 	}
 
-	instanceID := strings.TrimLeft(compute.Doc.Name, compute.Doc.VMScaleSetName+"_")
+	instanceID := strings.TrimPrefix(compute.Doc.Name, compute.Doc.VMScaleSetName+"_")
 
 	// names of VM's in VMScalesets seem to follow the of `<scale-set-name>_<instance-id>`
 	// where scale-set-name is alphanumeric (and is the same as compute.vmScaleSetName


### PR DESCRIPTION
The `AzureUniqueID` has been using the wrong strings function `TrimLeft` to find out the instanceID, instead we should stick to `TrimPrefix`

````
fmt.Println("using TrimLeft: ", strings.TrimLeft("PDAPI290_0", "PDAPI290_"))
fmt.Println("using TrimPrefix: ", strings.TrimPrefix("PDAPI290_0", "PDAPI290_"))

Result:

using TrimLeft:  
using TrimPrefix:  0
````

Little bit more description: `TrimLeft` removes the leading characters of a string that matches the cutset.
In other words, it iterates through the string one character at a time, from left to right and checks if the character exists in the cutset (regardless of order), once it fails to find a char in the cutset it returns the index which is used to slice the string.
Problem in the example I showed, when all character of the string exists in the cutset.



Signed-off-by: Dani Louca <dlouca@splunk.com>