### PR TITLE
Migrate off signalfx/defaults

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/beevik/ntp v0.3.0
 	github.com/cloudfoundry-incubator/uaago v0.0.0-20190307164349-8136b7bbe76e
 	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
+	github.com/creasty/defaults v1.6.0
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/denisenkom/go-mssqldb v0.12.3
 	github.com/docker/docker v20.10.18+incompatible
@@ -84,7 +85,6 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20200724154423-2164a8ac840e
 	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
-	github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657
 	github.com/signalfx/gateway v1.2.23
 	github.com/signalfx/golib/v3 v3.3.47
 	github.com/signalfx/ingest-protocols v0.1.14
@@ -117,7 +117,6 @@ require (
 
 require (
 	collectd.org v0.5.0 // indirect
-	github.com/creasty/defaults v1.5.1 // indirect
 	github.com/guregu/null v4.0.0+incompatible // indirect
 	github.com/influxdata/tail v1.0.0 // indirect
 	github.com/influxdata/toml v0.0.0-20180607005434-2a2e3012f7cf // indirect

--- a/go.sum
+++ b/go.sum
@@ -312,8 +312,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/creasty/defaults v1.5.1 h1:j8WexcS3d/t4ZmllX4GEkl4wIB/trOr035ajcLHCISM=
-github.com/creasty/defaults v1.5.1/go.mod h1:FPZ+Y0WNrbqOVw+c6av63eyHUAl6pMHZwqLPvXUZGfY=
+github.com/creasty/defaults v1.6.0 h1:ltuE9cfphUtlrBeomuu8PEyISTXnxqkBIoQfXgv7BSc=
+github.com/creasty/defaults v1.6.0/go.mod h1:iGzKe6pbEHnpMPtfDXZEr0NVxWnPTjb1bbDy08fPzYM=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v0.0.0-20161028175848-04cdfd42973b/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1370,8 +1370,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.0-20190222193949-1fb69526e884/go.mod h1:muYA2clvwCdj7nzAJ5vJIXYpJsUumhAl4Uu1wUNpWzA=
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3 h1:32k2QLgsKhcEs55q4REPKyIadvid5FPy2+VMgvbmKJ0=
 github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3/go.mod h1:gJrXWi7wSGXfiC7+VheQaz+ypdCt5SmZNL+BRxUe7y4=
-github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657 h1:2B5haF9erda6sSaeHpGKqmgM3irTkjB0bkdjWoV5Qbo=
-github.com/signalfx/defaults v1.2.2-0.20180531161417-70562fe60657/go.mod h1:mUgf0Go14xjLxNZFSGSK9m+GT7jCHyECuCjPh1zadUc=
 github.com/signalfx/gateway v1.2.23 h1:+yDgpU7qp3Ypha6naV6Uflk9u8R3LrqRjZ/ha3+1OrY=
 github.com/signalfx/gateway v1.2.23/go.mod h1:YzAGMSBSeqjV1okKI03Rx/eyQsMOt9SocbWQE5FTmls=
 github.com/signalfx/go-loggregator v1.0.1-0.20200205155641-5ba5ca92118d h1:pASiJ1M7WilKj0vFhVmOjeMiu7KxDdiL4t96LGuGKtw=

--- a/pkg/core/config/config_test.go
+++ b/pkg/core/config/config_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/signalfx/defaults"
+	"github.com/creasty/defaults"
 	"github.com/signalfx/golib/v3/pointer"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/core/config/dynamic.go
+++ b/pkg/core/config/dynamic.go
@@ -6,9 +6,9 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/creasty/defaults"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pkg/errors"
-	"github.com/signalfx/defaults"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/core/config/loader.go
+++ b/pkg/core/config/loader.go
@@ -9,8 +9,8 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/creasty/defaults"
 	"github.com/pkg/errors"
-	"github.com/signalfx/defaults"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources"
 	"github.com/signalfx/signalfx-agent/pkg/utils"
 	"github.com/signalfx/signalfx-agent/pkg/utils/structtags"

--- a/pkg/core/config/sources/sources.go
+++ b/pkg/core/config/sources/sources.go
@@ -9,9 +9,9 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/creasty/defaults"
 	"github.com/mitchellh/hashstructure"
 	"github.com/pkg/errors"
-	"github.com/signalfx/defaults"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/consul"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/env"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/sources/etcd2"

--- a/pkg/core/config/sources/zookeeper/zookeeper.go
+++ b/pkg/core/config/sources/zookeeper/zookeeper.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/creasty/defaults"
 	"github.com/samuel/go-zookeeper/zk"
-	"github.com/signalfx/defaults"
 	"github.com/signalfx/signalfx-agent/pkg/core/config/types"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/monitors/activemonitor.go
+++ b/pkg/monitors/activemonitor.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/creasty/defaults"
 	"github.com/pkg/errors"
-	"github.com/signalfx/defaults"
 
 	"github.com/signalfx/signalfx-agent/pkg/core/config"
 	"github.com/signalfx/signalfx-agent/pkg/core/meta"

--- a/pkg/utils/timeutil/duration_test.go
+++ b/pkg/utils/timeutil/duration_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/signalfx/defaults"
+	"github.com/creasty/defaults"
 
 	"gopkg.in/yaml.v2"
 )


### PR DESCRIPTION
Remove the dependency on signalfx/defaults as it has been archived, prefer to use github.com/creasty/defaults instead.
