### PR TITLE
Move comment to be in template

### DIFF
--- a/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
+++ b/deployments/k8s/helm/signalfx-agent/templates/deployment.yaml
@@ -1,6 +1,6 @@
+{{ if .Values.isServerless -}}
 # This is only used for the serverless deployment model where we can't use
 # DaemonSets.
-{{ if .Values.isServerless -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
I am trying install the `signalfx-agent` via Gitops (by running `helm template` and loading raw manifests) and it's failing because the `deployment` file that gets generated is not empty

```
---
# Source: signalfx-agent/templates/deployment.yaml
# This is only used for the serverless deployment model where we can't use
# DaemonSets.
```

An easy solution to fix this and to prevent the empty `deployment` file from being created is to move this comment into the conditional