### PR TITLE
Release 5.27.2

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-ARG AGENT_VERSION="5.27.1"
+ARG AGENT_VERSION="5.27.2"
 LABEL name="SignalFx Smart Agent" \
 	  maintainer="SignalFx, Inc." \
 	  vendor="SignalFx, Inc." \

--- a/deployments/cloudfoundry/buildpack/bin/supply
+++ b/deployments/cloudfoundry/buildpack/bin/supply
@@ -11,7 +11,7 @@ BUILDPACK_DIR=`dirname $(readlink -f ${BASH_SOURCE%/*})`
 TARGET_DIR="$BUILD_DIR/.signalfx"
 
 # Set a default version of the SignalFx Agent to use if none is specified
-SIGNALFX_AGENT_VERSION="${SIGNALFX_AGENT_VERSION-5.27.1}"
+SIGNALFX_AGENT_VERSION="${SIGNALFX_AGENT_VERSION-5.27.2}"
 
 echo "-----> Installing signalfx-agent ${SIGNALFX_AGENT_VERSION}"
 echo "       BUILD_DIR: $BUILD_DIR"

--- a/deployments/ecs/signalfx-agent-task.json
+++ b/deployments/ecs/signalfx-agent-task.json
@@ -33,7 +33,7 @@
                 },
                 {
                     "name": "CONFIG_URL",
-                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.27.1/deployments/ecs/agent.yaml"
+                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.27.2/deployments/ecs/agent.yaml"
                 }
             ],
             "ulimits": null,
@@ -60,7 +60,7 @@
             "memory": null,
             "memoryReservation": null,
             "volumesFrom": [],
-            "image": "quay.io/signalfx/signalfx-agent:5.27.1",
+            "image": "quay.io/signalfx/signalfx-agent:5.27.2",
             "disableNetworking": null,
             "healthCheck": null,
             "essential": true,

--- a/deployments/fargate/example-fargate-task.json
+++ b/deployments/fargate/example-fargate-task.json
@@ -34,14 +34,14 @@
                 },
                 {
                     "name": "CONFIG_URL",
-                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.27.1/deployments/fargate/agent.yaml"
+                    "value": "https://raw.githubusercontent.com/signalfx/signalfx-agent/v5.27.2/deployments/fargate/agent.yaml"
                 }
             ],
             "dockerLabels": {
                 "app": "signalfx-agent"
             },
             "name": "signalfx-agent",
-            "image": "quay.io/signalfx/signalfx-agent:5.27.1"
+            "image": "quay.io/signalfx/signalfx-agent:5.27.2"
         }
     ],
     "cpu": "128",

--- a/deployments/k8s/daemonset.yaml
+++ b/deployments/k8s/daemonset.yaml
@@ -6,7 +6,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.27.1
+    version: 5.27.2
 spec:
   selector:
     matchLabels:
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.27.1
+        version: 5.27.2
 
       annotations:
         {}
@@ -45,7 +45,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.27.1"
+        image: "quay.io/signalfx/signalfx-agent:5.27.2"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent

--- a/deployments/k8s/helm/signalfx-agent/Chart.yaml
+++ b/deployments/k8s/helm/signalfx-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: The SignalFx Smart Agent
 name: signalfx-agent
-appVersion: 5.27.1
+appVersion: 5.27.2
 version: 1.11.0
 keywords:
 - monitoring

--- a/deployments/k8s/helm/signalfx-agent/README.md
+++ b/deployments/k8s/helm/signalfx-agent/README.md
@@ -88,7 +88,7 @@ gatherClusterMetrics: false
 # If your kube install is using CRI-O instead of docker, set the below to false.
 gatherDockerMetrics: true
 
-agentVersion: 5.27.1
+agentVersion: 5.27.2
 
 # Kubelet on Windows doesn't seem to have the usage_bytes metrics so we'll
 # transform the working set metric to it so that built-in content works.
@@ -107,7 +107,7 @@ kubeletAPI:
 image:
   repository: quay.io/signalfx/signalfx-agent
   # This is a special windows container release of the agent for Windows.
-  tag: 5.27.1-windows
+  tag: 5.27.2-windows
   pullPolicy: Always
 ```
 

--- a/deployments/k8s/helm/signalfx-agent/values.yaml
+++ b/deployments/k8s/helm/signalfx-agent/values.yaml
@@ -1,6 +1,6 @@
 # Version of the signalfx-agent to deploy.  This will be the default for the
 # docker image tag if not overridden with imageTag
-agentVersion: 5.27.1
+agentVersion: 5.27.2
 
 # If false, datapoints, events, and spans will not be emitted to the SignalFx
 # backend.

--- a/deployments/k8s/serverless/deployment.yaml
+++ b/deployments/k8s/serverless/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   name: signalfx-agent
   labels:
     app: signalfx-agent
-    version: 5.27.1
+    version: 5.27.2
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
     metadata:
       labels:
         app: signalfx-agent
-        version: 5.27.1
+        version: 5.27.2
 
       annotations:
         {}
@@ -36,7 +36,7 @@ spec:
 
       containers:
       - name: signalfx-agent
-        image: "quay.io/signalfx/signalfx-agent:5.27.1"
+        image: "quay.io/signalfx/signalfx-agent:5.27.2"
         imagePullPolicy: IfNotPresent
         command:
         - /bin/signalfx-agent

--- a/deployments/splunk/docker-compose.yml
+++ b/deployments/splunk/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - /opt/splunk/var
       - /opt/splunk/etc
   signalfx-agent:
-    image: quay.io/signalfx/signalfx-agent:5.27.1
+    image: quay.io/signalfx/signalfx-agent:5.27.2
     container_name: signalfx-agent
     restart: always
     depends_on:

--- a/scripts/current-version
+++ b/scripts/current-version
@@ -17,7 +17,7 @@ tag=$($latest_tag --exact-match 2>/dev/null)
 # Clone didn't clone tags
 if test -z $tag
 then
-  tag="v5.27.1" # Updated by scripts/update-deployments-version
+  tag="v5.27.2" # Updated by scripts/update-deployments-version
 fi
 
 if test -z $tag || [[ $tag =~ (deb|rpm) ]]


### PR DESCRIPTION
Includes a bugfix for k8s service auth refresh helm chart, and codeowners

My understanding is I should merge this into main and then do the `git tag -a v5.27.2 && git push tags`