### PR TITLE
Fix solr integration tests

### DIFF
--- a/test-services/solr/Dockerfile
+++ b/test-services/solr/Dockerfile
@@ -1,5 +1,5 @@
 FROM bitnami/solr:latest
 
+ENV SOLR_JETTY_HOST 0.0.0.0
 ENTRYPOINT ["bash", "-c"]
 CMD ["solr start -c -e techproducts && tail -f /dev/null"]
-


### PR DESCRIPTION
The `latest` image was recently updated and breaks integration tests.