### PR TITLE
Update SmartAgent deprecation date

### DIFF
--- a/docs/smartagent-deprecation-notice.md
+++ b/docs/smartagent-deprecation-notice.md
@@ -1,5 +1,5 @@
 > # :warning: Deprecation Notice for SignalFx Smart Agent
-> **The SignalFx Smart Agent is deprecated and will reach End of Support on December 17th, 2022. After that date, this repository will be archived and no longer receive updates. Until then, only critical security fixes and bug fixes will be provided.**
+> **The SignalFx Smart Agent is deprecated and will reach End of Support on June 30th, 2023. After that date, this repository will be archived and no longer receive updates. Until then, only critical security fixes and bug fixes will be provided.**
 >
 >Going forward, you should use the [Splunk Distribution of OpenTelemetry Connector](https://docs.splunk.com/Observability/gdi/opentelemetry/resources.html), which fully supports the OpenTelemetry standard and includes customizations for:
 >* Splunk products


### PR DESCRIPTION
Update the date listed in the deprecation notice to reflect the extended date of June 30th, 2023.