### PR TITLE
Update Helm chart for latest release

### DIFF
--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.27.0
+    version: 5.27.1
 spec:
   selector:
     matchLabels:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.27.0
+        version: 5.27.1
 
       annotations:
         {}
@@ -45,7 +45,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.27.0"
+        image: "quay.io/signalfx/signalfx-agent:5.27.1"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent

--- a/deployments/k8s/serverless/deployment.yaml
+++ b/deployments/k8s/serverless/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.27.0
+    version: 5.27.1
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.27.0
+        version: 5.27.1
 
       annotations:
         {}
@@ -36,7 +36,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.27.0"
+        image: "quay.io/signalfx/signalfx-agent:5.27.1"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent


### PR DESCRIPTION
For every release the helm chart needs to be updated to point at the new release. This updates the helm chart for v5.27.1.