### PR TITLE
Update java to 11.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt update &&\
     apt install -y wget maven
 
 ARG TARGET_ARCH
-ARG JDK_VERSION=11.0.15_10
+ARG JDK_VERSION=11.0.16_8
 
 ENV OPENJDK_BASE_URL="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download"
 


### PR DESCRIPTION
Patching jdk to the latest patch available https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/tag/jdk-11.0.16%2B8

```
...
$ make run-dev-image
...
root@0058dd79a822:/usr/src/signalfx-agent# /bundle/jre/bin/java --version
openjdk 11.0.16 2022-07-19
OpenJDK Runtime Environment 18.9 (build 11.0.16+8)
OpenJDK 64-Bit Server VM 18.9 (build 11.0.16+8, mixed mode)
```