### PR TITLE
Update runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -242,8 +242,7 @@ jobs:
 
   integration_test:
     name: integration_test
-    # Running on Ubuntu 18.04 as Collectd python plugin required version GLIBC_2.29 which is not available on ubuntu-latest (20.04)
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [build]
     timeout-minutes: 60
     strategy:
@@ -315,6 +314,8 @@ jobs:
           echo "TEST_SERVICES_DIR=$TEST_SERVICES_DIR" >> $GITHUB_ENV
           echo "MARKERS=$MARKERS" >> $GITHUB_ENV
           echo "DEFAULT_TIMEOUT=120" >> $GITHUB_ENV
+          # LD_LIBRARY_PATH is set by actions/setup-python and conflicts with the agent
+          echo "LD_LIBRARY_PATH=" >> $GITHUB_ENV
           sudo apt-get update
           sudo apt-get install -y --only-upgrade ca-certificates
       - name: Run pytest

--- a/test-services/awsapi/requirements.txt
+++ b/test-services/awsapi/requirements.txt
@@ -1,2 +1,3 @@
 
 sanic==22.9.1
+websockets~=10.0


### PR DESCRIPTION
The `ubuntu-18.04` runner is no longer available: https://github.com/actions/runner-images/tree/main/images/linux