### PR TITLE
Add inline tag to collectd/chrony

### DIFF
--- a/pkg/monitors/collectd/chrony/chrony.go
+++ b/pkg/monitors/collectd/chrony/chrony.go
@@ -23,7 +23,7 @@ func init() {
 type Config struct {
 	// This cannot be multi instance until there is a way to differentiate them
 	// in collectd
-	config.MonitorConfig `singleInstance:"true"`
+	config.MonitorConfig `yaml:",inline" singleInstance:"true"`
 
 	// The hostname of the chronyd instance
 	Host string `yaml:"host" validate:"required" default:"localhost"`


### PR DESCRIPTION
Splunk OTEL fails to use collectd/chrony due to missing type field

```
main.go:130: application run finished with error: failed to get config: cannot unmarshal the configuration: error reading receivers configuration for "smartagent/chrony": failed creating Smart Agent Monitor custom config: yaml: unmarshal errors: line 2: field type not found in type chrony.Config
```

Signed-off-by: Dani Louca <dlouca@splunk.com>