### PR TITLE
Update Java to 11.0.16.1_1 and new GitHub repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ RUN ENCODED_VER=$(echo $JDK_VERSION | sed 's/_/%2B/g') && \
 
 RUN mkdir -p /opt/root && \
     tar -C /opt/root -xzf /tmp/openjdk.tar.gz && \
-    mv /opt/root/openjdk* /opt/root/jdk && \
+    mv /opt/root/jdk* /opt/root/jdk && \
     rm -f /tmp/openjdk.tar.gz
 
 ENV JAVA_HOME=/opt/root/jdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,15 +43,15 @@ RUN apt update &&\
     apt install -y wget maven
 
 ARG TARGET_ARCH
-ARG JDK_VERSION=11.0.16_8
+ARG JDK_VERSION=11.0.16.1_1
 
-ENV OPENJDK_BASE_URL="https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download"
+ENV OPENJDK_BASE_URL="https://github.com/adoptium/temurin11-binaries/releases/download"
 
 RUN ENCODED_VER=$(echo $JDK_VERSION | sed 's/_/%2B/g') && \
     if [ "$TARGET_ARCH" = "amd64" ]; then \
-    OPENJDK_URL="${OPENJDK_BASE_URL}/jdk-${ENCODED_VER}/OpenJDK11U-jdk_x64_linux_${JDK_VERSION}.tar.gz"; \
+    OPENJDK_URL="${OPENJDK_BASE_URL}/jdk-${ENCODED_VER}/OpenJDK11U-jdk_x64_linux_hotspot_${JDK_VERSION}.tar.gz"; \
     else \
-    OPENJDK_URL="${OPENJDK_BASE_URL}/jdk-${ENCODED_VER}/OpenJDK11U-jdk_aarch64_linux_${JDK_VERSION}.tar.gz"; \
+    OPENJDK_URL="${OPENJDK_BASE_URL}/jdk-${ENCODED_VER}/OpenJDK11U-jdk_aarch64_linux_hotspot_${JDK_VERSION}.tar.gz"; \
     fi && \
     wget -O /tmp/openjdk.tar.gz "$OPENJDK_URL"
 


### PR DESCRIPTION
Update Java from `11.0.16_8` to `11.0.16.1_1`

The previous URL for the JDK downloads has been archived/deprecated, so the `OPENJDK_BASE_URL` has also been updated.

Old: https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries
Update blog post: https://blog.adoptopenjdk.net/2021/03/transition-to-eclipse-an-update/
New: https://github.com/adoptium/temurin11-binaries/releases