### PR TITLE
All monitors own their loggers and set monitorID field

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -84,7 +84,7 @@ COPY --from=signalfx-agent-dev-cache:stage-agent-builder /go $GOPATH
 RUN go install golang.org/x/lint/golint@latest &&\
     if [ `uname -m` != "aarch64" ]; then go install github.com/go-delve/delve/cmd/dlv@latest; fi &&\
     go install github.com/tebeka/go2xunit@latest &&\
-    curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
 
 COPY ./ ./
 

--- a/pkg/core/common/docker/containerlist.go
+++ b/pkg/core/common/docker/containerlist.go
@@ -8,8 +8,9 @@ import (
 	dtypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/filters"
 	docker "github.com/docker/docker/client"
-	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
 )
 
 // ContainerChangeHandler is what gets called when a Docker container is

--- a/pkg/core/config/sources/vault/vault.go
+++ b/pkg/core/config/sources/vault/vault.go
@@ -11,12 +11,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/vault/auth"
-	"github.com/signalfx/signalfx-agent/pkg/core/config/types"
-	"github.com/sirupsen/logrus"
+	"github.com/hashicorp/vault/api"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/hashicorp/vault/api"
+	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/vault/auth"
+	"github.com/signalfx/signalfx-agent/pkg/core/config/types"
 )
 
 type vaultConfigSource struct {
@@ -32,7 +31,7 @@ type vaultConfigSource struct {
 	nowProvider  func() time.Time
 	conf         *Config
 	tokenRenewer *api.LifetimeWatcher
-	logger       logrus.FieldLogger
+	logger       log.FieldLogger
 }
 
 var _ types.Stoppable = &vaultConfigSource{}
@@ -110,7 +109,7 @@ func (c *Config) New() (types.ConfigSource, error) {
 
 // New creates a new vault ConfigSource
 func New(conf *Config) (types.ConfigSource, error) {
-	logger := logrus.WithFields(log.Fields{"remoteConfigSource": "vault"})
+	logger := log.WithFields(log.Fields{"remoteConfigSource": "vault"})
 
 	logger.Info("Initializing new Vault remote config instance")
 

--- a/pkg/core/diagnostics.go
+++ b/pkg/core/diagnostics.go
@@ -16,12 +16,12 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/sfxclient"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/dpfilters"
 	"github.com/signalfx/signalfx-agent/pkg/core/writer/tap"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 // VersionLine should be populated by the startup logic to contain version
@@ -211,13 +211,13 @@ func (a *Agent) datapointTapHandler(rw http.ResponseWriter, req *http.Request) {
 	rw.WriteHeader(200)
 	dpTap := tap.New(filter, rw)
 
-	logrus.Infof("Datapoint tap started")
+	log.Infof("Datapoint tap started")
 	a.writer.SetTap(dpTap)
 
 	dpTap.Run(req.Context())
 
 	a.writer.SetTap(nil)
-	logrus.Infof("Datapoint tap cleared")
+	log.Infof("Datapoint tap cleared")
 }
 
 func streamDatapoints(host string, port uint16, metric string, dims string) (io.ReadCloser, error) {

--- a/pkg/core/services/rules.go
+++ b/pkg/core/services/rules.go
@@ -123,7 +123,6 @@ func DoesServiceMatchRule(si Endpoint, ruleText string, doValidation bool) bool 
 	exprVal, ok := ret.(bool)
 	if !ok {
 		log.WithFields(log.Fields{
-
 			"discoveryRule":   ruleText,
 			"serviceInstance": spew.Sdump(si),
 		}).Errorf("Discovery rule did not evaluate to a true/false value")

--- a/pkg/core/writer/dimensions/dedup.go
+++ b/pkg/core/writer/dimensions/dedup.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 )
 
 type deduplicator struct {

--- a/pkg/core/writer/splunk/splunk.go
+++ b/pkg/core/writer/splunk/splunk.go
@@ -15,15 +15,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/signalfx/golib/v3/trace"
-
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
+	"github.com/signalfx/golib/v3/trace"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/writer/processor"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/monitors/aspdotnet/aspdotnet.go
+++ b/pkg/monitors/aspdotnet/aspdotnet.go
@@ -1,6 +1,8 @@
 package aspdotnet
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -26,6 +28,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/cgroups/cpu.go
+++ b/pkg/monitors/cgroups/cpu.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/sfxclient"
+
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-	"github.com/sirupsen/logrus"
 )
 
 func (m *Monitor) getCPUMetrics(controllerPath string, pathFilter filter.StringFilter) []*datapoint.Datapoint {
@@ -51,7 +51,7 @@ func (m *Monitor) getCPUMetrics(controllerPath string, pathFilter filter.StringF
 			})
 
 			if err != nil {
-				logrus.WithError(err).Errorf("Failed to process %s", f)
+				m.logger.WithError(err).Errorf("Failed to process %s", f)
 				continue
 			}
 

--- a/pkg/monitors/cgroups/cpuacct.go
+++ b/pkg/monitors/cgroups/cpuacct.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/sfxclient"
+
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-	"github.com/sirupsen/logrus"
 )
 
 func (m *Monitor) getCPUAcctMetrics(controllerPath string, pathFilter filter.StringFilter) []*datapoint.Datapoint {
@@ -63,7 +63,7 @@ func (m *Monitor) getCPUAcctMetrics(controllerPath string, pathFilter filter.Str
 			err := withOpenFile(file, func(fd *os.File) {
 				usage, err := parseFunc(fd)
 				if err != nil {
-					logrus.WithError(err).Errorf("Failed to parse %s", file)
+					m.logger.WithError(err).Errorf("Failed to parse %s", file)
 					return
 				}
 
@@ -74,7 +74,7 @@ func (m *Monitor) getCPUAcctMetrics(controllerPath string, pathFilter filter.Str
 				dps = append(dps, usageDPs...)
 			})
 			if err != nil {
-				logrus.WithError(err).Errorf("Could not process %s", file)
+				m.logger.WithError(err).Errorf("Could not process %s", file)
 			}
 		}
 	})

--- a/pkg/monitors/cgroups/memory.go
+++ b/pkg/monitors/cgroups/memory.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/sfxclient"
+
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-	"github.com/sirupsen/logrus"
 )
 
 func (m *Monitor) getMemoryMetrics(controllerPath string, pathFilter filter.StringFilter) []*datapoint.Datapoint {
@@ -55,7 +55,7 @@ func (m *Monitor) getMemoryMetrics(controllerPath string, pathFilter filter.Stri
 				fileDPs, err = parseFunc(fd)
 			})
 			if err != nil {
-				logrus.WithError(err).Errorf("Failed to process %s", f)
+				m.logger.WithError(err).Errorf("Failed to process %s", f)
 				continue
 			}
 

--- a/pkg/monitors/cgroups/monitor.go
+++ b/pkg/monitors/cgroups/monitor.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/prometheus/procfs"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-	"github.com/sirupsen/logrus"
 )
 
 // Config for this monitor
@@ -44,11 +45,12 @@ func init() {
 type Monitor struct {
 	Output types.FilteringOutput
 	cancel context.CancelFunc
+	logger logrus.FieldLogger
 }
 
 // Configure the monitor and start collection
 func (m *Monitor) Configure(conf *Config) error {
-	logger := logrus.WithField("monitorType", monitorType)
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 	var ctx context.Context
 	ctx, m.cancel = context.WithCancel(context.Background())
 
@@ -65,7 +67,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	utils.RunOnInterval(ctx, func() {
 		controllerPaths, err := getCgroupControllerPaths(conf.ProcPath)
 		if err != nil {
-			logger.WithError(err).Error("Failed to get cgroup controller roots")
+			m.logger.WithError(err).Error("Failed to get cgroup controller roots")
 			return
 		}
 

--- a/pkg/monitors/cloudfoundry/client.go
+++ b/pkg/monitors/cloudfoundry/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"log"
 	"net"
 	"net/http"
 	"strings"
@@ -13,9 +12,10 @@ import (
 	"code.cloudfoundry.org/go-loggregator"
 	"code.cloudfoundry.org/go-loggregator/rpc/loggregator_v2"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/dpmeta"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 const defaultShardID = "signalfx-nozzle"
@@ -111,7 +111,7 @@ func (c *SignalFxGatewayClient) processEnvelopes(ctx context.Context, streamer l
 
 			envDPs, err := envelopeToDatapoints(env)
 			if err != nil {
-				log.Printf("Error converting envelope to SignalFx datapoint: %v", err)
+				c.logger.Printf("Error converting envelope to SignalFx datapoint: %v", err)
 				continue
 			}
 

--- a/pkg/monitors/collectd/collectd.go
+++ b/pkg/monitors/collectd/collectd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
@@ -60,7 +61,7 @@ type Manager struct {
 	terminated     chan struct{}
 	requestRestart chan struct{}
 
-	logger *log.Entry
+	logger log.FieldLogger
 }
 
 var collectdSingleton *Manager

--- a/pkg/monitors/collectd/elasticsearch/elasticsearch.go
+++ b/pkg/monitors/collectd/elasticsearch/elasticsearch.go
@@ -9,7 +9,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/python"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/subproc"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -75,7 +74,7 @@ type Monitor struct {
 
 // Configure configures and runs the plugin in collectd
 func (m *Monitor) Configure(conf *Config) error {
-	log.Warn("The collectd/elasticsearch monitor is deprecated in favor of the elasticsearch monitor.")
+	m.Logger().Warn("The collectd/elasticsearch monitor is deprecated in favor of the elasticsearch monitor.")
 	conf.pyConf = &python.Config{
 		MonitorConfig: conf.MonitorConfig,
 		Host:          conf.Host,

--- a/pkg/monitors/collectd/kong/kong.go
+++ b/pkg/monitors/collectd/kong/kong.go
@@ -1,12 +1,11 @@
 package kong
 
 import (
-	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
 	"github.com/sirupsen/logrus"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
-
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
+	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/python"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/subproc"
 )
@@ -189,7 +188,7 @@ func (m *Monitor) Configure(c *Config) error {
 	for _, metric := range m.Output.EnabledMetrics() {
 		metricConfig := metricConfigMap[metric]
 		if metricConfig == "" {
-			log.Warnf("Unable to determine metric configuration name for %s", metric)
+			m.Logger().Warnf("Unable to determine metric configuration name for %s", metric)
 			continue
 		}
 

--- a/pkg/monitors/collectd/logging.go
+++ b/pkg/monitors/collectd/logging.go
@@ -7,8 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/signalfx/signalfx-agent/pkg/utils"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils"
 )
 
 var logRE = regexp.MustCompile(
@@ -17,7 +18,7 @@ var logRE = regexp.MustCompile(
 		`(?:\[(?P<level>\w+?)\] )?` +
 		`(?P<message>(?:(?P<plugin>[\w-]+?): )?.*)`)
 
-func logLine(line string, logger *log.Entry) {
+func logLine(line string, logger log.FieldLogger) {
 	groups := utils.RegexpGroupMap(logRE, line)
 
 	var level string

--- a/pkg/monitors/collectd/monitorcore.go
+++ b/pkg/monitors/collectd/monitorcore.go
@@ -12,9 +12,10 @@ import (
 	"text/template"
 
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
-	log "github.com/sirupsen/logrus"
 )
 
 // MonitorCore contains common data/logic for collectd monitors, mainly

--- a/pkg/monitors/collectd/python/python.go
+++ b/pkg/monitors/collectd/python/python.go
@@ -20,6 +20,8 @@ import (
 	"github.com/signalfx/golib/v3/event"
 	mpCollectd "github.com/signalfx/ingest-protocols/protocol/collectd"
 	collectdformat "github.com/signalfx/ingest-protocols/protocol/collectd/format"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
@@ -27,7 +29,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors/subproc/signalfx"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils/collectdutil"
-	log "github.com/sirupsen/logrus"
 )
 
 const messageTypeValueList subproc.MessageType = 100

--- a/pkg/monitors/collectd/rabbitmq/rabbitmq.go
+++ b/pkg/monitors/collectd/rabbitmq/rabbitmq.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/signalfx/golib/v3/pointer"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 
 	"github.com/signalfx/signalfx-agent/pkg/utils"
@@ -12,10 +13,7 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd/python"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/subproc"
-	log "github.com/sirupsen/logrus"
 )
-
-var logger = log.WithFields(log.Fields{"monitorType": monitorType})
 
 func init() {
 	monitors.Register(&monitorMetadata, func() interface{} {
@@ -97,7 +95,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	if conf.SSLVerify && strings.TrimSpace(conf.SSLCACertFile) == "" {
-		logger.Warn("Potential configuration error because SSLVerify is enabled while SSLCACertFile is empty. Default system root CA certificates will be used in SSL verification and may fail silently.")
+		m.Logger().Warn("Potential configuration error because SSLVerify is enabled while SSLCACertFile is empty. Default system root CA certificates will be used in SSL verification and may fail silently.")
 	}
 
 	conf.pyConf = &python.Config{

--- a/pkg/monitors/collectd/templating_linux.go
+++ b/pkg/monitors/collectd/templating_linux.go
@@ -11,15 +11,15 @@ import (
 	"reflect"
 	"runtime"
 	"strconv"
+	"strings"
 	"text/template"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
-	"github.com/signalfx/signalfx-agent/pkg/core/services"
-	"github.com/signalfx/signalfx-agent/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
-	"strings"
+	"github.com/signalfx/signalfx-agent/pkg/core/services"
+	"github.com/signalfx/signalfx-agent/pkg/utils"
 )
 
 // WriteConfFile writes a file to the given filePath, ensuring that the

--- a/pkg/monitors/collectd/write_server.go
+++ b/pkg/monitors/collectd/write_server.go
@@ -9,12 +9,12 @@ import (
 	"time"
 
 	"github.com/mailru/easyjson"
-	log "github.com/sirupsen/logrus"
-
 	collectdformat "github.com/signalfx/gateway/protocol/collectd/format"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
 	"github.com/signalfx/ingest-protocols/protocol/collectd"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/utils/collectdutil"
 )
 

--- a/pkg/monitors/conviva/conviva.go
+++ b/pkg/monitors/conviva/conviva.go
@@ -10,14 +10,14 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/sfxclient"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/dpmeta"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -54,7 +54,7 @@ func init() {
 
 // Configure monitor
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 	m.timeout = time.Duration(conf.TimeoutSeconds) * time.Second
 	m.client = newConvivaClient(&http.Client{
 		Transport: &http.Transport{

--- a/pkg/monitors/cpu/cpu_others.go
+++ b/pkg/monitors/cpu/cpu_others.go
@@ -7,5 +7,6 @@ import (
 	"github.com/shirou/gopsutil/cpu"
 )
 
-// setting cpu.Times to a package variable for testing purposes
-var times = cpu.Times
+func (m *Monitor) times(perCore bool) ([]cpu.TimesStat, error) {
+	return cpu.Times(perCore)
+}

--- a/pkg/monitors/docker/docker.go
+++ b/pkg/monitors/docker/docker.go
@@ -13,6 +13,8 @@ import (
 	dtypes "github.com/docker/docker/api/types"
 	docker "github.com/docker/docker/client"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	dockercommon "github.com/signalfx/signalfx-agent/pkg/core/common/docker"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
@@ -20,7 +22,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-	"github.com/sirupsen/logrus"
 )
 
 const dockerAPIVersion = "v1.24"
@@ -88,7 +89,7 @@ type dockerContainer struct {
 
 // Configure the monitor and kick off volume metric syncing
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	enhancedMetricsConfig := EnableExtraGroups(conf.EnhancedMetricsConfig, m.Output.EnabledMetrics())
 

--- a/pkg/monitors/dotnet/dotnet.go
+++ b/pkg/monitors/dotnet/dotnet.go
@@ -1,6 +1,8 @@
 package dotnet
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -26,6 +28,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/dotnet/dotnet_windows.go
+++ b/pkg/monitors/dotnet/dotnet_windows.go
@@ -8,17 +8,19 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var logger = logrus.WithField("monitorType", monitorType)
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
+	m.logger = logger.WithField("monitorID", conf.MonitorID)
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,
@@ -70,7 +72,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	// create base emitter
-	emitter := baseemitter.NewEmitter(m.Output, logger)
+	emitter := baseemitter.NewEmitter(m.Output, m.logger)
 
 	// Hard code the plugin name because the emitter will parse out the
 	// configured measurement name as plugin and that is confusing.
@@ -98,7 +100,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	// gather metrics on the specified interval
 	utils.RunOnInterval(ctx, func() {
 		if err := plugin.Gather(ac); err != nil {
-			logger.WithError(err).Errorf("an error was encountered while gathering metrics from the plugin")
+			m.logger.WithError(err).Errorf("an error was encountered while gathering metrics from the plugin")
 		}
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 

--- a/pkg/monitors/elasticsearch/query/datapoints_test.go
+++ b/pkg/monitors/elasticsearch/query/datapoints_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +34,7 @@ func TestDatapointsFromTerminalBucketAggregation(t *testing.T) {
 		"host": {
 			Type: "filters",
 		},
-	}, map[string]string{})
+	}, map[string]string{}, logrus.Fields{})
 
 	assert.ElementsMatch(t, dps, []*datapoint.Datapoint{
 		{
@@ -97,7 +98,7 @@ func TestMetricAggregationWithTermsAggregation(t *testing.T) {
 		"metric_agg_1": {
 			Type: "avg",
 		},
-	}, map[string]string{})
+	}, map[string]string{}, logrus.Fields{})
 
 	assert.ElementsMatch(t, dps, []*datapoint.Datapoint{
 		{
@@ -185,7 +186,7 @@ func TestExtendedStatsAggregationsFromFiltersAggregation(t *testing.T) {
 		"metric_agg_1": {
 			Type: "extended_stats",
 		},
-	}, map[string]string{})
+	}, map[string]string{}, logrus.Fields{})
 
 	dims := map[string]map[string]string{
 		"madrid": {
@@ -370,7 +371,7 @@ func TestPercentilesAggregationsFromFiltersAggregation(t *testing.T) {
 		"metric_agg_1": {
 			Type: "percentiles",
 		},
-	}, map[string]string{})
+	}, map[string]string{}, logrus.Fields{})
 
 	dims := map[string]map[string]string{
 		"madrid": {
@@ -484,7 +485,7 @@ func TestMultipleMetricAggregationWithTermsAggregation(t *testing.T) {
 		"metric_agg_3": {
 			Type: "extended_stats",
 		},
-	}, map[string]string{})
+	}, map[string]string{}, logrus.Fields{})
 
 	dims := map[string]map[string]string{
 		"metric_agg_1": {

--- a/pkg/monitors/elasticsearch/stats/elasticsearch.go
+++ b/pkg/monitors/elasticsearch/stats/elasticsearch.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // Config for this monitor
@@ -140,7 +141,7 @@ func (sinfo *sharedInfo) getAllSharedInfo() (map[string]string, map[string]strin
 
 // Configure monitor
 func (m *Monitor) Configure(c *Config) error {
-	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": monitorType}), 20*time.Second)
+	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": c.MonitorID}), 20*time.Second)
 
 	// conf is a config shallow copy that will be mutated and used to configure monitor
 	conf := &Config{}

--- a/pkg/monitors/expvar/expvar.go
+++ b/pkg/monitors/expvar/expvar.go
@@ -12,10 +12,11 @@ import (
 	"time"
 
 	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -50,7 +51,7 @@ type metricVal struct {
 
 // Configure monitor
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = log.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 	if m.Output.HasAnyExtraMetrics() {
 		conf.EnhancedMetrics = true
 	}

--- a/pkg/monitors/filesystems/filesystems.go
+++ b/pkg/monitors/filesystems/filesystems.go
@@ -9,14 +9,13 @@ import (
 
 	gopsutil "github.com/shirou/gopsutil/disk"
 	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -61,7 +60,7 @@ type Monitor struct {
 	fsTypes           *filter.OverridableStringFilter
 	mountPoints       *filter.OverridableStringFilter
 	sendModeDimension bool
-	logger            logrus.FieldLogger
+	logger            log.FieldLogger
 }
 
 // returns common dimensions map for every filesystem
@@ -222,7 +221,7 @@ func (m *Monitor) emitDatapoints() {
 // Configure is the main function of the monitor, it will report host metadata
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	var ctx context.Context
 	ctx, m.cancel = context.WithCancel(context.Background())

--- a/pkg/monitors/filesystems/filesystems_test.go
+++ b/pkg/monitors/filesystems/filesystems_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	gopsutil "github.com/shirou/gopsutil/disk"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,7 +60,7 @@ func TestCommonDimensions(t *testing.T) {
 		},
 	}
 
-	logger := logrus.WithFields(log.Fields{"monitorType": monitorType})
+	logger := log.WithFields(log.Fields{"monitorType": monitorType})
 	for _, tt := range cases {
 		m := Monitor{
 			hostFSPath:        tt.hostFSPath,

--- a/pkg/monitors/heroku/monitor.go
+++ b/pkg/monitors/heroku/monitor.go
@@ -5,11 +5,12 @@ import (
 	"os"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // Config for this monitor
@@ -31,7 +32,7 @@ func init() {
 
 // Configure monitor
 func (m *Monitor) Configure(c *Config) error {
-	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": "heroku-metadata"}), 20*time.Second)
+	m.logger = utils.NewThrottledLogger(log.WithFields(log.Fields{"monitorType": "heroku-metadata", "monitorID": c.MonitorID}), 20*time.Second)
 	m.ctx, m.cancel = context.WithCancel(context.Background())
 
 	go func() {

--- a/pkg/monitors/kubernetes/cluster/clusterstate.go
+++ b/pkg/monitors/kubernetes/cluster/clusterstate.go
@@ -4,24 +4,22 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/autoscaling/v2beta1"
-
-	"k8s.io/client-go/rest"
-
-	"github.com/signalfx/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics"
-	"github.com/signalfx/signalfx-agent/pkg/utils/k8sutil"
-	log "github.com/sirupsen/logrus"
-
 	quota "github.com/openshift/api/quota/v1"
 	quotav1 "github.com/openshift/client-go/quota/clientset/versioned/typed/quota/v1"
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/autoscaling/v2beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/kubernetes/cluster/metrics"
+	"github.com/signalfx/signalfx-agent/pkg/utils/k8sutil"
 )
 
 // State makes use of the K8s client's "reflector" helper to watch the API
@@ -32,18 +30,20 @@ type State struct {
 	reflectors  map[string]*cache.Reflector
 	namespace   string
 	cancel      func()
+	logger      log.FieldLogger
 
 	metricCache *metrics.DatapointCache
 	dimHandler  *metrics.DimensionHandler
 }
 
 func newState(flavor KubernetesDistribution, restConfig *rest.Config, metricCache *metrics.DatapointCache,
-	dimHandler *metrics.DimensionHandler, namespace string) (*State, error) {
+	dimHandler *metrics.DimensionHandler, namespace string, logger log.FieldLogger) (*State, error) {
 	state := &State{
 		reflectors:  make(map[string]*cache.Reflector),
 		metricCache: metricCache,
 		dimHandler:  dimHandler,
 		namespace:   namespace,
+		logger:      logger,
 	}
 
 	var err error
@@ -65,7 +65,7 @@ func newState(flavor KubernetesDistribution, restConfig *rest.Config, metricCach
 
 // Start starts syncing any resource that isn't already being synced
 func (cs *State) Start() {
-	log.Info("Starting K8s API resource sync")
+	cs.logger.Info("Starting K8s API resource sync")
 
 	var ctx context.Context
 	ctx, cs.cancel = context.WithCancel(context.Background())
@@ -172,7 +172,7 @@ func (cs *State) beginSyncForType(ctx context.Context, resType runtime.Object, r
 // channel properly.
 // See https://github.com/kubernetes/client-go/blob/release-8.0/tools/cache/controller.go#L144
 func (cs *State) Stop() {
-	log.Info("Stopping all K8s API resource sync")
+	cs.logger.Info("Stopping all K8s API resource sync")
 	if cs.cancel != nil {
 		cs.cancel()
 	}

--- a/pkg/monitors/kubernetes/cluster/monitor_test.go
+++ b/pkg/monitors/kubernetes/cluster/monitor_test.go
@@ -6,21 +6,18 @@ import (
 	"os"
 	"testing"
 
-	//"github.com/davecgh/go-spew/spew"
-
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/signalfx-agent/pkg/core/common/kubernetes"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/neotest"
-	log "github.com/sirupsen/logrus"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	. "github.com/signalfx/signalfx-agent/pkg/neotest/k8s/testhelpers/fakek8s"
 )
 

--- a/pkg/monitors/load/load.go
+++ b/pkg/monitors/load/load.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/shirou/gopsutil/load"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -37,7 +37,7 @@ type Monitor struct {
 // Configure is the main function of the monitor, it will report host metadata
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/pkg/monitors/manager.go
+++ b/pkg/monitors/manager.go
@@ -9,13 +9,14 @@ import (
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
 	"github.com/signalfx/golib/v3/trace"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/meta"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/collectd"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // MonitorManager coordinates the startup and shutdown of monitors based on the

--- a/pkg/monitors/manager_test.go
+++ b/pkg/monitors/manager_test.go
@@ -6,11 +6,12 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/meta"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
-	log "github.com/sirupsen/logrus"
 )
 
 // Used to make unique service ids

--- a/pkg/monitors/memory/memory.go
+++ b/pkg/monitors/memory/memory.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/shirou/gopsutil/mem"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -26,7 +26,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 // EmitDatapoints emits a set of memory datapoints
@@ -51,7 +51,7 @@ func (m *Monitor) emitDatapoints() {
 // Configure is the main function of the monitor, it will report host metadata
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/pkg/monitors/metadata/hostmetadata/hostmetadata.go
+++ b/pkg/monitors/metadata/hostmetadata/hostmetadata.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/metadata/hostmetadata"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/constants"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/metadata"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -45,7 +46,7 @@ type Monitor struct {
 // Configure is the main function of the monitor, it will report host metadata
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// metadatafuncs are the functions to collect host metadata.
 	// putting them directly in the array raised issues with the return type of info

--- a/pkg/monitors/mongodb/atlas/measurements/common.go
+++ b/pkg/monitors/mongodb/atlas/measurements/common.go
@@ -19,7 +19,7 @@ type Process struct {
 }
 
 // nextPage gets the next page for pagination request.
-func nextPage(resp *mongodbatlas.Response) (bool, int) {
+func nextPage(resp *mongodbatlas.Response, logger log.FieldLogger) (bool, int) {
 	if resp == nil || len(resp.Links) == 0 || resp.IsLastPage() {
 		return false, -1
 	}
@@ -27,7 +27,7 @@ func nextPage(resp *mongodbatlas.Response) (bool, int) {
 	currentPage, err := resp.CurrentPage()
 
 	if err != nil {
-		log.WithError(err).Error("failed to get the next page")
+		logger.WithError(err).Error("failed to get the next page")
 		return false, -1
 	}
 

--- a/pkg/monitors/monitor.go
+++ b/pkg/monitors/monitor.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 
 	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // MonitorFactory is a niladic function that creates an unconfigured instance

--- a/pkg/monitors/nagios/nagios.go
+++ b/pkg/monitors/nagios/nagios.go
@@ -15,11 +15,12 @@ import (
 	"github.com/patrickmn/go-cache"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -66,7 +67,7 @@ var (
 
 // Configure and kick off internal metric collection
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 	// Define global dimensions used for both datapoint and event
 	dimensions := map[string]string{
 		"plugin":  "nagios",

--- a/pkg/monitors/netio/netio.go
+++ b/pkg/monitors/netio/netio.go
@@ -7,13 +7,13 @@ import (
 
 	"github.com/shirou/gopsutil/net"
 	"github.com/signalfx/golib/v3/datapoint"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/filter"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 //nolint:gochecknoglobals setting net.IOCounters to a package variable for testing purposes
@@ -45,7 +45,7 @@ type Monitor struct {
 	filter                 *filter.OverridableStringFilter
 	networkTotal           uint64
 	previousInterfaceStats map[string]*netio
-	logger                 logrus.FieldLogger
+	logger                 log.FieldLogger
 }
 
 func (m *Monitor) updateTotals(iface string, intf *net.IOCountersStat) {
@@ -118,7 +118,7 @@ func (m *Monitor) EmitDatapoints() {
 // Configure is the main function of the monitor, it will report host metadata
 // on a varied interval
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/pkg/monitors/ntp/ntp.go
+++ b/pkg/monitors/ntp/ntp.go
@@ -4,15 +4,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/beevik/ntp"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-	"github.com/sirupsen/logrus"
-
-	"github.com/beevik/ntp"
 )
 
 const minInterval = 30 * time.Minute
@@ -43,7 +43,7 @@ type Monitor struct {
 
 // Configure and kick off internal metric collection
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 	// respect terms of service https://www.pool.ntp.org/tos.html
 	minIntervalSeconds := minInterval.Seconds()
 	if float64(conf.IntervalSeconds) < minIntervalSeconds {

--- a/pkg/monitors/processlist/processlist_darwin.go
+++ b/pkg/monitors/processlist/processlist_darwin.go
@@ -3,6 +3,8 @@
 
 package processlist
 
+import "github.com/sirupsen/logrus"
+
 type osCache struct {
 }
 
@@ -10,6 +12,6 @@ func initOSCache() *osCache {
 	return &osCache{}
 }
 
-func ProcessList(conf *Config, cache *osCache) ([]*TopProcess, error) {
+func ProcessList(conf *Config, cache *osCache, logger logrus.FieldLogger) ([]*TopProcess, error) {
 	return nil, nil
 }

--- a/pkg/monitors/processlist/processlist_linux.go
+++ b/pkg/monitors/processlist/processlist_linux.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/prometheus/procfs"
+	"github.com/sirupsen/logrus"
 )
 
 // A place to hold system info that is assumed not to change (or rarely change)
@@ -26,7 +27,7 @@ func initOSCache() *osCache {
 }
 
 // ProcessList takes a snapshot of running processes
-func ProcessList(conf *Config, cache *osCache) ([]*TopProcess, error) {
+func ProcessList(conf *Config, cache *osCache, logger logrus.FieldLogger) ([]*TopProcess, error) {
 	var fs procfs.FS
 	var err error
 	if conf.ProcPath == "" {
@@ -76,7 +77,7 @@ func ProcessList(conf *Config, cache *osCache) ([]*TopProcess, error) {
 				if err == nil {
 					cache.uidCache[uid] = user
 					username = user.Username
-				} else {
+				} else if logger != nil {
 					logger.WithError(err).Debugf("Could not lookup user id %s for process id %d", uid, p.PID)
 				}
 			}

--- a/pkg/monitors/processlist/processlist_linux_test.go
+++ b/pkg/monitors/processlist/processlist_linux_test.go
@@ -11,7 +11,7 @@ import (
 func TestProcessListLinux(t *testing.T) {
 	cache := initOSCache()
 
-	tps, err := ProcessList(&Config{}, cache)
+	tps, err := ProcessList(&Config{}, cache, nil)
 	require.Nil(t, err)
 	require.Greater(t, len(tps), 0)
 

--- a/pkg/monitors/prometheusexporter/prometheus.go
+++ b/pkg/monitors/prometheusexporter/prometheus.go
@@ -10,16 +10,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
-	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
-
-	"k8s.io/client-go/rest"
-
-	"github.com/sirupsen/logrus"
-
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/rest"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/common/auth"
+	"github.com/signalfx/signalfx-agent/pkg/core/common/httpclient"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -85,7 +83,7 @@ type fetcher func() (io.ReadCloser, expfmt.Format, error)
 
 // Configure the monitor and kick off volume metric syncing
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": m.monitorName})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": m.monitorName, "monitorID": conf.MonitorID})
 
 	var bearerToken string
 

--- a/pkg/monitors/sql/querier.go
+++ b/pkg/monitors/sql/querier.go
@@ -12,9 +12,10 @@ import (
 	"github.com/antonmedv/expr/vm"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 type querier struct {
@@ -29,7 +30,7 @@ type querier struct {
 	logQueries                bool
 }
 
-func newQuerier(query *Query, logQueries bool) (*querier, error) {
+func newQuerier(query *Query, logQueries bool, logger logrus.FieldLogger) (*querier, error) {
 	valueColumnNamesToMetrics := map[string]*Metric{}
 	metricToIndex := map[*Metric]int{}
 

--- a/pkg/monitors/statsd/parser_test.go
+++ b/pkg/monitors/statsd/parser_test.go
@@ -46,8 +46,8 @@ func TestParseMetrics(t *testing.T) {
 			"cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success:100|g|#svc:svc2",
 			[]*converter{
 				{
-					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}"),
-					metric:  parseFields("{traffic}.{action}"),
+					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}", nil),
+					metric:  parseFields("{traffic}.{action}", nil),
 				},
 			},
 			statsDMetric{
@@ -69,8 +69,8 @@ func TestParseMetrics(t *testing.T) {
 			"cluster.cds_egress_ecommerce-demo-mesh_gateway-vn_tcp_8080.update_success:100|g",
 			[]*converter{
 				{
-					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}"),
-					metric:  parseFields("{traffic}.{action}"),
+					pattern: parseFields("cluster.cds_{traffic}_{mesh}_{service}-vn_{}.{action}", nil),
+					metric:  parseFields("{traffic}.{action}", nil),
 				},
 			},
 			statsDMetric{
@@ -91,7 +91,11 @@ func TestParseMetrics(t *testing.T) {
 	for i := range cases {
 		tt := cases[i]
 		t.Run(tt.name, func(t *testing.T) {
-			sm := parseMetrics([]string{tt.raw}, tt.converters, "")
+			sl := &statsDListener{
+				converters: tt.converters,
+				prefix:     "",
+			}
+			sm := sl.parseMetrics([]string{tt.raw})
 			require.Equal(t, 1, len(sm))
 			require.Equal(t, tt.parsed, *sm[0])
 		})
@@ -176,7 +180,7 @@ func TestParseFields(t *testing.T) {
 	for i := range cases {
 		tt := cases[i]
 		t.Run(tt.pattern, func(t *testing.T) {
-			fp := parseFields(tt.pattern)
+			fp := parseFields(tt.pattern, nil)
 			if tt.expectNil {
 				require.Nil(t, fp)
 				return

--- a/pkg/monitors/subproc/core.go
+++ b/pkg/monitors/subproc/core.go
@@ -16,9 +16,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // RuntimeConfig for subprocs

--- a/pkg/monitors/subproc/signalfx/handler.go
+++ b/pkg/monitors/subproc/signalfx/handler.go
@@ -16,9 +16,10 @@ import (
 	signalfxformat "github.com/signalfx/gateway/protocol/signalfx/format"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/ingest-protocols/protocol/signalfx"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/subproc"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
-	"github.com/sirupsen/logrus"
 )
 
 const messageTypeDatapointJSONList subproc.MessageType = 200

--- a/pkg/monitors/supervisor/supervisor.go
+++ b/pkg/monitors/supervisor/supervisor.go
@@ -8,11 +8,12 @@ import (
 
 	"github.com/mattn/go-xmlrpc"
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -70,7 +71,7 @@ func (c *Config) ScrapeURL() string {
 
 // Configure and kick off internal metric collection
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType})
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// Start the metric gathering process here
 	var ctx context.Context

--- a/pkg/monitors/telegraf/common/emitter/baseemitter/baseemitter.go
+++ b/pkg/monitors/telegraf/common/emitter/baseemitter/baseemitter.go
@@ -6,8 +6,9 @@ import (
 	"github.com/influxdata/telegraf"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
-	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 )
 
 // TelegrafToSFXMetricType returns the signalfx metric type for a telegraf metric

--- a/pkg/monitors/telegraf/common/emitter/baseemitter/baseemitter_test.go
+++ b/pkg/monitors/telegraf/common/emitter/baseemitter/baseemitter_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
-	"github.com/signalfx/signalfx-agent/pkg/neotest"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/neotest"
 )
 
 func TestImmediateEmitter_Emit(t *testing.T) {

--- a/pkg/monitors/telegraf/common/emitter/batchemitter/batchemitter.go
+++ b/pkg/monitors/telegraf/common/emitter/batchemitter/batchemitter.go
@@ -4,9 +4,10 @@ import (
 	"sync"
 
 	"github.com/influxdata/telegraf"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
-	log "github.com/sirupsen/logrus"
 )
 
 // BatchEmitter gathers a batch of telegraf measurements that can be modified

--- a/pkg/monitors/telegraf/common/emitter/batchemitter/batchemitter_test.go
+++ b/pkg/monitors/telegraf/common/emitter/batchemitter/batchemitter_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/influxdata/telegraf/metric"
 	"github.com/signalfx/golib/v3/datapoint"
 	"github.com/signalfx/golib/v3/event"
-	"github.com/signalfx/signalfx-agent/pkg/neotest"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/neotest"
 )
 
 func TestImmediateEmitter_Emit(t *testing.T) {

--- a/pkg/monitors/telegraf/monitors/dns/dns.go
+++ b/pkg/monitors/telegraf/monitors/dns/dns.go
@@ -7,16 +7,15 @@ import (
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/dns_query"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
-
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -46,7 +45,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 type Emitter struct {
@@ -64,7 +63,7 @@ func (e *Emitter) AddError(err error) {
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	plugin := telegrafInputs.Inputs["dns_query"]().(*telegrafPlugin.DnsQuery)
 	plugin.Domains = conf.Domains

--- a/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
+++ b/pkg/monitors/telegraf/monitors/mssqlserver/mssqlserver.go
@@ -11,6 +11,8 @@ import (
 	"github.com/influxdata/telegraf"
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/sqlserver"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
@@ -18,8 +20,6 @@ import (
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -54,12 +54,12 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	plugin := telegrafInputs.Inputs["sqlserver"]().(*telegrafPlugin.SQLServer)
 

--- a/pkg/monitors/telegraf/monitors/ntpq/ntpq.go
+++ b/pkg/monitors/telegraf/monitors/ntpq/ntpq.go
@@ -6,15 +6,14 @@ import (
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/ntpq"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
-
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -32,7 +31,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 type Emitter struct {
@@ -41,7 +40,7 @@ type Emitter struct {
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	plugin := telegrafInputs.Inputs["ntpq"]().(*telegrafPlugin.NTPQ)
 	plugin.DNSLookup = *conf.DNSLookup

--- a/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
+++ b/pkg/monitors/telegraf/monitors/telegrafsnmp/telegrafsnmp.go
@@ -10,14 +10,14 @@ import (
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/snmp"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -106,7 +106,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel context.CancelFunc
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 // converts our config struct for field to a telegraf field
@@ -128,7 +128,7 @@ func getTelegrafFields(incoming []Field) ([]telegrafPlugin.Field, error) {
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	plugin := telegrafInputs.Inputs["snmp"]().(*telegrafPlugin.Snmp)
 

--- a/pkg/monitors/telegraf/monitors/varnish/varnish.go
+++ b/pkg/monitors/telegraf/monitors/varnish/varnish.go
@@ -9,15 +9,14 @@ import (
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/varnish"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
-
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
-	log "github.com/sirupsen/logrus"
 )
 
 func init() {
@@ -42,7 +41,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
-	logger logrus.FieldLogger
+	logger log.FieldLogger
 }
 
 type Emitter struct {
@@ -51,7 +50,7 @@ type Emitter struct {
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithFields(log.Fields{"monitorType": monitorType})
+	m.logger = log.WithFields(log.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	plugin := telegrafInputs.Inputs["varnish"]().(*telegrafPlugin.Varnish)
 	plugin.UseSudo = conf.UseSudo

--- a/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
+++ b/pkg/monitors/telegraf/monitors/winperfcounters/win_perf_counters.go
@@ -3,12 +3,13 @@ package winperfcounters
 import (
 	"strings"
 
-	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-
 	"github.com/influxdata/telegraf"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 func init() {
@@ -75,6 +76,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/telegraf/monitors/winservices/winservices.go
+++ b/pkg/monitors/telegraf/monitors/winservices/winservices.go
@@ -3,6 +3,8 @@ package winservices
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -23,6 +25,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel context.CancelFunc
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
+++ b/pkg/monitors/telegraf/monitors/winservices/winservices_windows.go
@@ -10,20 +10,22 @@ import (
 
 	telegrafInputs "github.com/influxdata/telegraf/plugins/inputs"
 	telegrafPlugin "github.com/influxdata/telegraf/plugins/inputs/win_services"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var logger = logrus.WithField("monitorType", monitorType)
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) (err error) {
+	m.logger = logger.WithField("monitorID", conf.MonitorID)
 	plugin := telegrafInputs.Inputs["win_services"]().(*telegrafPlugin.WinServices)
 
 	// create the emitter
-	em := baseemitter.NewEmitter(m.Output, logger)
+	em := baseemitter.NewEmitter(m.Output, m.logger)
 
 	// Hard code the plugin name because the emitter will parse out the
 	// configured measurement name as plugin and that is confusing.
@@ -42,7 +44,7 @@ func (m *Monitor) Configure(conf *Config) (err error) {
 	// gather metrics on the specified interval
 	utils.RunOnInterval(ctx, func() {
 		if err := plugin.Gather(ac); err != nil {
-			logger.WithError(err).Errorf("an error occurred while gathering metrics")
+			m.logger.WithError(err).Errorf("an error occurred while gathering metrics")
 		}
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 

--- a/pkg/monitors/vmem/vmem.go
+++ b/pkg/monitors/vmem/vmem.go
@@ -1,11 +1,12 @@
 package vmem
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/pkg/monitors/vmem/vmem_linux.go
+++ b/pkg/monitors/vmem/vmem_linux.go
@@ -12,9 +12,10 @@ import (
 	"time"
 
 	"github.com/signalfx/golib/v3/datapoint"
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/hostfs"
-	"github.com/sirupsen/logrus"
 )
 
 var cumulativeCounters = map[string]string{
@@ -65,7 +66,7 @@ func (m *Monitor) parseFileForDatapoints(contents []byte) []*datapoint.Datapoint
 
 // Configure and run the monitor on linux
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithField("monitorType", monitorType)
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/pkg/monitors/vmem/vmem_windows.go
+++ b/pkg/monitors/vmem/vmem_windows.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var metricNameMapping = map[string]string{
@@ -22,7 +23,7 @@ var metricNameMapping = map[string]string{
 
 // Configure and run the monitor on windows
 func (m *Monitor) Configure(conf *Config) (err error) {
-	m.logger = logrus.WithField("monitorType", monitorType)
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
 
 	// create contexts for managing the the plugin loop
 	var ctx context.Context

--- a/pkg/monitors/vsphere/monitor.go
+++ b/pkg/monitors/vsphere/monitor.go
@@ -4,16 +4,18 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger
 }
 
 func init() {
@@ -27,8 +29,8 @@ func init() {
 func (m *Monitor) Configure(conf *model.Config) error {
 	var ctx context.Context
 	ctx, m.cancel = context.WithCancel(context.Background())
-	log := logrus.WithField("monitorType", "vsphere")
-	r := newRunner(ctx, log, conf, m)
+	m.logger = logrus.WithFields(logrus.Fields{"monitorType": monitorType, "monitorID": conf.MonitorID})
+	r := newRunner(ctx, m.logger, conf, m)
 	// 20 seconds is the fixed, real-time metrics interval for vsphere/esxi
 	utils.RunOnInterval(ctx, r.run, model.RealtimeMetricsInterval*time.Second)
 	return nil

--- a/pkg/monitors/vsphere/runner.go
+++ b/pkg/monitors/vsphere/runner.go
@@ -3,19 +3,20 @@ package vsphere
 import (
 	"context"
 
-	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 	"github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
 
 type runner struct {
 	ctx                   context.Context
-	log                   *logrus.Entry
+	log                   logrus.FieldLogger
 	conf                  *model.Config
 	vsm                   *vSphereMonitor
 	vsphereReloadInterval int // seconds
 }
 
-func newRunner(ctx context.Context, log *logrus.Entry, conf *model.Config, monitor *Monitor) runner {
+func newRunner(ctx context.Context, log logrus.FieldLogger, conf *model.Config, monitor *Monitor) runner {
 	vsphereReloadInterval := int(conf.InventoryRefreshInterval.AsDuration().Seconds())
 	vsm := newVsphereMonitor(conf, log, monitor.Output.SendDatapoints)
 	return runner{

--- a/pkg/monitors/vsphere/service/auth.go
+++ b/pkg/monitors/vsphere/service/auth.go
@@ -5,19 +5,20 @@ import (
 	"crypto/tls"
 	"net/url"
 
-	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
 
 type AuthService struct {
-	log *logrus.Entry
+	log logrus.FieldLogger
 }
 
-func NewAuthService(log *logrus.Entry) *AuthService {
+func NewAuthService(log logrus.FieldLogger) *AuthService {
 	return &AuthService{log: log}
 }
 

--- a/pkg/monitors/vsphere/service/gateway.go
+++ b/pkg/monitors/vsphere/service/gateway.go
@@ -28,11 +28,11 @@ type IGateway interface {
 type Gateway struct {
 	ctx    context.Context
 	client *govmomi.Client
-	log    *log.Entry
+	log    log.FieldLogger
 	vcName string
 }
 
-func NewGateway(ctx context.Context, client *govmomi.Client, log *log.Entry) *Gateway {
+func NewGateway(ctx context.Context, client *govmomi.Client, log log.FieldLogger) *Gateway {
 	return &Gateway{
 		ctx:    ctx,
 		client: client,

--- a/pkg/monitors/vsphere/service/inventory.go
+++ b/pkg/monitors/vsphere/service/inventory.go
@@ -1,20 +1,21 @@
 package service
 
 import (
-	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
 
 // Traverses the inventory tree and returns all of the hosts and VMs.
 type InventorySvc struct {
-	log     *logrus.Entry
+	log     logrus.FieldLogger
 	gateway IGateway
 	f       InvFilter
 }
 
-func NewInventorySvc(gateway IGateway, log *logrus.Entry, f InvFilter) *InventorySvc {
+func NewInventorySvc(gateway IGateway, log logrus.FieldLogger, f InvFilter) *InventorySvc {
 	return &InventorySvc{gateway: gateway, f: f, log: log}
 }
 

--- a/pkg/monitors/vsphere/service/metrics.go
+++ b/pkg/monitors/vsphere/service/metrics.go
@@ -4,17 +4,18 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware/govmomi/vim25/types"
+
+	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
 )
 
 type MetricsSvc struct {
-	log     *logrus.Entry
+	log     logrus.FieldLogger
 	gateway IGateway
 }
 
-func NewMetricsService(gateway IGateway, log *logrus.Entry) *MetricsSvc {
+func NewMetricsService(gateway IGateway, log logrus.FieldLogger) *MetricsSvc {
 	return &MetricsSvc{log: log, gateway: gateway}
 }
 

--- a/pkg/monitors/vsphere/service/multi_perf_fetcher.go
+++ b/pkg/monitors/vsphere/service/multi_perf_fetcher.go
@@ -13,7 +13,7 @@ import (
 type multiPagePerfFetcher struct {
 	gateway  IGateway
 	pageSize int
-	log      *log.Entry
+	log      log.FieldLogger
 }
 
 func (f *multiPagePerfFetcher) invIterator(inv []*model.InventoryObject, maxSample int32) *invIterator {

--- a/pkg/monitors/vsphere/service/perf_fetcher.go
+++ b/pkg/monitors/vsphere/service/perf_fetcher.go
@@ -12,7 +12,7 @@ type perfFetcher interface {
 
 // Creates a perfFetcher implementation, either a singlePage or multiPage,
 // depending on pageSize (pageSize==0 turns off pagination).
-func newPerfFetcher(gateway IGateway, pageSize int, log *log.Entry) perfFetcher {
+func newPerfFetcher(gateway IGateway, pageSize int, log log.FieldLogger) perfFetcher {
 	if pageSize == 0 {
 		return &singlePagePerfFetcher{
 			gateway: gateway,

--- a/pkg/monitors/vsphere/service/points.go
+++ b/pkg/monitors/vsphere/service/points.go
@@ -13,7 +13,7 @@ import (
 )
 
 type PointsSvc struct {
-	log         *logrus.Entry
+	log         logrus.FieldLogger
 	gateway     IGateway
 	perfFetcher perfFetcher
 	ptConsumer  func(...*datapoint.Datapoint)
@@ -21,7 +21,7 @@ type PointsSvc struct {
 
 func NewPointsSvc(
 	gateway IGateway,
-	log *logrus.Entry,
+	log logrus.FieldLogger,
 	batchSize int,
 	ptConsumer func(...*datapoint.Datapoint),
 ) *PointsSvc {

--- a/pkg/monitors/vsphere/service/single_perf_fetcher.go
+++ b/pkg/monitors/vsphere/service/single_perf_fetcher.go
@@ -8,7 +8,7 @@ import (
 
 type singlePagePerfFetcher struct {
 	gateway IGateway
-	log     *log.Entry
+	log     log.FieldLogger
 }
 
 func (f *singlePagePerfFetcher) invIterator(

--- a/pkg/monitors/vsphere/vsphere_monitor.go
+++ b/pkg/monitors/vsphere/vsphere_monitor.go
@@ -15,7 +15,7 @@ import (
 // Encapsulates services and the current state of the vSphere monitor.
 type vSphereMonitor struct {
 	conf *model.Config
-	log  *logrus.Entry
+	log  logrus.FieldLogger
 
 	invSvc    *service.InventorySvc
 	metricSvc *service.MetricsSvc
@@ -31,7 +31,7 @@ type vSphereMonitor struct {
 
 func newVsphereMonitor(
 	conf *model.Config,
-	log *logrus.Entry,
+	log logrus.FieldLogger,
 	ptConsumer func(...*datapoint.Datapoint),
 ) *vSphereMonitor {
 	return &vSphereMonitor{

--- a/pkg/monitors/windowsiis/windowsiis.go
+++ b/pkg/monitors/windowsiis/windowsiis.go
@@ -1,11 +1,12 @@
 package windowsiis
 
 import (
-	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
+	"github.com/sirupsen/logrus"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
+	"github.com/signalfx/signalfx-agent/pkg/utils/timeutil"
 )
 
 func init() {
@@ -27,6 +28,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/windowsiis/windowsiis_windows.go
+++ b/pkg/monitors/windowsiis/windowsiis_windows.go
@@ -7,17 +7,19 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var logger = logrus.WithField("monitorType", monitorType)
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
+	m.logger = logger.WithField("monitorID", conf.MonitorID)
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,
@@ -93,7 +95,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	// create batch emitter
-	emitter := baseemitter.NewEmitter(m.Output, logger)
+	emitter := baseemitter.NewEmitter(m.Output, m.logger)
 
 	// Hard code the plugin name because the emitter will parse out the
 	// configured measurement name as plugin and that is confusing.
@@ -121,7 +123,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	// gather metrics on the specified interval
 	utils.RunOnInterval(ctx, func() {
 		if err := plugin.Gather(ac); err != nil {
-			logger.WithError(err).Errorf("an error occurred while gathering metrics from the plugin")
+			m.logger.WithError(err).Errorf("an error occurred while gathering metrics from the plugin")
 		}
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 

--- a/pkg/monitors/windowslegacy/windowslegacy.go
+++ b/pkg/monitors/windowslegacy/windowslegacy.go
@@ -1,6 +1,8 @@
 package windowslegacy
 
 import (
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/monitors"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/types"
@@ -26,6 +28,7 @@ type Config struct {
 type Monitor struct {
 	Output types.Output
 	cancel func()
+	logger logrus.FieldLogger // nolint: structcheck,unused
 }
 
 // Shutdown stops the metric sync

--- a/pkg/monitors/windowslegacy/windowslegacy_windows.go
+++ b/pkg/monitors/windowslegacy/windowslegacy_windows.go
@@ -7,17 +7,19 @@ import (
 	"context"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/accumulator"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/common/emitter/baseemitter"
 	"github.com/signalfx/signalfx-agent/pkg/monitors/telegraf/monitors/winperfcounters"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/sirupsen/logrus"
 )
 
 var logger = logrus.WithField("monitorType", monitorType)
 
 // Configure the monitor and kick off metric syncing
 func (m *Monitor) Configure(conf *Config) error {
+	m.logger = logger.WithField("monitorID", conf.MonitorID)
 	perfcounterConf := &winperfcounters.Config{
 		CountersRefreshInterval: conf.CountersRefreshInterval,
 		PrintValid:              conf.PrintValid,
@@ -125,7 +127,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	}
 
 	// create batch emitter
-	emitter := baseemitter.NewEmitter(m.Output, logger)
+	emitter := baseemitter.NewEmitter(m.Output, m.logger)
 
 	// Hard code the plugin name because the emitter will parse out the
 	// configured measurement name as plugin and that is confusing.
@@ -153,7 +155,7 @@ func (m *Monitor) Configure(conf *Config) error {
 	// gather metrics on the specified interval
 	utils.RunOnInterval(ctx, func() {
 		if err := plugin.Gather(ac); err != nil {
-			logger.WithError(err).Errorf("an error occurred while gathering metrics from the plugin")
+			m.logger.WithError(err).Errorf("an error occurred while gathering metrics from the plugin")
 		}
 	}, time.Duration(conf.IntervalSeconds)*time.Second)
 

--- a/pkg/neotest/k8s/testhelpers/fakek8s/fakek8s.go
+++ b/pkg/neotest/k8s/testhelpers/fakek8s/fakek8s.go
@@ -10,9 +10,8 @@ import (
 	"sync"
 
 	"github.com/davecgh/go-spew/spew"
-	log "github.com/sirupsen/logrus"
-
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/observers/docker/docker.go
+++ b/pkg/observers/docker/docker.go
@@ -8,13 +8,12 @@ import (
 	"strconv"
 	"strings"
 
+	dtypes "github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
-	dtypes "github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	dockercommon "github.com/signalfx/signalfx-agent/pkg/core/common/docker"
-
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/observers"

--- a/pkg/observers/ecs/ecs.go
+++ b/pkg/observers/ecs/ecs.go
@@ -10,12 +10,13 @@ import (
 	"strings"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/common/ecs"
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/observers"
 	"github.com/signalfx/signalfx-agent/pkg/observers/docker"
-	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/observers/host/host.go
+++ b/pkg/observers/host/host.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/shirou/gopsutil/net"
 	"github.com/shirou/gopsutil/process"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
@@ -41,7 +40,7 @@ type Observer struct {
 	serviceCallbacks *observers.ServiceCallbacks
 	serviceDiffer    *observers.ServiceDiffer
 	config           *Config
-	logger           logrus.FieldLogger
+	logger           log.FieldLogger
 }
 
 // Config specific to the host observer

--- a/pkg/observers/kubelet/kubelet.go
+++ b/pkg/observers/kubelet/kubelet.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/common/kubelet"
@@ -78,7 +77,7 @@ type Observer struct {
 	client           *kubelet.Client
 	serviceDiffer    *observers.ServiceDiffer
 	serviceCallbacks *observers.ServiceCallbacks
-	logger           logrus.FieldLogger
+	logger           log.FieldLogger
 }
 
 // pod structure from kubelet
@@ -124,10 +123,10 @@ func init() {
 
 // Configure the kubernetes observer/client
 func (k *Observer) Configure(config *Config) error {
-	k.logger = logrus.WithFields(logrus.Fields{"observerType": observerType})
+	k.logger = log.WithFields(log.Fields{"observerType": observerType})
 
 	var err error
-	k.client, err = kubelet.NewClient(&config.KubeletAPI)
+	k.client, err = kubelet.NewClient(&config.KubeletAPI, k.logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/observers/kubernetes/annotations.go
+++ b/pkg/observers/kubernetes/annotations.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/signalfx/signalfx-agent/pkg/utils"
-	"github.com/signalfx/signalfx-agent/pkg/utils/k8sutil"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	k8s "k8s.io/client-go/kubernetes"
+
+	"github.com/signalfx/signalfx-agent/pkg/utils"
+	"github.com/signalfx/signalfx-agent/pkg/utils/k8sutil"
 )
 
 var annotationConfigRegexp = regexp.MustCompile(

--- a/pkg/observers/kubernetes/api.go
+++ b/pkg/observers/kubernetes/api.go
@@ -10,9 +10,7 @@ import (
 	"os"
 	"reflect"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
-
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -162,12 +160,12 @@ type Observer struct {
 	// removed.
 	endpointsByUID map[types.UID][]services.Endpoint
 	stopper        chan struct{}
-	logger         logrus.FieldLogger
+	logger         log.FieldLogger
 }
 
 // Configure configures and starts watching for endpoints
 func (o *Observer) Configure(config *Config) error {
-	o.logger = logrus.WithFields(log.Fields{"observerType": observerType})
+	o.logger = log.WithFields(log.Fields{"observerType": observerType})
 
 	// There is a bug/limitation in the k8s go client's Controller where
 	// goroutines are leaked even when using the stop channel properly.  So we

--- a/pkg/observers/manager.go
+++ b/pkg/observers/manager.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/config"
 )
 
 // ObserverWrapper represents an active observer

--- a/pkg/observers/observer.go
+++ b/pkg/observers/observer.go
@@ -11,11 +11,12 @@ package observers
 
 import (
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/validation"
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
-	log "github.com/sirupsen/logrus"
 )
 
 // Shutdownable describes an observer that has a shutdown routine.  Observers

--- a/pkg/observers/servicediffer.go
+++ b/pkg/observers/servicediffer.go
@@ -3,8 +3,9 @@ package observers
 import (
 	"time"
 
-	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	log "github.com/sirupsen/logrus"
+
+	"github.com/signalfx/signalfx-agent/pkg/core/services"
 )
 
 // ServiceDiffer will run the DiscoveryFn every IntervalSeconds and report

--- a/pkg/selfdescribe/observers.go
+++ b/pkg/selfdescribe/observers.go
@@ -8,9 +8,10 @@ import (
 	"sort"
 	"strings"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/signalfx/signalfx-agent/pkg/core/services"
 	"github.com/signalfx/signalfx-agent/pkg/observers"
-	log "github.com/sirupsen/logrus"
 )
 
 type observerMetadata struct {

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -55,7 +55,7 @@ type LogrusGolibShim struct {
 	logrus.FieldLogger
 }
 
-var _ log.Logger = &LogrusGolibShim{}
+var _ log.Logger = (*LogrusGolibShim)(nil)
 
 // Log conforms to the golib Log interface
 func (l *LogrusGolibShim) Log(keyvals ...interface{}) {

--- a/pkg/utils/log_test.go
+++ b/pkg/utils/log_test.go
@@ -5,9 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/signalfx-agent/pkg/neotest"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/signalfx/signalfx-agent/pkg/neotest"
 )
 
 func TestThrottledLogger(t *testing.T) {


### PR DESCRIPTION
These changes move from the global logrus standard logger to per-monitor instance loggers that also set their `"monitorID"` field to be able to better differentiate between monitor instances. This is required for future Splunk collector distribution functionality and to fix a limitation in the Smart Agent receiver where all instances of a particular monitor type are reported to use the same collector component logger despite collecting data from different entities (makes debugging difficult).

I believe that all subprocess monitors already set a `monitorID` field so this continues the pattern w/ native ones.

edit: there are also a number of import ordering changes that were automatically applied from goland.**

edit: Appears to be some deadlock/race condition scenarios in unrelated test that I've tried to address.