### PR TITLE
VSphere : option to enable soap client debugging

### DIFF
--- a/docs/monitors/vsphere.md
+++ b/docs/monitors/vsphere.md
@@ -70,6 +70,7 @@ Configuration](../monitor-config.md#common-configuration).**
 | `tlsCACertPath` | no | `string` | Path to the ca file |
 | `tlsClientCertificatePath` | no | `string` | Configure client certs. Both tlsClientKeyPath and tlsClientCertificatePath must be present. The files must contain PEM encoded data. Path to the client certificate |
 | `tlsClientKeyPath` | no | `string` | Path to the keyfile |
+| `soapClientDebug` | no | `bool` | When set to true, all the SOAP requests and responses will be logged. This generates lots of data, only use it for debugging. For this setting to take effect, make sure to restart the agent (**default:** `false`) |
 
 
 ## Metrics

--- a/pkg/monitors/vsphere/model/model.go
+++ b/pkg/monitors/vsphere/model/model.go
@@ -72,6 +72,10 @@ type Config struct {
 	TLSClientCertificatePath string `yaml:"tlsClientCertificatePath"`
 	// Path to the keyfile
 	TLSClientKeyPath string `yaml:"tlsClientKeyPath"`
+	// When set to true, all the SOAP requests and responses will be logged.
+	// This generates lots of data, only use it for debugging.
+	// For this setting to take effect, make sure to restart the agent
+	SOAPClientDebug bool `yaml:"soapClientDebug"`
 }
 
 type Dimensions map[string]string

--- a/pkg/monitors/vsphere/service/auth.go
+++ b/pkg/monitors/vsphere/service/auth.go
@@ -9,6 +9,7 @@ import (
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/debug"
 	"github.com/vmware/govmomi/vim25/soap"
 
 	"github.com/signalfx/signalfx-agent/pkg/monitors/vsphere/model"
@@ -60,6 +61,9 @@ func (svc *AuthService) newGovmomiClient(ctx context.Context, myURL *url.URL, co
 }
 
 func (svc *AuthService) newVimClient(ctx context.Context, myURL *url.URL, conf *model.Config) (*vim25.Client, error) {
+	if conf.SOAPClientDebug {
+		debug.SetProvider(&LogProvider{log: svc.log})
+	}
 	soapClient := soap.NewClient(myURL, conf.InsecureSkipVerify)
 	if conf.TLSCACertPath != "" {
 		svc.log.Info("Attempting to load TLSCACertPath from ", conf.TLSCACertPath)

--- a/pkg/monitors/vsphere/service/log_provider.go
+++ b/pkg/monitors/vsphere/service/log_provider.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"io"
+	"regexp"
+
+	"github.com/sirupsen/logrus"
+)
+
+type LogWriterCloser struct {
+	log logrus.FieldLogger
+}
+
+func NewLogWriterCloser(log logrus.FieldLogger) *LogWriterCloser {
+	return &LogWriterCloser{log: log}
+}
+
+func (lwc *LogWriterCloser) Write(p []byte) (n int, err error) {
+	lwc.log.Info(string(Scrub(p)))
+	return len(p), nil
+}
+
+func (lwc *LogWriterCloser) Close() error {
+	return nil
+}
+
+type LogProvider struct {
+	log logrus.FieldLogger
+}
+
+func (s *LogProvider) NewFile(p string) io.WriteCloser {
+	return NewLogWriterCloser(s.log)
+}
+
+func (s *LogProvider) Flush() {
+}
+
+var scrubPassword = regexp.MustCompile(`<password>(.*)</password>`)
+
+func Scrub(in []byte) []byte {
+	return scrubPassword.ReplaceAll(in, []byte(`<password>********</password>`))
+}

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -56607,6 +56607,14 @@
             "required": false,
             "type": "string",
             "elementKind": ""
+          },
+          {
+            "yamlName": "soapClientDebug",
+            "doc": "When set to true, all the SOAP requests and responses will be logged. This generates lots of data, only use it for debugging. For this setting to take effect, make sure to restart the agent",
+            "default": false,
+            "required": false,
+            "type": "bool",
+            "elementKind": ""
           }
         ]
       },


### PR DESCRIPTION
The VSphere monitor is hard to debug as the log messages don’t provide markers to where the code has failed, it only returns the low level error from the SDK.

For example, from this error, it’s almost impossible to know which API call caused it.

```
Aug 30 17:28:41 dtvadb02.bbldtl.int otelcol[31973]: 2022-08-30T17:28:41.873+1000        error        vsphere/runner.go:34        firstTimeSetup failed        {"kind": "receiver", "name": "smartagent/vsphere", "pipeline": "metrics", "monitorType":        "vsphere", "error": "Post \"https://xxxxxxx/sdk\": Forbidden"}
```
This bug is to allow the user to turn debugging on the SOAP client so we can see the SOAP requests/responses

Signed-off-by: Dani Louca <dlouca@splunk.com>