### PR TITLE
Update K8s cluster metadata

### DIFF
--- a/docs/monitors/kubernetes-cluster.md
+++ b/docs/monitors/kubernetes-cluster.md
@@ -117,8 +117,8 @@ This monitor will also emit by default any metrics that are not listed below.
     StatefulSet version indicated by `current_revision` property on the
     `kubernetes_uid` dimension for this StatefulSet.
 
- - `kubernetes.stateful_set.desired` (*gauge*)<br>    Number of desired pods in the stateful set (the `spec.replicas` field)
- - `kubernetes.stateful_set.ready` (*gauge*)<br>    Number of pods created by the stateful set that have the `Ready` condition
+ - ***`kubernetes.stateful_set.desired`*** (*gauge*)<br>    Number of desired pods in the stateful set (the `spec.replicas` field)
+ - ***`kubernetes.stateful_set.ready`*** (*gauge*)<br>    Number of pods created by the stateful set that have the `Ready` condition
  - `kubernetes.stateful_set.updated` (*gauge*)<br>    The number of pods created by the StatefulSet controller from the
     StatefulSet version indicated by the `update_revision` property on the
     `kubernetes_uid` dimension for this StatefulSet.

--- a/docs/monitors/openshift-cluster.md
+++ b/docs/monitors/openshift-cluster.md
@@ -118,8 +118,8 @@ This monitor will also emit by default any metrics that are not listed below.
     StatefulSet version indicated by `current_revision` property on the
     `kubernetes_uid` dimension for this StatefulSet.
 
- - `kubernetes.stateful_set.desired` (*gauge*)<br>    Number of desired pods in the stateful set (the `spec.replicas` field)
- - `kubernetes.stateful_set.ready` (*gauge*)<br>    Number of pods created by the stateful set that have the `Ready` condition
+ - ***`kubernetes.stateful_set.desired`*** (*gauge*)<br>    Number of desired pods in the stateful set (the `spec.replicas` field)
+ - ***`kubernetes.stateful_set.ready`*** (*gauge*)<br>    Number of pods created by the stateful set that have the `Ready` condition
  - `kubernetes.stateful_set.updated` (*gauge*)<br>    The number of pods created by the StatefulSet controller from the
     StatefulSet version indicated by the `update_revision` property on the
     `kubernetes_uid` dimension for this StatefulSet.

--- a/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
+++ b/pkg/monitors/kubernetes/cluster/meta/genmetadata.go
@@ -189,6 +189,8 @@ var DefaultMetrics = map[string]bool{
 	KubernetesReplicationControllerDesired:                 true,
 	KubernetesResourceQuotaHard:                            true,
 	KubernetesResourceQuotaUsed:                            true,
+	KubernetesStatefulSetDesired:                           true,
+	KubernetesStatefulSetReady:                             true,
 	OpenshiftAppliedclusterquotaCPUHard:                    true,
 	OpenshiftAppliedclusterquotaCPUUsed:                    true,
 	OpenshiftAppliedclusterquotaMemoryHard:                 true,

--- a/pkg/monitors/kubernetes/cluster/metadata.yaml
+++ b/pkg/monitors/kubernetes/cluster/metadata.yaml
@@ -178,11 +178,11 @@ common:
       type: gauge
     kubernetes.stateful_set.desired:
       description: Number of desired pods in the stateful set (the `spec.replicas` field)
-      default: false
+      default: true
       type: gauge
     kubernetes.stateful_set.ready:
       description: Number of pods created by the stateful set that have the `Ready` condition
-      default: false
+      default: true
       type: gauge
     kubernetes.stateful_set.current:
       description: |

--- a/selfdescribe.json
+++ b/selfdescribe.json
@@ -39697,13 +39697,13 @@
           "type": "gauge",
           "description": "Number of desired pods in the stateful set (the `spec.replicas` field)",
           "group": null,
-          "default": false
+          "default": true
         },
         "kubernetes.stateful_set.ready": {
           "type": "gauge",
           "description": "Number of pods created by the stateful set that have the `Ready` condition",
           "group": null,
-          "default": false
+          "default": true
         },
         "kubernetes.stateful_set.updated": {
           "type": "gauge",
@@ -44023,13 +44023,13 @@
           "type": "gauge",
           "description": "Number of desired pods in the stateful set (the `spec.replicas` field)",
           "group": null,
-          "default": false
+          "default": true
         },
         "kubernetes.stateful_set.ready": {
           "type": "gauge",
           "description": "Number of pods created by the stateful set that have the `Ready` condition",
           "group": null,
-          "default": false
+          "default": true
         },
         "kubernetes.stateful_set.updated": {
           "type": "gauge",


### PR DESCRIPTION
Updates the K8s cluster monitor metadata to reflect that `kubernetes.stateful_set.desired` and `kubernetes.stateful_set.ready` are now default metrics.