### PR TITLE
upgrade protobuf and mysql-connector-python

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,9 +3,9 @@ black==22.12.0
 docker==6.0.1
 hvac==0.11.2
 kubernetes==21.7.0
-mysql-connector-python==8.0.31
+mysql-connector-python==8.0.32
 netifaces==0.11.0
-protobuf==3.20.1
+protobuf==3.20.2
 psutil==5.9.4
 pylint==2.13.9
 pytest-split==0.8.0


### PR DESCRIPTION
upgrade protobuf and mysql-connector-python at the same time to resolve strict versioning conflicts.

This upgrades protobuf to 3.20.2 and mysql-connector-python to 8.0.32.