### PR TITLE
Fix jenkins test

### DIFF
--- a/test-services/jenkins/Dockerfile
+++ b/test-services/jenkins/Dockerfile
@@ -2,7 +2,7 @@ ARG JENKINS_REPO=jenkins/jenkins
 ARG JENKINS_VERSION=alpine
 FROM ${JENKINS_REPO}:${JENKINS_VERSION}
 COPY metrics.groovy /usr/share/jenkins/ref/init.groovy.d/metrics.groovy
-RUN /usr/local/bin/install-plugins.sh docker-slaves metrics
+RUN jenkins-plugin-cli -p docker-slaves metrics
 
 ARG JENKINS_PORT
 


### PR DESCRIPTION
https://github.com/signalfx/signalfx-agent/runs/7566145652?check_suite_focus=true
`/usr/local/bin/install-plugins.sh` has been removed in the latest image.