### PR TITLE
Fixing systemd metadata so sendLoadState, sendSubState and sendActiveState work again

### DIFF
--- a/docs/monitors/collectd-systemd.md
+++ b/docs/monitors/collectd-systemd.md
@@ -81,35 +81,35 @@ Metrics that are categorized as
 (*default*) are ***in bold and italics*** in the list below.
 
 
- - `gauge.active_state.activating` (*gauge*)<br>    Indicates that the systemd unit/service has previously been inactive but is currently in the process of entering an active state
- - `gauge.active_state.active` (*gauge*)<br>    Indicates that the systemd unit/service is active
- - `gauge.active_state.deactivating` (*gauge*)<br>    Indicates that the systemd unit/service is currently in the process of deactivation
- - `gauge.active_state.failed` (*gauge*)<br>    Indicates that the systemd unit/service is inactive the previous run was not successful
- - `gauge.active_state.inactive` (*gauge*)<br>    Indicates that the systemd unit/service is inactive and the previous run was successful or no previous run has taken place yet
- - `gauge.active_state.reloading` (*gauge*)<br>    Indicates that the systemd unit/service is active and currently reloading its configuration
- - `gauge.load_state.error` (*gauge*)<br>    Indicates that the systemd unit/service configuration failed to load
- - `gauge.load_state.loaded` (*gauge*)<br>    Indicates that the systemd unit/service configuration was loaded and parsed successfully
- - `gauge.load_state.masked` (*gauge*)<br>    Indicates that the systemd unit/service is currently masked out (i.e. symlinked to /dev/null etc)
- - `gauge.load_state.not-found` (*gauge*)<br>    Indicates that the systemd unit/service configuration was not found
- - `gauge.substate.dead` (*gauge*)<br>    Indicates that the systemd unit/service died
- - `gauge.substate.exited` (*gauge*)<br>    Indicates that the systemd unit/service exited
- - `gauge.substate.failed` (*gauge*)<br>    Indicates that the systemd unit/service failed
  - ***`gauge.substate.running`*** (*gauge*)<br>    Indicates that the systemd unit/service is running
 
 #### Group ActiveState
 All of the following metrics are part of the `ActiveState` metric group. All of
 the non-default metrics below can be turned on by adding `ActiveState` to the
 monitor config option `extraGroups`:
+ - `gauge.active_state.activating` (*gauge*)<br>    Indicates that the systemd unit/service has previously been inactive but is currently in the process of entering an active state
+ - `gauge.active_state.active` (*gauge*)<br>    Indicates that the systemd unit/service is active
+ - `gauge.active_state.deactivating` (*gauge*)<br>    Indicates that the systemd unit/service is currently in the process of deactivation
+ - `gauge.active_state.failed` (*gauge*)<br>    Indicates that the systemd unit/service is inactive the previous run was not successful
+ - `gauge.active_state.inactive` (*gauge*)<br>    Indicates that the systemd unit/service is inactive and the previous run was successful or no previous run has taken place yet
+ - `gauge.active_state.reloading` (*gauge*)<br>    Indicates that the systemd unit/service is active and currently reloading its configuration
 
 #### Group LoadState
 All of the following metrics are part of the `LoadState` metric group. All of
 the non-default metrics below can be turned on by adding `LoadState` to the
 monitor config option `extraGroups`:
+ - `gauge.load_state.error` (*gauge*)<br>    Indicates that the systemd unit/service configuration failed to load
+ - `gauge.load_state.loaded` (*gauge*)<br>    Indicates that the systemd unit/service configuration was loaded and parsed successfully
+ - `gauge.load_state.masked` (*gauge*)<br>    Indicates that the systemd unit/service is currently masked out (i.e. symlinked to /dev/null etc)
+ - `gauge.load_state.not-found` (*gauge*)<br>    Indicates that the systemd unit/service configuration was not found
 
 #### Group SubState
 All of the following metrics are part of the `SubState` metric group. All of
 the non-default metrics below can be turned on by adding `SubState` to the
 monitor config option `extraGroups`:
+ - `gauge.substate.dead` (*gauge*)<br>    Indicates that the systemd unit/service died
+ - `gauge.substate.exited` (*gauge*)<br>    Indicates that the systemd unit/service exited
+ - `gauge.substate.failed` (*gauge*)<br>    Indicates that the systemd unit/service failed
 
 ### Non-default metrics (version 4.7.0+)
 

--- a/pkg/monitors/collectd/systemd/genmetadata.go
+++ b/pkg/monitors/collectd/systemd/genmetadata.go
@@ -9,7 +9,17 @@ import (
 
 const monitorType = "collectd/systemd"
 
-var groupSet = map[string]bool{}
+const (
+	groupActiveState = "ActiveState"
+	groupLoadState   = "LoadState"
+	groupSubState    = "SubState"
+)
+
+var groupSet = map[string]bool{
+	groupActiveState: true,
+	groupLoadState:   true,
+	groupSubState:    true,
+}
 
 const (
 	gaugeActiveStateActivating   = "gauge.active_state.activating"
@@ -29,19 +39,19 @@ const (
 )
 
 var metricSet = map[string]monitors.MetricInfo{
-	gaugeActiveStateActivating:   {Type: datapoint.Gauge},
-	gaugeActiveStateActive:       {Type: datapoint.Gauge},
-	gaugeActiveStateDeactivating: {Type: datapoint.Gauge},
-	gaugeActiveStateFailed:       {Type: datapoint.Gauge},
-	gaugeActiveStateInactive:     {Type: datapoint.Gauge},
-	gaugeActiveStateReloading:    {Type: datapoint.Gauge},
-	gaugeLoadStateError:          {Type: datapoint.Gauge},
-	gaugeLoadStateLoaded:         {Type: datapoint.Gauge},
-	gaugeLoadStateMasked:         {Type: datapoint.Gauge},
-	gaugeLoadStateNotFound:       {Type: datapoint.Gauge},
-	gaugeSubstateDead:            {Type: datapoint.Gauge},
-	gaugeSubstateExited:          {Type: datapoint.Gauge},
-	gaugeSubstateFailed:          {Type: datapoint.Gauge},
+	gaugeActiveStateActivating:   {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeActiveStateActive:       {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeActiveStateDeactivating: {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeActiveStateFailed:       {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeActiveStateInactive:     {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeActiveStateReloading:    {Type: datapoint.Gauge, Group: groupActiveState},
+	gaugeLoadStateError:          {Type: datapoint.Gauge, Group: groupLoadState},
+	gaugeLoadStateLoaded:         {Type: datapoint.Gauge, Group: groupLoadState},
+	gaugeLoadStateMasked:         {Type: datapoint.Gauge, Group: groupLoadState},
+	gaugeLoadStateNotFound:       {Type: datapoint.Gauge, Group: groupLoadState},
+	gaugeSubstateDead:            {Type: datapoint.Gauge, Group: groupSubState},
+	gaugeSubstateExited:          {Type: datapoint.Gauge, Group: groupSubState},
+	gaugeSubstateFailed:          {Type: datapoint.Gauge, Group: groupSubState},
 	gaugeSubstateRunning:         {Type: datapoint.Gauge},
 }
 
@@ -49,7 +59,27 @@ var defaultMetrics = map[string]bool{
 	gaugeSubstateRunning: true,
 }
 
-var groupMetricsMap = map[string][]string{}
+var groupMetricsMap = map[string][]string{
+	groupActiveState: []string{
+		gaugeActiveStateActivating,
+		gaugeActiveStateActive,
+		gaugeActiveStateDeactivating,
+		gaugeActiveStateFailed,
+		gaugeActiveStateInactive,
+		gaugeActiveStateReloading,
+	},
+	groupLoadState: []string{
+		gaugeLoadStateError,
+		gaugeLoadStateLoaded,
+		gaugeLoadStateMasked,
+		gaugeLoadStateNotFound,
+	},
+	groupSubState: []string{
+		gaugeSubstateDead,
+		gaugeSubstateExited,
+		gaugeSubstateFailed,
+	},
+}
 
 var monitorMetadata = monitors.Metadata{
 	MonitorType:     "collectd/systemd",

--- a/pkg/monitors/collectd/systemd/metadata.yaml
+++ b/pkg/monitors/collectd/systemd/metadata.yaml
@@ -60,31 +60,37 @@ monitors:
       description: Indicates that the systemd unit/service is active
       default: false
       type: gauge
+      group: ActiveState
     gauge.active_state.inactive:
       description: Indicates that the systemd unit/service is inactive and the previous
         run was successful or no previous run has taken place yet
       default: false
       type: gauge
+      group: ActiveState
     gauge.active_state.activating:
       description: Indicates that the systemd unit/service has previously been inactive
         but is currently in the process of entering an active state
       default: false
       type: gauge
+      group: ActiveState
     gauge.active_state.deactivating:
       description: Indicates that the systemd unit/service is currently in the process
         of deactivation
       default: false
       type: gauge
+      group: ActiveState
     gauge.active_state.reloading:
       description: Indicates that the systemd unit/service is active and currently
         reloading its configuration
       default: false
       type: gauge
+      group: ActiveState
     gauge.active_state.failed:
       description: Indicates that the systemd unit/service is inactive the previous
         run was not successful
       default: false
       type: gauge
+      group: ActiveState
     gauge.substate.running:
       description: Indicates that the systemd unit/service is running
       default: true
@@ -93,32 +99,39 @@ monitors:
       description: Indicates that the systemd unit/service exited
       default: false
       type: gauge
+      group: SubState
     gauge.substate.failed:
       description: Indicates that the systemd unit/service failed
       default: false
       type: gauge
+      group: SubState
     gauge.substate.dead:
       description: Indicates that the systemd unit/service died
       default: false
       type: gauge
+      group: SubState
     gauge.load_state.loaded:
       description: Indicates that the systemd unit/service configuration was loaded
         and parsed successfully
       default: false
       type: gauge
+      group: LoadState
     gauge.load_state.not-found:
       description: Indicates that the systemd unit/service configuration was not found
       default: false
       type: gauge
+      group: LoadState
     gauge.load_state.error:
       description: Indicates that the systemd unit/service configuration failed to
         load
       default: false
       type: gauge
+      group: LoadState
     gauge.load_state.masked:
       description: Indicates that the systemd unit/service is currently masked out
         (i.e. symlinked to /dev/null etc)
       default: false
       type: gauge
+      group: LoadState
   monitorType: collectd/systemd
   properties:

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -21724,112 +21724,115 @@
         "": {
           "description": "",
           "metrics": [
-            "gauge.active_state.activating",
-            "gauge.active_state.active",
-            "gauge.active_state.deactivating",
-            "gauge.active_state.failed",
-            "gauge.active_state.inactive",
-            "gauge.active_state.reloading",
-            "gauge.load_state.error",
-            "gauge.load_state.loaded",
-            "gauge.load_state.masked",
-            "gauge.load_state.not-found",
-            "gauge.substate.dead",
-            "gauge.substate.exited",
-            "gauge.substate.failed",
             "gauge.substate.running"
           ]
         },
         "ActiveState": {
           "description": "Metrics which indicate whether a service is currently active or not",
-          "metrics": null
+          "metrics": [
+            "gauge.active_state.activating",
+            "gauge.active_state.active",
+            "gauge.active_state.deactivating",
+            "gauge.active_state.failed",
+            "gauge.active_state.inactive",
+            "gauge.active_state.reloading"
+          ]
         },
         "LoadState": {
           "description": "Metrics which indicate whether a service's unit configuration file has been loaded",
-          "metrics": null
+          "metrics": [
+            "gauge.load_state.error",
+            "gauge.load_state.loaded",
+            "gauge.load_state.masked",
+            "gauge.load_state.not-found"
+          ]
         },
         "SubState": {
           "description": "Metrics which provide further clarification of a service's active state",
-          "metrics": null
+          "metrics": [
+            "gauge.substate.dead",
+            "gauge.substate.exited",
+            "gauge.substate.failed"
+          ]
         }
       },
       "metrics": {
         "gauge.active_state.activating": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service has previously been inactive but is currently in the process of entering an active state",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.active_state.active": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is active",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.active_state.deactivating": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is currently in the process of deactivation",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.active_state.failed": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is inactive the previous run was not successful",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.active_state.inactive": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is inactive and the previous run was successful or no previous run has taken place yet",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.active_state.reloading": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is active and currently reloading its configuration",
-          "group": null,
+          "group": "ActiveState",
           "default": false
         },
         "gauge.load_state.error": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service configuration failed to load",
-          "group": null,
+          "group": "LoadState",
           "default": false
         },
         "gauge.load_state.loaded": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service configuration was loaded and parsed successfully",
-          "group": null,
+          "group": "LoadState",
           "default": false
         },
         "gauge.load_state.masked": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service is currently masked out (i.e. symlinked to /dev/null etc)",
-          "group": null,
+          "group": "LoadState",
           "default": false
         },
         "gauge.load_state.not-found": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service configuration was not found",
-          "group": null,
+          "group": "LoadState",
           "default": false
         },
         "gauge.substate.dead": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service died",
-          "group": null,
+          "group": "SubState",
           "default": false
         },
         "gauge.substate.exited": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service exited",
-          "group": null,
+          "group": "SubState",
           "default": false
         },
         "gauge.substate.failed": {
           "type": "gauge",
           "description": "Indicates that the systemd unit/service failed",
-          "group": null,
+          "group": "SubState",
           "default": false
         },
         "gauge.substate.running": {


### PR DESCRIPTION
cc: @rmfitzpatrick 

Adding an integration is more involved than first anticipated as it's tricky to get the unit tests containers to work with systemd.
Validated this manually.