### PR TITLE
Downgrade gh to 2.22.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -394,10 +394,8 @@ github-release:
     - win-msi-sign
   before_script:
     # install gh cli
-    - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
-    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-    - apt update
-    - apt install -y gh
+    - wget https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_linux_amd64.deb
+    - dpkg -i gh_2.22.1_linux_amd64.deb
   script:
     - mkdir -p dist/assets/
     - mv dist/signalfx-agent-*.tar.gz dist/assets/


### PR DESCRIPTION
Downgrade `gh` cli to last known working version since the latest version fails to create releases.